### PR TITLE
Permit installation using pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@fullcalendar/timegrid": "^5.4.0",
     "apexcharts": "^3.22.2",
     "autosize": "^4.0.2",
-    "bootstrap": "twbs/bootstrap#c63aebc",
+    "bootstrap": "twbs/bootstrap#c63aebc86ba05f0ebb420add653b80804c6a0cff",
     "countup.js": "^2.0.7",
     "daterangepicker": "^3.1.0",
     "flatpickr": "^4.6.6",


### PR DESCRIPTION
We are currently trying to refactor our UI using tabler.

On my machine, since I added the `@tabler/core` package, `npm install` takes up to 12 minutes (was about 30 seconds before this change). I wanted to try `pnpm`, but it does not handle short commit hash in dependencies specs, and fails with this message: ` ERROR  Could not resolve c63aebc to a commit of git://github.com/twbs/bootstrap.git.`.

Using the full hash could permit usage of `pnpm` to fetch your wonderful creation.