### PR TITLE
Fix error on serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ When completed, you will be able to run the various commands provided in the com
 
 ### Build Tabler
 
-1. From the root `/tabler` directory, run `npm run serve` in the command line.
+1. From the root `/tabler` directory, run `bundle exec npm run serve` in the command line.
 2. Open [http://localhost:4000](http://localhost:4000) in your browser, and voilà.
 3. Any change in `/src` directory will build application and refresh the page.
 


### PR DESCRIPTION
This fixes the following error: You have already activated public_suffix 3.0.2, but your Gemfile requires public_suffix 3.0.0. Prepending `bundle exec` to your command may solve this.