### PR TITLE
Make input borders in dark mode a darker

### DIFF
--- a/src/scss/_dark.scss
+++ b/src/scss/_dark.scss
@@ -48,6 +48,7 @@
   .form-imagecheck-figure:before {
     background-color: $dark-mode-darken;
     color: $dark-mode-text;
+    border-color: $dark-mode-lighten-10;
   }
 
   .form-control-plaintext {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -184,6 +184,7 @@ $colors: (
 // Dark mode
 $dark-mode-darken: darken($dark, 2%) !default;
 $dark-mode-lighten: lighten($dark, 2%) !default;
+$dark-mode-lighten-10: lighten($dark, 10%) !default;
 $dark-mode-text: $light;
 
 // Borders


### PR DESCRIPTION
If you have big forms the light color looks really trippy. This PR makes the input borders a bit darker.

Before:
![Screenshot from 2021-05-19 12-11-21](https://user-images.githubusercontent.com/160743/118796014-7bb78b00-b89b-11eb-93bc-c6c545480615.png)

After:
![Screenshot from 2021-05-19 12-11-09](https://user-images.githubusercontent.com/160743/118796045-82460280-b89b-11eb-933f-2b12fc69f458.png)
