### PR TITLE
Fix bootstrap path in bundle.scss

### DIFF
--- a/src/assets/scss/bundle.scss
+++ b/src/assets/scss/bundle.scss
@@ -1,7 +1,6 @@
 /**
-Dashboard UI
+ * Dashboard UI
  */
-
 @import 'variables';
-@import '~bootstrap/scss/bootstrap.scss';
+@import '../../../node_modules/bootstrap/scss/bootstrap.scss';
 @import 'dashboard/dashboard';


### PR DESCRIPTION
placeholder `~` in path not not supported in SASS. See https://sass-lang.com/documentation/file.SASS_REFERENCE.html#import