### PR TITLE
#32 Fix docs to point to 401.html instead of 104.html

### DIFF
--- a/dist/blog.html
+++ b/dist/blog.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/cards.html
+++ b/dist/cards.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/charts.html
+++ b/dist/charts.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/crypto-currencies.html
+++ b/dist/crypto-currencies.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/docs/alerts.html
+++ b/dist/docs/alerts.html
@@ -147,7 +147,7 @@
                       <a href="../register.html" class="nav-item ">Register</a>
                       <a href="../forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="../400.html" class="nav-item ">400 error</a>
-                      <a href="../104.html" class="nav-item ">401 error</a>
+                      <a href="../401.html" class="nav-item ">401 error</a>
                       <a href="../403.html" class="nav-item ">403 error</a>
                       <a href="../404.html" class="nav-item ">404 error</a>
                       <a href="../500.html" class="nav-item ">500 error</a>
@@ -265,10 +265,10 @@
                       <p>Add <code class="highlighter-rouge">.alert-icon</code> class.</p>
                       <div class="example">
                         <div class="alert alert-icon alert-primary" role="alert">
-                          <i class="fe fe-bell mr-2" aria-hidden="true"></i> You have done 5 actions. 
+                          <i class="fe fe-bell mr-2" aria-hidden="true"></i> You have done 5 actions.
                         </div>
                         <div class="alert alert-icon alert-success" role="alert">
-                          <i class="fe fe-check mr-2" aria-hidden="true"></i> The page has been added. 
+                          <i class="fe fe-check mr-2" aria-hidden="true"></i> The page has been added.
                         </div>
                         <div class="alert alert-icon alert-danger" role="alert">
                           <i class="fe fe-alert-triangle mr-2" aria-hidden="true"></i> The daily report has failed. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
@@ -276,10 +276,10 @@
                       </div>
                       <div class="highlight">
                         <pre><code class="language-html" data-lang="html"><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"alert alert-icon alert-primary"</span> <span class="na">role=</span><span class="s">"alert"</span><span class="nt">&gt;</span>
-  <span class="nt">&lt;i</span> <span class="na">class=</span><span class="s">"fe fe-bell mr-2"</span> <span class="na">aria-hidden=</span><span class="s">"true"</span><span class="nt">&gt;&lt;/i&gt;</span> You have done 5 actions. 
+  <span class="nt">&lt;i</span> <span class="na">class=</span><span class="s">"fe fe-bell mr-2"</span> <span class="na">aria-hidden=</span><span class="s">"true"</span><span class="nt">&gt;&lt;/i&gt;</span> You have done 5 actions.
 <span class="nt">&lt;/div&gt;</span>
 <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"alert alert-icon alert-success"</span> <span class="na">role=</span><span class="s">"alert"</span><span class="nt">&gt;</span>
-  <span class="nt">&lt;i</span> <span class="na">class=</span><span class="s">"fe fe-check mr-2"</span> <span class="na">aria-hidden=</span><span class="s">"true"</span><span class="nt">&gt;&lt;/i&gt;</span> The page has been added. 
+  <span class="nt">&lt;i</span> <span class="na">class=</span><span class="s">"fe fe-check mr-2"</span> <span class="na">aria-hidden=</span><span class="s">"true"</span><span class="nt">&gt;&lt;/i&gt;</span> The page has been added.
 <span class="nt">&lt;/div&gt;</span>
 <span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"alert alert-icon alert-danger"</span> <span class="na">role=</span><span class="s">"alert"</span><span class="nt">&gt;</span>
   <span class="nt">&lt;i</span> <span class="na">class=</span><span class="s">"fe fe-alert-triangle mr-2"</span> <span class="na">aria-hidden=</span><span class="s">"true"</span><span class="nt">&gt;&lt;/i&gt;</span> The daily report has failed. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Lorem ipsum dolor sit amet, consectetur adipisicing elit.

--- a/dist/docs/avatars.html
+++ b/dist/docs/avatars.html
@@ -147,7 +147,7 @@
                       <a href="../register.html" class="nav-item ">Register</a>
                       <a href="../forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="../400.html" class="nav-item ">400 error</a>
-                      <a href="../104.html" class="nav-item ">401 error</a>
+                      <a href="../401.html" class="nav-item ">401 error</a>
                       <a href="../403.html" class="nav-item ">403 error</a>
                       <a href="../404.html" class="nav-item ">404 error</a>
                       <a href="../500.html" class="nav-item ">500 error</a>

--- a/dist/docs/buttons.html
+++ b/dist/docs/buttons.html
@@ -147,7 +147,7 @@
                       <a href="../register.html" class="nav-item ">Register</a>
                       <a href="../forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="../400.html" class="nav-item ">400 error</a>
-                      <a href="../104.html" class="nav-item ">401 error</a>
+                      <a href="../401.html" class="nav-item ">401 error</a>
                       <a href="../403.html" class="nav-item ">403 error</a>
                       <a href="../404.html" class="nav-item ">404 error</a>
                       <a href="../500.html" class="nav-item ">500 error</a>

--- a/dist/docs/cards.html
+++ b/dist/docs/cards.html
@@ -147,7 +147,7 @@
                       <a href="../register.html" class="nav-item ">Register</a>
                       <a href="../forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="../400.html" class="nav-item ">400 error</a>
-                      <a href="../104.html" class="nav-item ">401 error</a>
+                      <a href="../401.html" class="nav-item ">401 error</a>
                       <a href="../403.html" class="nav-item ">403 error</a>
                       <a href="../404.html" class="nav-item ">404 error</a>
                       <a href="../500.html" class="nav-item ">500 error</a>

--- a/dist/docs/charts.html
+++ b/dist/docs/charts.html
@@ -147,7 +147,7 @@
                       <a href="../register.html" class="nav-item ">Register</a>
                       <a href="../forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="../400.html" class="nav-item ">400 error</a>
-                      <a href="../104.html" class="nav-item ">401 error</a>
+                      <a href="../401.html" class="nav-item ">401 error</a>
                       <a href="../403.html" class="nav-item ">403 error</a>
                       <a href="../404.html" class="nav-item ">404 error</a>
                       <a href="../500.html" class="nav-item ">500 error</a>
@@ -291,7 +291,7 @@
         <span class="p">],</span>
         <span class="na">labels</span><span class="p">:</span> <span class="kc">true</span><span class="p">,</span>
         <span class="na">type</span><span class="p">:</span> <span class="s1">'line'</span><span class="p">,</span> <span class="c1">// default type of chart</span>
-        <span class="na">colors</span><span class="p">:</span> <span class="p">{</span> 
+        <span class="na">colors</span><span class="p">:</span> <span class="p">{</span>
           <span class="s1">'data1'</span><span class="p">:</span> <span class="nx">tabler</span><span class="p">.</span><span class="nx">colors</span><span class="p">[</span><span class="s2">"blue"</span><span class="p">],</span>
           <span class="s1">'data2'</span><span class="p">:</span> <span class="nx">tabler</span><span class="p">.</span><span class="nx">colors</span><span class="p">[</span><span class="s2">"green"</span><span class="p">]</span>
         <span class="p">},</span>

--- a/dist/docs/colors.html
+++ b/dist/docs/colors.html
@@ -147,7 +147,7 @@
                       <a href="../register.html" class="nav-item ">Register</a>
                       <a href="../forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="../400.html" class="nav-item ">400 error</a>
-                      <a href="../104.html" class="nav-item ">401 error</a>
+                      <a href="../401.html" class="nav-item ">401 error</a>
                       <a href="../403.html" class="nav-item ">403 error</a>
                       <a href="../404.html" class="nav-item ">404 error</a>
                       <a href="../500.html" class="nav-item ">500 error</a>

--- a/dist/docs/form-components.html
+++ b/dist/docs/form-components.html
@@ -147,7 +147,7 @@
                       <a href="../register.html" class="nav-item ">Register</a>
                       <a href="../forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="../400.html" class="nav-item ">400 error</a>
-                      <a href="../104.html" class="nav-item ">401 error</a>
+                      <a href="../401.html" class="nav-item ">401 error</a>
                       <a href="../403.html" class="nav-item ">403 error</a>
                       <a href="../404.html" class="nav-item ">404 error</a>
                       <a href="../500.html" class="nav-item ">500 error</a>

--- a/dist/docs/grid.html
+++ b/dist/docs/grid.html
@@ -147,7 +147,7 @@
                       <a href="../register.html" class="nav-item ">Register</a>
                       <a href="../forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="../400.html" class="nav-item ">400 error</a>
-                      <a href="../104.html" class="nav-item ">401 error</a>
+                      <a href="../401.html" class="nav-item ">401 error</a>
                       <a href="../403.html" class="nav-item ">403 error</a>
                       <a href="../404.html" class="nav-item ">404 error</a>
                       <a href="../500.html" class="nav-item ">500 error</a>

--- a/dist/docs/index.html
+++ b/dist/docs/index.html
@@ -147,7 +147,7 @@
                       <a href="../register.html" class="nav-item ">Register</a>
                       <a href="../forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="../400.html" class="nav-item ">400 error</a>
-                      <a href="../104.html" class="nav-item ">401 error</a>
+                      <a href="../401.html" class="nav-item ">401 error</a>
                       <a href="../403.html" class="nav-item ">403 error</a>
                       <a href="../404.html" class="nav-item ">404 error</a>
                       <a href="../500.html" class="nav-item ">500 error</a>

--- a/dist/docs/tags.html
+++ b/dist/docs/tags.html
@@ -147,7 +147,7 @@
                       <a href="../register.html" class="nav-item ">Register</a>
                       <a href="../forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="../400.html" class="nav-item ">400 error</a>
-                      <a href="../104.html" class="nav-item ">401 error</a>
+                      <a href="../401.html" class="nav-item ">401 error</a>
                       <a href="../403.html" class="nav-item ">403 error</a>
                       <a href="../404.html" class="nav-item ">404 error</a>
                       <a href="../500.html" class="nav-item ">500 error</a>
@@ -430,19 +430,19 @@
                       <div class="example">
                         <div class="tags">
                           <span class="tag">
-                            One 
+                            One
                             <a href="javascript:void(0)" class="tag-addon"><i class="fe fe-x"></i></a>
                           </span>
                           <span class="tag">
-                            Two 
+                            Two
                             <a href="javascript:void(0)" class="tag-addon"><i class="fe fe-x"></i></a>
                           </span>
                           <span class="tag">
-                            Three 
+                            Three
                             <a href="javascript:void(0)" class="tag-addon"><i class="fe fe-x"></i></a>
                           </span>
                           <span class="tag">
-                            Four 
+                            Four
                             <a href="javascript:void(0)" class="tag-addon"><i class="fe fe-x"></i></a>
                           </span>
                         </div>
@@ -450,19 +450,19 @@
                       <div class="highlight">
                         <pre><code class="language-html" data-lang="html"><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"tags"</span><span class="nt">&gt;</span>
   <span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"tag"</span><span class="nt">&gt;</span>
-    One 
+    One
     <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span> <span class="na">class=</span><span class="s">"tag-addon"</span><span class="nt">&gt;&lt;i</span> <span class="na">class=</span><span class="s">"fe fe-x"</span><span class="nt">&gt;&lt;/i&gt;&lt;/a&gt;</span>
   <span class="nt">&lt;/span&gt;</span>
   <span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"tag"</span><span class="nt">&gt;</span>
-    Two 
+    Two
     <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span> <span class="na">class=</span><span class="s">"tag-addon"</span><span class="nt">&gt;&lt;i</span> <span class="na">class=</span><span class="s">"fe fe-x"</span><span class="nt">&gt;&lt;/i&gt;&lt;/a&gt;</span>
   <span class="nt">&lt;/span&gt;</span>
   <span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"tag"</span><span class="nt">&gt;</span>
-    Three 
+    Three
     <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span> <span class="na">class=</span><span class="s">"tag-addon"</span><span class="nt">&gt;&lt;i</span> <span class="na">class=</span><span class="s">"fe fe-x"</span><span class="nt">&gt;&lt;/i&gt;&lt;/a&gt;</span>
   <span class="nt">&lt;/span&gt;</span>
   <span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"tag"</span><span class="nt">&gt;</span>
-    Four 
+    Four
     <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#"</span> <span class="na">class=</span><span class="s">"tag-addon"</span><span class="nt">&gt;&lt;i</span> <span class="na">class=</span><span class="s">"fe fe-x"</span><span class="nt">&gt;&lt;/i&gt;&lt;/a&gt;</span>
   <span class="nt">&lt;/span&gt;</span>
 <span class="nt">&lt;/div&gt;</span></code></pre>

--- a/dist/docs/typography.html
+++ b/dist/docs/typography.html
@@ -147,7 +147,7 @@
                       <a href="../register.html" class="nav-item ">Register</a>
                       <a href="../forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="../400.html" class="nav-item ">400 error</a>
-                      <a href="../104.html" class="nav-item ">401 error</a>
+                      <a href="../401.html" class="nav-item ">401 error</a>
                       <a href="../403.html" class="nav-item ">403 error</a>
                       <a href="../404.html" class="nav-item ">404 error</a>
                       <a href="../500.html" class="nav-item ">500 error</a>

--- a/dist/email.html
+++ b/dist/email.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/empty.html
+++ b/dist/empty.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/form-elements.html
+++ b/dist/form-elements.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>
@@ -1064,9 +1064,9 @@
                                 }
                             }
                         });
-                
+
                         $('#select-beast').selectize({});
-                
+
                         $('#select-users').selectize({
                             render: {
                                 option: function (data, escape) {
@@ -1083,7 +1083,7 @@
                                 }
                             }
                         });
-                
+
                         $('#select-countries').selectize({
                             render: {
                                 option: function (data, escape) {

--- a/dist/gallery.html
+++ b/dist/gallery.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/icons.html
+++ b/dist/icons.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/index.html
+++ b/dist/index.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/invoice.html
+++ b/dist/invoice.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/lookup.html
+++ b/dist/lookup.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/maps.html
+++ b/dist/maps.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>
@@ -278,8 +278,8 @@
                   require(['jquery', 'vector-map', 'vector-map-de'], function(){
                       $(document).ready(function(){
                           var data = {"DE-BE":11,"DE-ST":43,"DE-RP":4,"DE-BB":65,"DE-NI":4,"DE-MV":24,"DE-TH":45,"DE-BW":7,"DE-HH":45,"DE-SH":9,"DE-NW":8,"DE-SN":27,"DE-HB":42,"DE-SL":85,"DE-BY":24,"DE-HE":66};
-                  
-                  
+
+
                           var markers = [
                               {latLng: [52.50, 13.39], name: 'Berlin'},
                               {latLng: [53.56, 10.00], name: 'Hamburg'},
@@ -292,8 +292,8 @@
                               {latLng: [51.45, 7.01], name: 'Essen'},
                               {latLng: [53.07, 8.80], name: 'Bremen'}
                           ];
-                  
-                  
+
+
                           $('#map-germany-svg').vectorMap({
                               map: 'de_merc',
                               zoomButtons : false,
@@ -344,11 +344,11 @@
                   require(['jquery', 'vector-map', 'vector-map-world'], function(){
                       $(document).ready(function(){
                           var data = {"AF":16.63,"AL":11.58,"DZ":158.97,"AO":85.81,"AG":1.1,"AR":351.02,"AM":8.83,"AU":1219.72,"AT":366.26,"AZ":52.17,"BS":7.54,"BH":21.73,"BD":105.4,"BB":3.96,"BY":52.89,"BE":461.33,"BZ":1.43,"BJ":6.49,"BT":1.4,"BO":19.18,"BA":16.2,"BW":12.5,"BR":2023.53,"BN":11.96,"BG":44.84,"BF":8.67,"BI":1.47,"KH":11.36,"CM":21.88,"CA":1563.66,"CV":1.57,"CF":2.11,"TD":7.59,"CL":199.18,"CN":5745.13,"CO":283.11,"KM":0.56,"CD":12.6,"CG":11.88,"CR":35.02,"CI":22.38,"HR":59.92,"CY":22.75,"CZ":195.23,"DK":304.56,"DJ":1.14,"DM":0.38,"DO":50.87,"EC":61.49,"EG":216.83,"SV":21.8,"GQ":14.55,"ER":2.25,"EE":19.22,"ET":30.94,"FJ":3.15,"FI":231.98,"FR":2555.44,"GA":12.56,"GM":1.04,"GE":11.23,"DE":3305.9,"GH":18.06,"GR":305.01,"GD":0.65,"GT":40.77,"GN":4.34,"GW":0.83,"GY":2.2,"HT":6.5,"HN":15.34,"HK":226.49,"HU":132.28,"IS":12.77,"IN":1430.02,"ID":695.06,"IR":337.9,"IQ":84.14,"IE":204.14,"IL":201.25,"IT":2036.69,"JM":13.74,"JP":5390.9,"JO":27.13,"KZ":129.76,"KE":32.42,"KI":0.15,"KR":986.26,"UNDEFINED":5.73,"KW":117.32,"KG":4.44,"LA":6.34,"LV":23.39,"LB":39.15,"LS":1.8,"LR":0.98,"LY":77.91,"LT":35.73,"LU":52.43,"MK":9.58,"MG":8.33,"MW":5.04,"MY":218.95,"MV":1.43,"ML":9.08,"MT":7.8,"MR":3.49,"MU":9.43,"MX":1004.04,"MD":5.36,"MN":5.81,"ME":3.88,"MA":91.7,"MZ":10.21,"MM":35.65,"NA":11.45,"NP":15.11,"NL":770.31,"NZ":138,"NI":6.38,"NE":5.6,"NG":206.66,"false":413.51,"OM":53.78,"PK":174.79,"PA":27.2,"PG":8.81,"PY":17.17,"PE":153.55,"PH":189.06,"PL":438.88,"PT":223.7,"QA":126.52,"RO":158.39,"RU":1476.91,"RW":5.69,"WS":0.55,"ST":0.19,"SA":434.44,"SN":12.66,"RS":38.92,"SC":0.92,"SL":1.9,"SG":217.38,"SK":86.26,"SI":46.44,"SB":0.67,"ZA":354.41,"ES":1374.78,"LK":48.24,"KN":0.56,"LC":1,"VC":0.58,"SD":65.93,"SR":3.3,"SZ":3.17,"SE":444.59,"CH":522.44,"SY":59.63,"TW":426.98,"TJ":5.58,"TZ":22.43,"TH":312.61,"TL":0.62,"TG":3.07,"TO":0.3,"TT":21.2,"TN":43.86,"TR":729.05,"TM":0,"UG":17.12,"UA":136.56,"AE":239.65,"GB":2258.57,"US":14624.18,"UY":40.71,"UZ":37.72,"VU":0.72,"VE":285.21,"VN":101.99,"YE":30.02,"ZM":15.69,"ZW":5.5};
-                  
-                  
+
+
                           var markers = false;
-                  
-                  
+
+
                           $('#map-world-svg').vectorMap({
                               map: 'world_mill',
                               zoomButtons : false,

--- a/dist/pagination.html
+++ b/dist/pagination.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/pricing-cards.html
+++ b/dist/pricing-cards.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/profile.html
+++ b/dist/profile.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/sample-cards.html
+++ b/dist/sample-cards.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>
@@ -1556,8 +1556,8 @@
                   require(['jquery', 'vector-map', 'vector-map-de'], function(){
                       $(document).ready(function(){
                           var data = {"DE-BE":11,"DE-ST":43,"DE-RP":4,"DE-BB":65,"DE-NI":4,"DE-MV":24,"DE-TH":45,"DE-BW":7,"DE-HH":45,"DE-SH":9,"DE-NW":8,"DE-SN":27,"DE-HB":42,"DE-SL":85,"DE-BY":24,"DE-HE":66};
-                  
-                  
+
+
                           var markers = [
                               {latLng: [52.50, 13.39], name: 'Berlin'},
                               {latLng: [53.56, 10.00], name: 'Hamburg'},
@@ -1570,8 +1570,8 @@
                               {latLng: [51.45, 7.01], name: 'Essen'},
                               {latLng: [53.07, 8.80], name: 'Bremen'}
                           ];
-                  
-                  
+
+
                           $('#map-germany-svg').vectorMap({
                               map: 'de_merc',
                               zoomButtons : false,
@@ -2279,11 +2279,11 @@
                   require(['jquery', 'vector-map', 'vector-map-world'], function(){
                       $(document).ready(function(){
                           var data = {"AF":16.63,"AL":11.58,"DZ":158.97,"AO":85.81,"AG":1.1,"AR":351.02,"AM":8.83,"AU":1219.72,"AT":366.26,"AZ":52.17,"BS":7.54,"BH":21.73,"BD":105.4,"BB":3.96,"BY":52.89,"BE":461.33,"BZ":1.43,"BJ":6.49,"BT":1.4,"BO":19.18,"BA":16.2,"BW":12.5,"BR":2023.53,"BN":11.96,"BG":44.84,"BF":8.67,"BI":1.47,"KH":11.36,"CM":21.88,"CA":1563.66,"CV":1.57,"CF":2.11,"TD":7.59,"CL":199.18,"CN":5745.13,"CO":283.11,"KM":0.56,"CD":12.6,"CG":11.88,"CR":35.02,"CI":22.38,"HR":59.92,"CY":22.75,"CZ":195.23,"DK":304.56,"DJ":1.14,"DM":0.38,"DO":50.87,"EC":61.49,"EG":216.83,"SV":21.8,"GQ":14.55,"ER":2.25,"EE":19.22,"ET":30.94,"FJ":3.15,"FI":231.98,"FR":2555.44,"GA":12.56,"GM":1.04,"GE":11.23,"DE":3305.9,"GH":18.06,"GR":305.01,"GD":0.65,"GT":40.77,"GN":4.34,"GW":0.83,"GY":2.2,"HT":6.5,"HN":15.34,"HK":226.49,"HU":132.28,"IS":12.77,"IN":1430.02,"ID":695.06,"IR":337.9,"IQ":84.14,"IE":204.14,"IL":201.25,"IT":2036.69,"JM":13.74,"JP":5390.9,"JO":27.13,"KZ":129.76,"KE":32.42,"KI":0.15,"KR":986.26,"UNDEFINED":5.73,"KW":117.32,"KG":4.44,"LA":6.34,"LV":23.39,"LB":39.15,"LS":1.8,"LR":0.98,"LY":77.91,"LT":35.73,"LU":52.43,"MK":9.58,"MG":8.33,"MW":5.04,"MY":218.95,"MV":1.43,"ML":9.08,"MT":7.8,"MR":3.49,"MU":9.43,"MX":1004.04,"MD":5.36,"MN":5.81,"ME":3.88,"MA":91.7,"MZ":10.21,"MM":35.65,"NA":11.45,"NP":15.11,"NL":770.31,"NZ":138,"NI":6.38,"NE":5.6,"NG":206.66,"false":413.51,"OM":53.78,"PK":174.79,"PA":27.2,"PG":8.81,"PY":17.17,"PE":153.55,"PH":189.06,"PL":438.88,"PT":223.7,"QA":126.52,"RO":158.39,"RU":1476.91,"RW":5.69,"WS":0.55,"ST":0.19,"SA":434.44,"SN":12.66,"RS":38.92,"SC":0.92,"SL":1.9,"SG":217.38,"SK":86.26,"SI":46.44,"SB":0.67,"ZA":354.41,"ES":1374.78,"LK":48.24,"KN":0.56,"LC":1,"VC":0.58,"SD":65.93,"SR":3.3,"SZ":3.17,"SE":444.59,"CH":522.44,"SY":59.63,"TW":426.98,"TJ":5.58,"TZ":22.43,"TH":312.61,"TL":0.62,"TG":3.07,"TO":0.3,"TT":21.2,"TN":43.86,"TR":729.05,"TM":0,"UG":17.12,"UA":136.56,"AE":239.65,"GB":2258.57,"US":14624.18,"UY":40.71,"UZ":37.72,"VU":0.72,"VE":285.21,"VN":101.99,"YE":30.02,"ZM":15.69,"ZW":5.5};
-                  
-                  
+
+
                           var markers = false;
-                  
-                  
+
+
                           $('#map-world-svg').vectorMap({
                               map: 'world_mill',
                               zoomButtons : false,

--- a/dist/store.html
+++ b/dist/store.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>

--- a/dist/users-list.html
+++ b/dist/users-list.html
@@ -147,7 +147,7 @@
                       <a href="./register.html" class="nav-item ">Register</a>
                       <a href="./forgot-password.html" class="nav-item ">Forgot password</a>
                       <a href="./400.html" class="nav-item ">400 error</a>
-                      <a href="./104.html" class="nav-item ">401 error</a>
+                      <a href="./401.html" class="nav-item ">401 error</a>
                       <a href="./403.html" class="nav-item ">403 error</a>
                       <a href="./404.html" class="nav-item ">404 error</a>
                       <a href="./500.html" class="nav-item ">500 error</a>


### PR DESCRIPTION
## Description
There was an issue in the docs where the link to "401 page" in the menu pointed to 104.html. I've updated everywhere that said 104.html to point to 401.html instead.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
