### PR TITLE
added optgroup form examples

### DIFF
--- a/src/pages/_data/selects.yml
+++ b/src/pages/_data/selects.yml
@@ -69,3 +69,25 @@ labels:
 people:
   value: 4
   data: people
+
+optgroups:
+  value: Optgroups
+  data: optgroup
+  options:
+    -
+      title: Tags
+      options:
+        - HTML
+        - JavaScript
+        - CSS
+        - jQuery
+        - Bootstrap
+        - Ruby
+        - Python
+    -
+      title: People
+      options:
+        - Chuck Tesla
+        - Elon Musk
+        - Paweł Kuna
+        - Nikola Tesla

--- a/src/pages/_includes/cards/form/layout.html
+++ b/src/pages/_includes/cards/form/layout.html
@@ -29,6 +29,21 @@
 				<div {% if horizontal %}class="col"{% endif %}>
 					<select class="form-select">
 						<option>Option 1</option>
+						<optgroup label="Optgroup 1">
+							<option>Option 1</option>
+							<option>Option 2</option>
+						</optgroup>
+					  <option>Option 2</option>
+						<optgroup label="Optgroup 2">
+							<option>Option 1</option>
+							<option>Option 2</option>
+						</optgroup>
+						<optgroup label="Optgroup 3">
+							<option>Option 1</option>
+							<option>Option 2</option>
+						</optgroup>
+					  <option>Option 3</option>
+					  <option>Option 4</option>
 					</select>
 				</div>
 			</div>

--- a/src/pages/_includes/forms/form-elements-6.html
+++ b/src/pages/_includes/forms/form-elements-6.html
@@ -47,6 +47,11 @@
 </div>
 
 <div class="mb-3">
+	 <label class="form-label">Advanced select with optgroup</label>
+	 {% include ui/select.html key="optgroups" %}
+</div>
+
+<div class="mb-3">
 	<label class="form-label">Select with avatars</label>
 	{% include ui/select.html key="people" indicator="avatar" %}
 </div>

--- a/src/pages/_includes/ui/select.html
+++ b/src/pages/_includes/ui/select.html
@@ -65,7 +65,7 @@
 		var el;
 		window.TomSelect && ({% if jekyll.environment == 'development' %}window.tabler_select["select-{{ id }}"] = {% endif %}new TomSelect(el = document.getElementById('select-{{ id }}'), {
 			copyClassesToDropdown: false,
-			dropdownClass: 'dropdown-menu',
+			dropdownClass: 'dropdown-menu ts-dropdown',
 			optionClass:'dropdown-item',
 
 			{% unless include.show-search %}

--- a/src/pages/_includes/ui/select.html
+++ b/src/pages/_includes/ui/select.html
@@ -20,6 +20,15 @@
 				<option value="{{ person.id }}"{% if include.indicator == 'avatar' %} data-custom-properties="{% capture indicator %}{% include ui/avatar.html size='xs' person=person %}{% endcapture %}{{ indicator | strip | escape }}"{% endif %}>{{ person.full_name }}</option>
 			{% endfor %}
 
+		{% elsif data.data == 'optgroup' %}
+			{% for group in options %}
+	 			<optgroup label="{{ group.title }}">
+					{% for option in group.options %}
+					<option value="{{ option }}">{{ option }}</option>
+					{% endfor %}
+				</optgroup>
+			{% endfor %}
+
 		{% else %}
 			{% for option in options %}
 				{% if option.first %}


### PR DESCRIPTION
@rjd22 here is a PR that adds optgroup examples in the form page, so they can be tested easily

See also #1024 and #1098

This is default browser (Safari) rendering:
<img width="261" alt="Bildschirmfoto 2022-04-11 um 12 27 47" src="https://user-images.githubusercontent.com/533162/162721796-4b94e4dd-b2c5-40ba-88c2-3284b9f8b2c9.png">

And this is how Tom-Select currently looks:
<img width="174" alt="Bildschirmfoto 2022-04-11 um 12 28 41" src="https://user-images.githubusercontent.com/533162/162721891-b8c10b12-76c5-46f3-85d1-9066381c1575.png">

This is how it looks normally with TomSelect and Bootstrap 5:  https://tom-select.js.org/examples/optgroups/

**UPDATE**
I found the issue that is causing it.
You are importing the [tom select bootstrap 5](https://github.com/tabler/tabler/blob/main/src/scss/vendor/_tom-select.scss#L1) css file, but you are preventing the rules from being applied. They are prefixed like this: `.#{$select-ns}-dropdown` where `select-ns` variable is `ts` by default, resulting in rules like these:
```css
.ts-dropdown {
	.optgroup-header {
		font-size: $font-size-sm;
		line-height: $line-height-base;
	}
}
```

But the classes are [not applied in the select.html include](https://github.com/tabler/tabler/blob/main/src/pages/_includes/ui/select.html#L59-L60).
Is that on purpose @codecalm? By re-applying them (I did in the PR) the dropdown now looks better:
<img width="218" alt="Bildschirmfoto 2022-04-11 um 12 55 08" src="https://user-images.githubusercontent.com/533162/162725801-119ffbfd-e8d9-4541-b787-9c8b4f2cf43b.png">

Now dark mode still has an issue, it shows the header with white background. This rule makes it slightly better:
```css
.ts-wrapper{
  .dropdown-menu {
    .optgroup-header {
      color: var(--#{$variable-prefix}body-color);
      background-color: var(--#{$variable-prefix}body-bg);
    }
  }
}
```
but I am not entirely happy with the result and would like to leave this up to you, because you simply know better.
