### PR TITLE
adjust margin and padding on demo profile page avatars

### DIFF
--- a/dist/profile.html
+++ b/dist/profile.html
@@ -271,7 +271,7 @@
                   <ul class="list-group card-list-group">
                     <li class="list-group-item py-5">
                       <div class="media">
-                        <div class="media-object avatar avatar-md mr-4" style="background-image: url(demo/faces/male/16.jpg)"></div>
+                        <div class="media-object avatar avatar-md m-3 p-4" style="background-image: url(demo/faces/male/16.jpg)"></div>
                         <div class="media-body">
                           <div class="media-heading">
                             <small class="float-right text-muted">4 min</small>
@@ -284,7 +284,7 @@
                           </div>
                           <ul class="media-list">
                             <li class="media mt-4">
-                              <div class="media-object avatar mr-4" style="background-image: url(demo/faces/female/17.jpg)"></div>
+                              <div class="media-object avatar m-3 p-4" style="background-image: url(demo/faces/female/17.jpg)"></div>
                               <div class="media-body">
                                 <strong>Debra Beck: </strong>
                                 Donec id elit non mi porta gravida at eget metus. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Donec ullamcorper nulla non metus
@@ -292,7 +292,7 @@
                               </div>
                             </li>
                             <li class="media mt-4">
-                              <div class="media-object avatar mr-4" style="background-image: url(demo/faces/male/32.jpg)"></div>
+                              <div class="media-object avatar m-3 p-4" style="background-image: url(demo/faces/male/32.jpg)"></div>
                               <div class="media-body">
                                 <strong>Jack Ruiz: </strong>
                                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit
@@ -305,7 +305,7 @@
                     </li>
                     <li class="list-group-item py-5">
                       <div class="media">
-                        <div class="media-object avatar avatar-md mr-4" style="background-image: url(demo/faces/male/16.jpg)"></div>
+                        <div class="media-object avatar avatar-md m-3 p-4" style="background-image: url(demo/faces/male/16.jpg)"></div>
                         <div class="media-body">
                           <div class="media-heading">
                             <small class="float-right text-muted">12 min</small>
@@ -320,7 +320,7 @@
                     </li>
                     <li class="list-group-item py-5">
                       <div class="media">
-                        <div class="media-object avatar avatar-md mr-4" style="background-image: url(demo/faces/male/16.jpg)"></div>
+                        <div class="media-object avatar avatar-md m-3 p-4" style="background-image: url(demo/faces/male/16.jpg)"></div>
                         <div class="media-body">
                           <div class="media-heading">
                             <small class="float-right text-muted">34 min</small>
@@ -332,7 +332,7 @@
                           </div>
                           <ul class="media-list">
                             <li class="media mt-4">
-                              <div class="media-object avatar mr-4" style="background-image: url(demo/faces/male/26.jpg)"></div>
+                              <div class="media-object avatar m-3 p-4" style="background-image: url(demo/faces/male/26.jpg)"></div>
                               <div class="media-body">
                                 <strong>Wayne Holland: </strong>
                                 Donec id elit non mi porta gravida at eget metus. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Donec ullamcorper nulla non metus


### PR DESCRIPTION
## Description

Adjusted margin and padding on the demo `profile` page
<!--- Describe your changes in detail -->

## Screenshots (if appropriate):

# Current Version
<img width="1280" alt="screen shot 2018-04-05 at 1 09 25 am" src="https://user-images.githubusercontent.com/10762368/38348178-4d709ff8-386e-11e8-886d-0460b524a5dc.png">

# Proposed
<img width="1280" alt="screen shot 2018-04-05 at 1 13 32 am" src="https://user-images.githubusercontent.com/10762368/38348243-aadbd860-386e-11e8-8b71-391377cf74d7.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
