### PR TITLE
Avatar status badges should match the avatar size

### DIFF
--- a/scss/ui/_avatars.scss
+++ b/scss/ui/_avatars.scss
@@ -39,6 +39,10 @@
     font-size: $size / 2;
     line-height: $size;
   }
+    .avatar-#{$avatar-size} .badge:empty {
+    width: $size / 4;
+    height: $size / 4;
+  }
 }
 
 


### PR DESCRIPTION
This updates the status badge of avatar icons so that the badge will match the avatar size.

Before:
![Avatar Status Sizes - Original](https://user-images.githubusercontent.com/6931029/81441234-66176d80-913f-11ea-86aa-82064e532fd0.png)

After:
![Avatar Status Sizes - New](https://user-images.githubusercontent.com/6931029/81441241-6a438b00-913f-11ea-9d49-1a7379879c64.png)

I believe the easiest option is to just set the width/height of the status badge to 1/4th the avatar w/h. From the options I tried, it looks the best while requiring hardly any changes.
