### PR TITLE
Fix vertical alignment of empty badge elements

### DIFF
--- a/src/scss/ui/_badges.scss
+++ b/src/scss/ui/_badges.scss
@@ -22,6 +22,7 @@
     min-height: auto;
     padding: 0;
     border-radius: $border-radius-pill;
+    vertical-align: baseline;
   }
 
   .avatar {


### PR DESCRIPTION
Closes #1006 

Improves vertical alignment of empty `.badge` elements.