### PR TITLE
Fix issue with broken 'tabler.svg' logo on 'Login', 'Register' and 'Forgot Password' pages

### DIFF
--- a/dist/forgot-password.html
+++ b/dist/forgot-password.html
@@ -43,7 +43,7 @@
           <div class="row">
             <div class="col col-login mx-auto">
               <div class="text-center mb-6">
-                <img src="./assets/brand/tabler.svg" class="h-6" alt="">
+                <img src="./demo/brand/tabler.svg" class="h-6" alt="">
               </div>
               <form class="card" action="" method="post">
                 <div class="card-body p-6">

--- a/dist/login.html
+++ b/dist/login.html
@@ -43,7 +43,7 @@
           <div class="row">
             <div class="col col-login mx-auto">
               <div class="text-center mb-6">
-                <img src="./assets/brand/tabler.svg" class="h-6" alt="">
+                <img src="./demo/brand/tabler.svg" class="h-6" alt="">
               </div>
               <form class="card" action="" method="post">
                 <div class="card-body p-6">

--- a/dist/register.html
+++ b/dist/register.html
@@ -43,7 +43,7 @@
           <div class="row">
             <div class="col col-login mx-auto">
               <div class="text-center mb-6">
-                <img src="./assets/brand/tabler.svg" class="h-6" alt="">
+                <img src="./demo/brand/tabler.svg" class="h-6" alt="">
               </div>
               <form class="card" action="" method="post">
                 <div class="card-body p-6">

--- a/src/_layouts/single.html
+++ b/src/_layouts/single.html
@@ -7,7 +7,7 @@ layout: base
 		<div class="row">
 			<div class="col {{ page.col-class | default: 'col-login' }} mx-auto">
 				<div class="text-center mb-6">
-					<img src="./assets/brand/tabler.svg" class="h-6" alt="">
+					<img src="./demo/brand/tabler.svg" class="h-6" alt="">
 				</div>
 
 				{{ content }}


### PR DESCRIPTION
Noticed a broken Tabler logo on **Login**, **Register** and **Forgot Password** pages while I was browsing the theme.

The fix seems to be trivial, so I decided to address that since it didn't look right to show the demo with broken images.

Hope this would help to make things even better! 😃 

Please find below a comparison `before` vs. `after` for each page adjusted.

## Login
`before`
<img width="510" alt="image" src="https://user-images.githubusercontent.com/3822219/39561200-0e737144-4e59-11e8-8345-eb163a147cb3.png">
`after`
<img width="538" alt="image" src="https://user-images.githubusercontent.com/3822219/39561214-29f1b246-4e59-11e8-8e06-575182e7c287.png">

## Register
`before`
<img width="495" alt="image" src="https://user-images.githubusercontent.com/3822219/39561241-50ea1730-4e59-11e8-9088-9ebfb3108116.png">
`after`
<img width="481" alt="image" src="https://user-images.githubusercontent.com/3822219/39561251-6350dd5a-4e59-11e8-947a-17a0873bfc6c.png">

## Forgot Password
`before`
<img width="468" alt="image" src="https://user-images.githubusercontent.com/3822219/39561264-7b76a310-4e59-11e8-9f9b-11f6a438928e.png">
`after`
<img width="453" alt="image" src="https://user-images.githubusercontent.com/3822219/39561276-8b69a786-4e59-11e8-8072-37cbec3b64dd.png">