### PR TITLE
Fix dark mode not being applied to alerts

### DIFF
--- a/src/scss/_dark.scss
+++ b/src/scss/_dark.scss
@@ -12,7 +12,8 @@
   .footer:not(.footer-transparent),
   .modal-content,
   .modal-header,
-  .dropdown-menu {
+  .dropdown-menu,
+  .alert {
     background-color: $dark;
     color: inherit;
   }


### PR DESCRIPTION
Alerts always looked a bit off with dark mode. This applies dark mode to
alerts making them look less out of place. This also fixes text that has no
style like text-muted applied to be visible.

Before:
![Screenshot from 2021-05-19 10-58-18](https://user-images.githubusercontent.com/160743/118786241-e663c900-b891-11eb-9747-2ec63b2c6dba.png)

After:
![Screenshot from 2021-05-19 10-59-38](https://user-images.githubusercontent.com/160743/118786286-f11e5e00-b891-11eb-9fd0-0502845aa5d3.png)
