### PR TITLE
Missing bootstrap components

### DIFF
--- a/src/scss/_bootstrap-components.scss
+++ b/src/scss/_bootstrap-components.scss
@@ -27,6 +27,8 @@
 @import "~bootstrap/scss/popover";
 @import "~bootstrap/scss/carousel";
 @import "~bootstrap/scss/spinners";
+@import "~bootstrap/scss/offcanvas";
+@import "~bootstrap/scss/placeholders";
 
 // Helpers
 @import "~bootstrap/scss/helpers";


### PR DESCRIPTION
Added missing bootstrap components
- Offcanvas https://getbootstrap.com/docs/5.0/components/offcanvas/
- Placeholders https://github.com/twbs/bootstrap/blob/main/scss/_placeholders.scss

