### PR TITLE
Light button has dark loading

### DIFF
--- a/src/scss/ui/_buttons.scss
+++ b/src/scss/ui/_buttons.scss
@@ -180,6 +180,12 @@
   }
 }
 
+.btn-loading.btn-light {
+  &:after {
+    color: $dark;
+  }
+}
+
 
 $btn-colors: $theme-colors;
 


### PR DESCRIPTION
In case when button had .btn-light, the .btn-loading was not visible. Fixed with changing loading color to dark.