### PR TITLE
Replace duplicate blog's menu items with carousel

### DIFF
--- a/src/_data/menu.yml
+++ b/src/_data/menu.yml
@@ -41,7 +41,7 @@ components:
       name: Blog
       url: blog.html
 
-    blog:
+    carousel:
       name: Carousel
       url: carousel.html
 


### PR DESCRIPTION
Hi!

I fix broken link to blog section in the menu items 😉 