### PR TITLE
Update minor typo in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ insert_final_newline=false
 indent_style=tab
 tab_width=3
 
-[{*.rb,*.yml,*,scss}]
+[{*.rb,*.yml,*.scss}]
 indent_style=space
 indent_size=2
 


### PR DESCRIPTION
Had used a comma instead of a dot: `*,scss` ~> `*.scss`