### PR TITLE
Change input icon demo to sun and moon

### DIFF
--- a/src/_includes/cards/form-all-elements.html
+++ b/src/_includes/cards/form-all-elements.html
@@ -175,11 +175,11 @@
 					<div class="selectgroup selectgroup-pills">
 						<label class="selectgroup-item">
 							<input type="radio" name="icon-input" value="1" class="selectgroup-input" checked="">
-							<span class="selectgroup-button selectgroup-button-icon"><i class="fa fa-male"></i></span>
+							<span class="selectgroup-button selectgroup-button-icon"><i class="fe fe-sun"></i></span>
 						</label>
 						<label class="selectgroup-item">
 							<input type="radio" name="icon-input" value="2" class="selectgroup-input">
-							<span class="selectgroup-button selectgroup-button-icon"><i class="fa fa-female"></i></span>
+							<span class="selectgroup-button selectgroup-button-icon"><i class="fe fe-moon"></i></span>
 						</label>
 					</div>
 				</div>


### PR DESCRIPTION
## Description
People are mistaking the "Icons input" demo as "gender input" due to the icons used. This changes the icons from male and female to day and night (#37)

## Screenshots (if appropriate):
![Sun and Moon icons](http://puu.sh/A0BHO/b99b5f7697.jpg)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)