### PR TITLE
Make the datatables preview page functional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "gulp-sass": "^5.1.0",
         "imask": "^6.4.2",
         "jsvectormap": "^1.4.5",
+        "list.js": "^2.3.1",
         "litepicker": "^2.0.12",
         "nouislider": "^15.6.0",
         "plyr": "^3.7.2",
@@ -9676,6 +9677,18 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/list.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/list.js/-/list.js-2.3.1.tgz",
+      "integrity": "sha512-jnmm7DYpKtH3DxtO1E2VNCC9Gp7Wrp/FWA2JxQrZUhVJ2RCQBd57pCN6W5w6jpsfWZV0PCAbTX2NOPgyFeeZZg==",
+      "dev": true,
+      "dependencies": {
+        "string-natural-compare": "^2.0.2"
+      },
+      "engines": {
+        "node": "^6.0 || ^8.0 || ^10.0 || ^12.0 || >=14"
+      }
+    },
     "node_modules/litepicker": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/litepicker/-/litepicker-2.0.12.tgz",
@@ -14402,6 +14415,12 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/string-natural-compare": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-2.0.3.tgz",
+      "integrity": "sha512-4Kcl12rNjc+6EKhY8QyDVuQTAlMWwRiNbsxnVwBUKFr7dYPQuXVrtNU4sEkjF9LHY0AY6uVbB3ktbkIH4LC+BQ==",
+      "dev": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -23717,6 +23736,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "list.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/list.js/-/list.js-2.3.1.tgz",
+      "integrity": "sha512-jnmm7DYpKtH3DxtO1E2VNCC9Gp7Wrp/FWA2JxQrZUhVJ2RCQBd57pCN6W5w6jpsfWZV0PCAbTX2NOPgyFeeZZg==",
+      "dev": true,
+      "requires": {
+        "string-natural-compare": "^2.0.2"
+      }
+    },
     "litepicker": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/litepicker/-/litepicker-2.0.12.tgz",
@@ -27390,6 +27418,12 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "string-natural-compare": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-2.0.3.tgz",
+      "integrity": "sha512-4Kcl12rNjc+6EKhY8QyDVuQTAlMWwRiNbsxnVwBUKFr7dYPQuXVrtNU4sEkjF9LHY0AY6uVbB3ktbkIH4LC+BQ==",
+      "dev": true
     },
     "string-width": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -89,21 +89,22 @@
     "gulp-sass": "^5.1.0",
     "imask": "^6.4.2",
     "jsvectormap": "^1.4.5",
+    "list.js": "^2.3.1",
     "litepicker": "^2.0.12",
     "nouislider": "^15.6.0",
+    "plyr": "^3.7.2",
     "postcss": "^8.4.13",
     "release-it": "^15.0.0",
     "rollup": "^2.72.1",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-cleanup": "^3.2.1",
     "sass": "^1.51.0",
+    "tinymce": "^6.0.3",
     "tom-select": "^2.0.1",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
     "yaml": "^2.0.1",
-    "yargs": "^17.4.1",
-    "plyr": "^3.7.2",
-    "tinymce": "^6.0.3"
+    "yargs": "^17.4.1"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.5",
@@ -115,6 +116,7 @@
     "autosize": "^5.0.1",
     "choices.js": "^10.1.0",
     "countup.js": "^2.1.0",
+    "dropzone": "^6.0.0-beta.2",
     "flatpickr": "^4.6.13",
     "fslightbox": "^3.3.1",
     "imask": "^6.4.2",
@@ -122,10 +124,9 @@
     "list.js": "^2.3.1",
     "litepicker": "^2.0.12",
     "nouislider": "^15.6.0",
-    "dropzone": "^6.0.0-beta.2",
-    "tom-select": "^2.0.1",
     "plyr": "^3.7.2",
-    "tinymce": "^6.0.3"
+    "tinymce": "^6.0.3",
+    "tom-select": "^2.0.1"
   },
   "peerDependenciesMeta": {
     "apexcharts": {

--- a/src/pages/datatables.html
+++ b/src/pages/datatables.html
@@ -10,7 +10,7 @@ menu: base.datatables
 	<div class="card-body">
 		{% assign products = 'Tabler,Tabler Icons,Tabler Emails,Tabler Components,Tabler Illustrations,Bootstrap' | split: ',' %}
 		{% assign techs = 'brand-apple,brand-windows,brand-debian,brand-android' | split: ',' %}
-		<div id="table-{{ id }}">
+		<div id="table-{{ id }}" class="table-responsive">
 		<table class="table">
 			<thead>
 			<tr>
@@ -35,7 +35,7 @@ menu: base.datatables
 				<td class="sort-quantity">{{ forloop.index | random_number: 1, 200 }}</td>
 				<td class="sort-progress" data-progress="{{ progress }}">
 					<div class="row align-items-center">
-						<div class="col-auto">{{ progress }}%</div>
+						<div class="col-12 col-lg-auto">{{ progress }}%</div>
 						<div class="col">{% include ui/progress.html value=progress width="5rem" %}</div>
 					</div>
 				</td>


### PR DESCRIPTION
A number of fixes for the datatables preview page (see https://preview.tabler.io/datatables.html)

- Add list.js to the devDependencies to actually make sorting columns work
- Wrap the table in `table-responsive` to show properly on tablet and mobile
  - make the progress text be full with on tablet/mobile to prevent breaking out of the table.   
- (other package.json changes are just alphabetising) 