### PR TITLE
Declare sass variables as default to allow overrides

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -1,80 +1,79 @@
 // Options
-$enable-rounded: true;
-$enable-shadows: false;
-$enable-gradients: false;
-$enable-transitions: true;
-$enable-hover-media-query: false;
-$enable-grid-classes: true;
-$enable-print-styles: true;
+$enable-rounded: true !default;
+$enable-shadows: false !default;
+$enable-gradients: false !default;
+$enable-transitions: true !default;
+$enable-hover-media-query: false !default;
+$enable-grid-classes: true !default;
+$enable-print-styles: true !default;
 
 //Fonts
-$font-family-base: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-$font-family-monospace: Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+$font-family-base: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif !default;
+$font-family-monospace: Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
 
-$font-size-base: .9375rem;
-$font-size-lg: 1.125rem;
-$font-size-sm: .875rem;
+$font-size-base: .9375rem !default;
+$font-size-lg: 1.125rem !default;
+$font-size-sm: .875rem !default;
 
-$line-height-base: 1.5;
+$line-height-base: 1.5 !default;
 
-$h1-font-size: 2rem; //32px
-$h2-font-size: 1.75rem; //28px
-$h3-font-size: 1.5rem; //24px
-$h4-font-size: 1.125rem; //18px
-$h5-font-size: 1rem; //16px
-$h6-font-size: .875rem; //14px
+$h1-font-size: 2rem !default; //32px
+$h2-font-size: 1.75rem !default; //28px
+$h3-font-size: 1.5rem !default; //24px
+$h4-font-size: 1.125rem !default; //18px
+$h5-font-size: 1rem !default; //16px
+$h6-font-size: .875rem !default; //14px
 
-$small-font-size: 87.5%;
+$small-font-size: 87.5% !default;
 
-$headings-margin-bottom: .66em;
-$headings-font-family: inherit;
-$headings-font-weight: 600;
-$headings-line-height: 1.1;
-$headings-color: inherit;
+$headings-margin-bottom: .66em !default;
+$headings-font-family: inherit !default;
+$headings-font-weight: 600 !default;
+$headings-line-height: 1.1 !default;
+$headings-color: inherit !default;
 
-$display1-size: 4.5rem;
-$display2-size: 4rem;
-$display3-size: 3.5rem;
-$display4-size: 3rem;
+$display1-size: 4.5rem !default;
+$display2-size: 4rem !default;
+$display3-size: 3.5rem !default;
+$display4-size: 3rem !default;
 
 // Colors
-$gray-100: #f8f9fa;
-$gray-200: #e9ecef;
-$gray-300: #dee2e6;
-$gray-400: #ced4da;
-$gray-500: #adb5bd;
-$gray-600: #868e96;
-$gray-700: #495057;
-$gray-800: #343a40;
-$gray-900: #212529;
+$gray-100: #f8f9fa !default;
+$gray-200: #e9ecef !default;
+$gray-300: #dee2e6 !default;
+$gray-400: #ced4da !default;
+$gray-500: #adb5bd !default;
+$gray-600: #868e96 !default;
+$gray-700: #495057 !default;
+$gray-800: #343a40 !default;
+$gray-900: #212529 !default;
 
-$blue: #467fcf;
-$azure: #45aaf2;
-$indigo: #6574cd;
-$purple: #a55eea;
-$pink: #f66d9b;
-$red: #cd201f;
-$orange: #fd9644;
-$yellow: #f1c40f;
-$lime: #7bd235;
-$green: #5eba00;
-$teal: #2bcbba;
-$cyan: #17a2b8;
+$blue: #467fcf !default;
+$azure: #45aaf2 !default;
+$indigo: #6574cd !default;
+$purple: #a55eea !default;
+$pink: #f66d9b !default;
+$red: #cd201f !default;
+$orange: #fd9644 !default;
+$yellow: #f1c40f !default;
+$lime: #7bd235 !default;
+$green: #5eba00 !default;
+$teal: #2bcbba !default;
+$cyan: #17a2b8 !default;
 
+$text-muted: #9aa0ac !default;
+$text-muted-dark: #6e7687 !default;
 
-$text-muted: #9aa0ac;
-$text-muted-dark: #6e7687;
+$white: #fff !default;
 
-$white: #fff;
-
-$primary: $blue;
-$secondary: $gray-600;
-$success: $green;
-$info: $azure;
-$warning: $yellow;
-$danger: $red;
-$light: $gray-100;
-$dark: $gray-800;
+$primary: $blue !default;
+$secondary: $gray-600 !default;
+$success: $green !default;
+$info: $azure !default;
+$warning: $yellow !default;
+$danger: $red !default;
+$light: $gray-100 !default;
+$dark: $gray-800 !default;
 
 $colors: (
 	"blue": $blue,
@@ -121,63 +120,63 @@ $social-colors: (
 	"bitbucket": #0052cc,
 );
 
-$body-bg: #f5f7fb;
-$body-color: $gray-700;
+$body-bg: #f5f7fb !default;
+$body-color: $gray-700 !default;
 
 // Code
-$code-font-size: 85%;
-$code-color: inherit;
+$code-font-size: 85% !default;
+$code-color: inherit !default;
 
-$kbd-color: #fff;
-$kbd-bg: $gray-800;
+$kbd-color: #fff !default;
+$kbd-bg: $gray-800 !default;
 
-$pre-color: $gray-900;
+$pre-color: $gray-900 !default;
 
 // Yiq
-$yiq-contrasted-threshold: 190;
-$yiq-text-dark: $body-color;
-$yiq-text-light: $white;
+$yiq-contrasted-threshold: 190 !default;
+$yiq-text-dark: $body-color !default;
+$yiq-text-light: $white !default;
 
 // Buttons
-$input-line-height: (24/15);
-$btn-line-height: (24/13);
+$input-line-height: (24/15) !default;
+$btn-line-height: (24/13) !default;
 
-$input-line-height-sm: (16/14);
-$btn-line-height-sm: (16/12);
+$input-line-height-sm: (16/14) !default;
+$btn-line-height-sm: (16/12) !default;
 
-$input-line-height-lg: (26/18);
-$btn-line-height-lg: (26/16);
+$input-line-height-lg: (26/18) !default;
+$btn-line-height-lg: (26/16) !default;
 
-$input-btn-focus-width: 2px;
+$input-btn-focus-width: 2px !default;
 
-$input-disabled-bg: $gray-100;
+$input-disabled-bg: $gray-100 !default;
 
-$input-focus-border-color: #1991eb;
-$custom-select-focus-border-color: #1991eb;
+$input-focus-border-color: #1991eb !default;
+$custom-select-focus-border-color: #1991eb !default;
 
 // Borders
-$border-width: 1px;
+$border-width: 1px !default;
 //$border-color: #dee3eb;
-$border-color: rgba(0, 40, 100, .12);
-$border-color-dark: rgba(0, 40, 100, .24);
+$border-color: rgba(0, 40, 100, .12) !default;
+$border-color-dark: rgba(0, 40, 100, .24) !default;
 
 // Inputs
-$input-bg: #fff;
-$input-height: 2.375rem;
+$input-bg: #fff !default;
+$input-height: 2.375rem !default;
 
-$input-color: $gray-700;
-$input-border-color: $border-color;
-$input-border-width: 1px;
-$input-box-shadow: inset 0 1px 1px rgba(#000, .075);
+$input-color: $gray-700 !default;
+$input-border-color: $border-color !default;
+$input-border-width: 1px !default;
+$input-box-shadow: inset 0 1px 1px rgba(#000, .075) !default;
 
-$input-group-addon-border-color: $input-border-color;
-$input-group-addon-bg: #fbfbfc;
+$input-group-addon-border-color: $input-border-color !default;
+$input-group-addon-bg: #fbfbfc !default;
 
-$input-placeholder-color: $gray-500;
+$input-placeholder-color: $gray-500 !default;
 
 // Grid
-$grid-columns: 12;
-$grid-gutter-width: 1.5rem;
+$grid-columns: 12 !default;
+$grid-gutter-width: 1.5rem !default;
 
 $grid-breakpoints: (
 	xs: 0,
@@ -195,20 +194,20 @@ $container-max-widths: (
 );
 
 // Header
-$header-bg: #0667d0;
-$header-color: #fff;
-$header-height: 4.5rem;
+$header-bg: #0667d0 !default;
+$header-color: #fff !default;
+$header-height: 4.5rem !default;
 
 // Cards
-$card-border-color: $border-color;
-$card-spacer-y: 1.5rem;
-$card-spacer-x: 1.5rem;
+$card-border-color: $border-color !default;
+$card-spacer-y: 1.5rem !default;
+$card-spacer-x: 1.5rem !default;
 
 // Alerts
-$alert-link-font-weight: 600;
+$alert-link-font-weight: 600 !default;
 
 // Spacing
-$spacer: 1rem;
+$spacer: 1rem !default;
 $spacers: (
 	0: 0,
 	1: $spacer * .25,
@@ -241,71 +240,69 @@ $sizes: (
 );
 
 // Footer
-$footer-bg: #fff;
+$footer-bg: #fff !default;
 
 // Dropdowns
-$dropdown-border-color: $border-color;
-$dropdown-box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+$dropdown-border-color: $border-color !default;
+$dropdown-box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05) !default;
 
 // Z-index
-$zindex-overlay: 900;
-$zindex-dropdown: 1000;
-$zindex-sticky: 1020;
-$zindex-fixed: 1030;
-$zindex-modal-backdrop: 1040;
-$zindex-modal: 1050;
-$zindex-popover: 1060;
-$zindex-tooltip: 1070;
+$zindex-overlay: 900 !default;
+$zindex-dropdown: 1000 !default;
+$zindex-sticky: 1020 !default;
+$zindex-fixed: 1030 !default;
+$zindex-modal-backdrop: 1040 !default;
+$zindex-modal: 1050 !default;
+$zindex-popover: 1060 !default;
+$zindex-tooltip: 1070 !default;
 
 // Components
-$border-radius: 3px;
-$border-radius-lg: 3px;
-$border-radius-sm: 3px;
+$border-radius: 3px !default;
+$border-radius-lg: 3px !default;
+$border-radius-sm: 3px !default;
 
 // Tables
-$table-accent-bg: rgba(0, 0, 0, .02);
-$table-hover-bg: rgba(0, 0, 0, .04);
+$table-accent-bg: rgba(0, 0, 0, .02) !default;
+$table-hover-bg: rgba(0, 0, 0, .04) !default;
 
-$custom-select-padding-y: .5rem;
-$custom-select-padding-x: .75rem;
+$custom-select-padding-y: .5rem !default;
+$custom-select-padding-x: .75rem !default;
 
-$custom-select-indicator-color: #999;
-$custom-select-indicator: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 5'%3E%3Cpath fill='#{$custom-select-indicator-color}' d='M0 0L10 0L5 5L0 0'/%3E%3C/svg%3E");
+$custom-select-indicator-color: #999 !default;
+$custom-select-indicator: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 5'%3E%3Cpath fill='#{$custom-select-indicator-color}' d='M0 0L10 0L5 5L0 0'/%3E%3C/svg%3E") !default;
 
 // Aside
-$aside-width: 22rem;
+$aside-width: 22rem !default;
 
 // List group
-$list-group-border-color: $border-color;
-$list-group-active-color: $primary;
-$list-group-active-bg: mix($primary, #fff, 4%);
-$list-group-active-border-color: $list-group-border-color;
+$list-group-border-color: $border-color !default;
+$list-group-active-color: $primary !default;
+$list-group-active-bg: mix($primary, #fff, 4%) !default;
+$list-group-active-border-color: $list-group-border-color !default;
 
 // Popovers
-$popover-body-padding-y: .75rem;
-$popover-body-padding-x: 1rem;
-$popover-border-color: #dee3eb;
-$popover-body-color: $text-muted-dark;
-$popover-arrow-width: .5rem;
-$popover-arrow-height: .5rem;
+$popover-body-padding-y: .75rem !default;
+$popover-body-padding-x: 1rem !default;
+$popover-border-color: #dee3eb !default;
+$popover-body-color: $text-muted-dark !default;
+$popover-arrow-width: .5rem !default;
+$popover-arrow-height: .5rem !default;
 
 // Badges
-$badge-font-weight: 600;
-
-
+$badge-font-weight: 600 !default;
 
 // Icons flags
-$flag-icons: ('ad', 'ae', 'af', 'ag', 'ai', 'al', 'am', 'ao', 'aq', 'ar', 'as', 'at', 'au', 'aw', 'ax', 'az', 'ba', 'bb', 'bd', 'be', 'bf', 'bg', 'bh', 'bi', 'bj', 'bl', 'bm', 'bn', 'bo', 'bq', 'br', 'bs', 'bt', 'bv', 'bw', 'by', 'bz', 'ca', 'cc', 'cd', 'cf', 'cg', 'ch', 'ci', 'ck', 'cl', 'cm', 'cn', 'co', 'cr', 'cu', 'cv', 'cw', 'cx', 'cy', 'cz', 'de', 'dj', 'dk', 'dm', 'do', 'dz', 'ec', 'ee', 'eg', 'eh', 'er', 'es', 'et', 'eu', 'fi', 'fj', 'fk', 'fm', 'fo', 'fr', 'ga', 'gb-eng', 'gb-nir', 'gb-sct', 'gb-wls', 'gb', 'gd', 'ge', 'gf', 'gg', 'gh', 'gi', 'gl', 'gm', 'gn', 'gp', 'gq', 'gr', 'gs', 'gt', 'gu', 'gw', 'gy', 'hk', 'hm', 'hn', 'hr', 'ht', 'hu', 'id', 'ie', 'il', 'im', 'in', 'io', 'iq', 'ir', 'is', 'it', 'je', 'jm', 'jo', 'jp', 'ke', 'kg', 'kh', 'ki', 'km', 'kn', 'kp', 'kr', 'kw', 'ky', 'kz', 'la', 'lb', 'lc', 'li', 'lk', 'lr', 'ls', 'lt', 'lu', 'lv', 'ly', 'ma', 'mc', 'md', 'me', 'mf', 'mg', 'mh', 'mk', 'ml', 'mm', 'mn', 'mo', 'mp', 'mq', 'mr', 'ms', 'mt', 'mu', 'mv', 'mw', 'mx', 'my', 'mz', 'na', 'nc', 'ne', 'nf', 'ng', 'ni', 'nl', 'no', 'np', 'nr', 'nu', 'nz', 'om', 'pa', 'pe', 'pf', 'pg', 'ph', 'pk', 'pl', 'pm', 'pn', 'pr', 'ps', 'pt', 'pw', 'py', 'qa', 're', 'ro', 'rs', 'ru', 'rw', 'sa', 'sb', 'sc', 'sd', 'se', 'sg', 'sh', 'si', 'sj', 'sk', 'sl', 'sm', 'sn', 'so', 'sr', 'ss', 'st', 'sv', 'sx', 'sy', 'sz', 'tc', 'td', 'tf', 'tg', 'th', 'tj', 'tk', 'tl', 'tm', 'tn', 'to', 'tr', 'tt', 'tv', 'tw', 'tz', 'ua', 'ug', 'um', 'un', 'us', 'uy', 'uz', 'va', 'vc', 've', 'vg', 'vi', 'vn', 'vu', 'wf', 'ws', 'ye', 'yt', 'za', 'zm', 'zw');
+$flag-icons: ('ad', 'ae', 'af', 'ag', 'ai', 'al', 'am', 'ao', 'aq', 'ar', 'as', 'at', 'au', 'aw', 'ax', 'az', 'ba', 'bb', 'bd', 'be', 'bf', 'bg', 'bh', 'bi', 'bj', 'bl', 'bm', 'bn', 'bo', 'bq', 'br', 'bs', 'bt', 'bv', 'bw', 'by', 'bz', 'ca', 'cc', 'cd', 'cf', 'cg', 'ch', 'ci', 'ck', 'cl', 'cm', 'cn', 'co', 'cr', 'cu', 'cv', 'cw', 'cx', 'cy', 'cz', 'de', 'dj', 'dk', 'dm', 'do', 'dz', 'ec', 'ee', 'eg', 'eh', 'er', 'es', 'et', 'eu', 'fi', 'fj', 'fk', 'fm', 'fo', 'fr', 'ga', 'gb-eng', 'gb-nir', 'gb-sct', 'gb-wls', 'gb', 'gd', 'ge', 'gf', 'gg', 'gh', 'gi', 'gl', 'gm', 'gn', 'gp', 'gq', 'gr', 'gs', 'gt', 'gu', 'gw', 'gy', 'hk', 'hm', 'hn', 'hr', 'ht', 'hu', 'id', 'ie', 'il', 'im', 'in', 'io', 'iq', 'ir', 'is', 'it', 'je', 'jm', 'jo', 'jp', 'ke', 'kg', 'kh', 'ki', 'km', 'kn', 'kp', 'kr', 'kw', 'ky', 'kz', 'la', 'lb', 'lc', 'li', 'lk', 'lr', 'ls', 'lt', 'lu', 'lv', 'ly', 'ma', 'mc', 'md', 'me', 'mf', 'mg', 'mh', 'mk', 'ml', 'mm', 'mn', 'mo', 'mp', 'mq', 'mr', 'ms', 'mt', 'mu', 'mv', 'mw', 'mx', 'my', 'mz', 'na', 'nc', 'ne', 'nf', 'ng', 'ni', 'nl', 'no', 'np', 'nr', 'nu', 'nz', 'om', 'pa', 'pe', 'pf', 'pg', 'ph', 'pk', 'pl', 'pm', 'pn', 'pr', 'ps', 'pt', 'pw', 'py', 'qa', 're', 'ro', 'rs', 'ru', 'rw', 'sa', 'sb', 'sc', 'sd', 'se', 'sg', 'sh', 'si', 'sj', 'sk', 'sl', 'sm', 'sn', 'so', 'sr', 'ss', 'st', 'sv', 'sx', 'sy', 'sz', 'tc', 'td', 'tf', 'tg', 'th', 'tj', 'tk', 'tl', 'tm', 'tn', 'to', 'tr', 'tt', 'tv', 'tw', 'tz', 'ua', 'ug', 'um', 'un', 'us', 'uy', 'uz', 'va', 'vc', 've', 'vg', 'vi', 'vn', 'vu', 'wf', 'ws', 'ye', 'yt', 'za', 'zm', 'zw') !default;
 
 // Hr
-$hr-border-color: $border-color;
+$hr-border-color: $border-color !default;
 
 // Thumbnails
-$thumbnail-bg: #fff;
+$thumbnail-bg: #fff !default;
 
 // Pagination
-$pagination-color: $body-color;
-$pagination-disabled-color: $gray-400;
+$pagination-color: $body-color !default;
+$pagination-disabled-color: $gray-400 !default;
 
 // Navs
-$nav-tabs-link-active-bg: transparent;
+$nav-tabs-link-active-bg: transparent !default;


### PR DESCRIPTION
This PR implements the functionality requested at #79 and is totally backwards-compatible/non-obtrusive as it changes nothing (except that it now allows overriding these variables).

### Example: 
To change the main background color to white now simply set this **before** importing `dashboard.scss`:

```sass
$body-bg: #fff;
```