### PR TITLE
Fix dropdown icon in latest Chrome

### DIFF
--- a/src/assets/scss/dashboard/_selectize.scss
+++ b/src/assets/scss/dashboard/_selectize.scss
@@ -332,7 +332,7 @@
 	width: 8px;
 	height: 10px;
 
-	background: #fff url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 5'%3E%3Cpath fill='#999' d='M0 0L10 0L5 5L0 0'/%3E%3C/svg%3E") no-repeat center;
+	background: #fff url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 5'%3E%3Cpath fill='%23999' d='M0 0L10 0L5 5L0 0'/%3E%3C/svg%3E") no-repeat center;
 	background-size: 8px 10px;
 	transition: .3s transform;
 }


### PR DESCRIPTION
The `#` needed to be URL encoded