### PR TITLE
Fix #1079: Fix select being blank when using tab to highlight field

### DIFF
--- a/src/scss/ui/_forms.scss
+++ b/src/scss/ui/_forms.scss
@@ -53,6 +53,15 @@ Form hint
 }
 
 /**
+Form select
+ */
+.form-select {
+  &:-moz-focusring {
+    color: var(--#{$variable-prefix}body-color);
+  }
+}
+
+/**
 Form control
  */
 .form-control {


### PR DESCRIPTION
How to test:

- Open firefox
- Go to forms
- Click fields above the selects
- Use tab to move into the next field
- It should not go blank