### PR TITLE
Remove vertical-align for alert anchor elements

### DIFF
--- a/scss/ui/_alerts.scss
+++ b/scss/ui/_alerts.scss
@@ -12,7 +12,6 @@
   a{
     display: inline-block;
     height:100%;
-    vertical-align: middle;
 
     .icon {
       height: 100%;


### PR DESCRIPTION
There is an issue with line alignment when you define a modal, with an alert & anchor, example: https://jsfiddle.net/57h8qdya/

Before
<img width="681" alt="Screenshot 2020-05-04 at 19 25 33" src="https://user-images.githubusercontent.com/7195374/80999787-200b9280-8e3d-11ea-992b-81b0f77705a1.png">

After
<img width="670" alt="Screenshot 2020-05-04 at 19 26 07" src="https://user-images.githubusercontent.com/7195374/80999799-26017380-8e3d-11ea-9dcf-2dff15b5d821.png">
