### PR TITLE
Fix invoice table jumping

### DIFF
--- a/pages/_includes/cards/invoices.html
+++ b/pages/_includes/cards/invoices.html
@@ -3,7 +3,7 @@
       <h3 class="card-title">Invoices</h3>
    </div>
    <div class="table-responsive">
-      <table class="table card-table table-vcenter text-nowrap datatable">
+      <table class="table card-table table-vcenter text-nowrap datatable overflow-hidden">
          <thead>
             <tr>
                <th class="w-1p"><input class="form-check-input m-0 align-middle" type="checkbox"></th>


### PR DESCRIPTION
### Issue:
When a user clicks on the `action` button in the invoice table, dropdown makes some extra spaces below the table which causes jumping.

![invoice-table-issue](https://user-images.githubusercontent.com/8412286/67918274-96051780-fbd6-11e9-856b-ce6c4ec6b5ea.gif)

### Solution
Adding `overflow-hidden` to the `table` element.