### PR TITLE
text-decoration-skip fix

### DIFF
--- a/src/assets/scss/dashboard/_type.scss
+++ b/src/assets/scss/dashboard/_type.scss
@@ -3,7 +3,7 @@
 }
 
 a {
-	text-decoration-skip: ink;
+	text-decoration-skip-ink: auto;
 }
 
 h1, h2, h3, h4, h5, h6,


### PR DESCRIPTION
The `text-decoration-skip` spec has changed