### PR TITLE
Make lite validation also work properly for form select

### DIFF
--- a/src/scss/ui/forms/_validation.scss
+++ b/src/scss/ui/forms/_validation.scss
@@ -6,4 +6,8 @@
   .form-control.is-#{$state}-lite {
     @extend %validation-lite;
   }
+
+  .form-select.is-#{$state}-lite {
+    @extend %validation-lite;
+  }
 }


### PR DESCRIPTION
![Screenshot from 2021-01-18 12-28-02](https://user-images.githubusercontent.com/160743/104909811-b6aac000-5988-11eb-9190-42dcd7ebefb6.png)

Lite validation was only work for form fields with the `.form-control` class. Selects
use the `.form-select` class. This change also applies lite validation for the selects.