### PR TITLE
Add vertical layout for selectgroup

### DIFF
--- a/src/_includes/cards/form-all-elements.html
+++ b/src/_includes/cards/form-all-elements.html
@@ -150,6 +150,23 @@
 					</div>
 				</div>
 				<div class="form-group">
+					<label class="form-label">Shipping methods</label>
+					<div class="selectgroup selectgroup-vertical w-100">
+						<label class="selectgroup-item">
+							<input type="radio" name="shipping" value="unregistered" class="selectgroup-input" checked>
+							<span class="selectgroup-button">Unregistered</span>
+						</label>
+						<label class="selectgroup-item">
+							<input type="radio" name="shipping" value="priority" class="selectgroup-input">
+							<span class="selectgroup-button">Priority Mail</span>
+						</label>
+						<label class="selectgroup-item">
+							<input type="radio" name="shipping" value="express" class="selectgroup-input">
+							<span class="selectgroup-button">Express Mail</span>
+						</label>
+					</div>
+				</div>
+				<div class="form-group">
 					<label class="form-label">Icons input</label>
 					<div class="selectgroup w-100">
 						<label class="selectgroup-item">

--- a/src/assets/scss/dashboard/forms/_custom-selectgroup.scss
+++ b/src/assets/scss/dashboard/forms/_custom-selectgroup.scss
@@ -2,11 +2,17 @@
 	display: inline-flex;
 }
 
+.selectgroup-vertical {
+	flex-direction: column;
+}
+
 .selectgroup-item {
 	flex-grow: 1;
 	position: relative;
+}
 
-	& + & {
+.selectgroup:not(.selectgroup-vertical) > .selectgroup-item {
+	& + .selectgroup-item {
 		margin-left: -1px;
 	}
 
@@ -17,6 +23,27 @@
 
 	&:not(:last-child) .selectgroup-button {
 		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
+	}
+}
+
+.selectgroup-vertical > .selectgroup-item {
+	&:not(:last-child) {
+		margin-bottom: 0;
+	}
+
+	& + .selectgroup-item {
+		margin-top: -1px;
+		margin-left: 0;
+	}
+
+	&:not(:first-child) .selectgroup-button {
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
+	}
+
+	&:not(:last-child) .selectgroup-button {
+		border-bottom-left-radius: 0;
 		border-bottom-right-radius: 0;
 	}
 }


### PR DESCRIPTION
## Description

This PR adds a vertical layout for the `selectgroup` form element. It is enabled by adding a `selectgroup-vertical` on the container.

```html
<div class="selectgroup selectgroup-vertical">
    <!-- .selectgroup-item -->
</div>
```

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/154633/39097903-fcd94592-4662-11e8-944d-e930d092dc8c.png)

## Types of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)