### PR TITLE
Adds primary support for y2 axis

### DIFF
--- a/src/_data/charts.yml
+++ b/src/_data/charts.yml
@@ -117,6 +117,7 @@ spline:
   type: spline
   show-labels: true
   hide-legend: true
+  multipleAxes: true
   categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun']
   series:
     - name: Hestavollane

--- a/src/_includes/js-charts.html
+++ b/src/_includes/js-charts.html
@@ -12,6 +12,13 @@ require(['c3', 'jquery'], function(c3, $) {
 					{% for serie in data.series %}
 					['data{{ forloop.index }}', {{ serie.data | join: ', '}}]{% unless forloop.last %},{% endunless %}{% endfor %}
 				],
+				{% if data.multipleAxes %}
+				axes: {
+				    // each columns data
+					data1: 'y',
+					data2: 'y2'
+				},
+				{% endif %}
 
 				{% if data.fill %}
 				classes: {
@@ -76,6 +83,11 @@ require(['c3', 'jquery'], function(c3, $) {
 					// name of each category
 					categories: [{% for category in data.categories %}'{{ category }}'{% unless forloop.last %}, {% endunless %}{% endfor %}]
 				},
+				{% endif %}
+					{% if data.multipleAxes %}
+					y2: {
+						show: true
+					},
 				{% endif %}
 				{% if data.rotated %}
 				rotated: true,


### PR DESCRIPTION
See 'Wind speed during two days' graph for a representation.

When two datasets differ greatly in amplitude, we often times need a second y axis to better represent their values.

Of course, we need to datasets (series) in the graph object, the first one being the y (left) and second one the y2 (right)