### PR TITLE
Changes for Bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "url": "https://github.com/tabler/tabler/issues"
   },
   "devDependencies": {
-    "bootstrap": "^4.1.0",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^5.0.0",
     "gulp-rename": "^1.3.0",
@@ -45,6 +44,7 @@
     "npm-run-all": "^4.1.3"
   },
   "dependencies": {
+    "bootstrap": "^4.1.0",
     "opencollective": "^1.0.3"
   },
   "files": [

--- a/src/assets/scss/bundle.scss
+++ b/src/assets/scss/bundle.scss
@@ -2,5 +2,5 @@
  * Dashboard UI
  */
 @import 'variables';
-@import '../../../node_modules/bootstrap/scss/bootstrap.scss';
+@import 'node_modules/bootstrap/scss/bootstrap.scss';
 @import 'dashboard/dashboard';


### PR DESCRIPTION
I found old fix in bundle.scss: https://github.com/tabler/tabler/commit/8496732fd6d13067bba7bee5fda204aa338710a9
So now, it's problem with install tabler-ui by Webpack.

Path to Bootstrap "../../../bootstrap/scss/bootstrap.scss" doesn't work now.

I tested version with "~bootstrap/scss/bootstrap.scss" and "bootstrap/scss/bootstrap.scss" and works perfectly.