### PR TITLE
Fix select-tag background SVG in Firefox

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -270,7 +270,7 @@ $custom-select-padding-y: .5rem;
 $custom-select-padding-x: .75rem;
 
 $custom-select-indicator-color: #999;
-$custom-select-indicator: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 5'%3E%3Cpath fill='#{$custom-select-indicator-color}' d='M0 0L10 0L5 5L0 0'/%3E%3C/svg%3E");
+$custom-select-indicator: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 5'%3E%3Cpath fill='#{$custom-select-indicator-color}' d='M0 0L10 0L5 5L0 0'/%3E%3C/svg%3E"), "#", "%23");
 
 // Aside
 $aside-width: 22rem;

--- a/src/assets/scss/bundle.scss
+++ b/src/assets/scss/bundle.scss
@@ -2,5 +2,6 @@
  * Dashboard UI
  */
 @import 'variables';
+@import '../../../node_modules/bootstrap/scss/_functions.scss';
 @import '../../../node_modules/bootstrap/scss/bootstrap.scss';
 @import 'dashboard/dashboard';


### PR DESCRIPTION
[fixes #117]

Issue reported by @JamesLF #117

> Classes such as `.selectize-control.single` and `.custom-select` that use an SVG embedded background to render their dropdown indicator fail when rendered on Firefox. This is due to Firefox reading instances of `#` in the data-uris as the start of an anchor section and the end of the URI.

> Replacing `#` with `%23` I found to be an acceptable work around, although for some reason it breaks the automatic insert of `$custom-select-indicator-color` in to `$custom-select-indicator` in the variables file, so I manually insert that color for that instruction.

Issue appears only in Firefox. Fix works in Chrome as expected.

| Before   |      After      |
|----------|:-------------:|
| ![image](https://user-images.githubusercontent.com/9843321/50974626-57418c00-14f4-11e9-9214-f5df678ffb3e.png) |  ![image](https://user-images.githubusercontent.com/9843321/50974580-3da04480-14f4-11e9-82b8-d0b8d76dcf43.png) |

