### PR TITLE
Fix flex issues in IE11

### DIFF
--- a/src/assets/scss/dashboard/_aside.scss
+++ b/src/assets/scss/dashboard/_aside.scss
@@ -21,7 +21,7 @@
 
 .aside-body {
 	padding: 1.5rem;
-	flex: 1;
+	flex: 1 1 auto;
 	overflow: auto;
 }
 

--- a/src/assets/scss/dashboard/_cards.scss
+++ b/src/assets/scss/dashboard/_cards.scss
@@ -15,7 +15,7 @@
 }
 
 .card-body {
-	flex: 1;
+	flex: 1 1 auto;
 	margin: 0;
 	padding: $card-spacer-y $card-spacer-x;
 	position: relative;
@@ -322,7 +322,7 @@ Card tabs
 }
 
 .card-tabs-item {
-	flex: 1;
+	flex: 1 1 auto;
 	display: block;
 	padding: 1rem $card-spacer-x;
 	border-bottom: 1px solid $border-color;

--- a/src/assets/scss/dashboard/_grid.scss
+++ b/src/assets/scss/dashboard/_grid.scss
@@ -19,7 +19,7 @@
 		align-items: stretch;
 
 		.card {
-			flex: 1;
+			flex: 1 1 auto;
 		}
 	}
 }

--- a/src/assets/scss/dashboard/_layout.scss
+++ b/src/assets/scss/dashboard/_layout.scss
@@ -16,7 +16,7 @@
 }
 
 .page-main {
-	flex: 1;
+	flex: 1 1 auto;
 }
 
 .page-content {
@@ -74,7 +74,7 @@
 }
 
 .page-single {
-	flex: 1;
+	flex: 1 1 auto;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/src/assets/scss/dashboard/bootstrap/_media.scss
+++ b/src/assets/scss/dashboard/bootstrap/_media.scss
@@ -4,5 +4,5 @@
 }
 
 .media-body {
-  flex: 1;
+  flex: 1 1 auto;
 }


### PR DESCRIPTION
## Description
IE11 has issues with vertically flexed items when the `flex` property is defined in the short form e.g. "flex: 1". This update expands the definition to their full form which resolved major layout issues in IE11. (sort of fixes #18)

## Screenshots (if appropriate):
Before
<img width="1186" alt="before" src="https://user-images.githubusercontent.com/147496/38279613-535a7ef4-375e-11e8-80ad-7015041cc99f.png">


After
<img width="1193" alt="after" src="https://user-images.githubusercontent.com/147496/38279616-5692476e-375e-11e8-9410-8e48d6a3cf31.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
