### PR TITLE
Add "bundle exec" to use bundled, not latest versions of the deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "scripts": {
     "gulp-watch": "gulp watch",
     "gulp-build": "gulp build",
-    "jekyll-watch": "jekyll build --watch",
-    "jekyll-serve": "jekyll serve --livereload",
+    "jekyll-watch": "bundle exec jekyll build --watch",
+    "jekyll-serve": "bundle exec jekyll serve --livereload",
     "gh-pages": "./gh-pages.sh",
-    "dist": "gulp build && JEKYLL_ENV=production jekyll build --destination dist",
+    "dist": "gulp build && JEKYLL_ENV=production bundle exec jekyll build --destination dist",
     "publish-dist": "./gh-pages.sh",
     "watch": "gulp build && npm-run-all --parallel gulp-watch jekyll-watch",
     "serve": "gulp build && npm-run-all --parallel gulp-watch jekyll-serve",


### PR DESCRIPTION
`yarn dist` and `yarn jekyll-serve` don't run on mac without this change.