### PR TITLE
add font-display: swap; to improve font loading

### DIFF
--- a/src/scss/fonts/_webfonts.scss
+++ b/src/scss/fonts/_webfonts.scss
@@ -5,6 +5,7 @@
   @font-face {
     font-family: $font-local;
     font-style: normal;
+    font-display: swap;
     font-weight: 300;
     src: local(''),
     url('#{$assets-base}/fonts/inter-v7-latin-ext_latin-300.woff2') format('woff2'),
@@ -14,6 +15,7 @@
   @font-face {
     font-family: $font-local;
     font-style: normal;
+    font-display: swap;
     font-weight: 400;
     src: local(''),
     url('#{$assets-base}/fonts/inter-v7-latin-ext_latin-regular.woff2') format('woff2'),
@@ -23,6 +25,7 @@
   @font-face {
     font-family: $font-local;
     font-style: normal;
+    font-display: swap;
     font-weight: 500;
     src: local(''),
     url('#{$assets-base}/fonts/inter-v7-latin-ext_latin-500.woff2') format('woff2'),
@@ -32,6 +35,7 @@
   @font-face {
     font-family: $font-local;
     font-style: normal;
+    font-display: swap;
     font-weight: 600;
     src: local(''),
     url('#{$assets-base}/fonts/inter-v7-latin-ext_latin-600.woff2') format('woff2'),
@@ -41,6 +45,7 @@
   @font-face {
     font-family: $font-local;
     font-style: normal;
+    font-display: swap;
     font-weight: 700;
     src: local(''),
     url('#{$assets-base}/fonts/inter-v7-latin-ext_latin-700.woff2') format('woff2'),


### PR DESCRIPTION
I added the `font-display: swap;` tag when loading the Inter font to improve the experience on slower connections.
It will make the text appear immediately with a fallback font and swap it with the Inter font as soon as the font is loaded. This shouldn't have any visual change for most users with a proper internet connection, but for slower connections - especially on mobile - this can make a huge difference.
More infos: https://developers.google.com/web/updates/2016/02/font-display#swap