### PR TITLE
Make development activity chart full width on tablets

### DIFF
--- a/src/pages/_includes/layout/homepage.html
+++ b/src/pages/_includes/layout/homepage.html
@@ -104,7 +104,7 @@
 		</div>
 	</div>
 
-	<div class="col-md-6">
+	<div class="col-lg-6">
 		{% include cards/development-activity.html %}
 	</div>
 


### PR DESCRIPTION
Small fix that bothered me on the homepage.

Viewing the [preview homepage](https://preview.tabler.io/) on a tablet showed this big empty space.

You can reproduce it by opening element inspector in your browser and setting the dimensions to iPad air for example.

![Screenshot 2022-06-18 at 12 19 31](https://user-images.githubusercontent.com/516028/174433607-1a886879-bb4b-48f2-ae2a-25d2937ed62c.png)

