### PR TITLE
added popover docs page

### DIFF
--- a/src/pages/_data/docs.yml
+++ b/src/pages/_data/docs.yml
@@ -150,6 +150,9 @@ components:
     tooltips:
       title: Tooltips
       url: docs/tooltips.html
+    popover:
+      title: Popover
+      url: docs/popover.html
 
 utils:
   title: Utilities

--- a/src/pages/_docs/popover.md
+++ b/src/pages/_docs/popover.md
@@ -1,0 +1,38 @@
+---
+title: Popovers
+description: Popovers are used to provide additional information on elements where a simple tooltip is not sufficient.
+bootstrap-link: components/popovers
+menu: docs.components.popover
+---
+
+
+## Default markup
+
+To create a default popover.
+
+{% capture code %}
+<button type="button" class="btn btn-lg btn-danger" data-bs-toggle="popover" title="Popover title" data-bs-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
+{% endcapture %}
+{% include example.html code=code %}
+
+
+## Directions
+
+To create a default popover.
+
+{% capture code %}
+<button type="button" class="btn btn-secondary" data-bs-container="body" data-bs-toggle="popover" data-bs-placement="top" data-bs-content="Top popover">
+Popover on top
+</button>
+<button type="button" class="btn btn-secondary" data-bs-container="body" data-bs-toggle="popover" data-bs-placement="right" data-bs-content="Right popover">
+Popover on right
+</button>
+<button type="button" class="btn btn-secondary" data-bs-container="body" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-content="Bottom popover">
+Popover on bottom
+</button>
+<button type="button" class="btn btn-secondary" data-bs-container="body" data-bs-toggle="popover" data-bs-placement="left" data-bs-content="Left popover">
+Popover on left
+</button>
+{% endcapture %}
+{% include example.html code=code %}
+

--- a/src/pages/_docs/popover.md
+++ b/src/pages/_docs/popover.md
@@ -8,17 +8,16 @@ menu: docs.components.popover
 
 ## Default markup
 
-To create a default popover.
+To create a default popover use:
 
 {% capture code %}
 <button type="button" class="btn btn-lg btn-danger" data-bs-toggle="popover" title="Popover title" data-bs-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
 {% endcapture %}
 {% include example.html code=code %}
 
+## Four directions
 
-## Directions
-
-To create a default popover.
+Four options are available: top, right, bottom, and left aligned. Directions are mirrored when using Bootstrap in RTL.
 
 {% capture code %}
 <button type="button" class="btn btn-secondary" data-bs-container="body" data-bs-toggle="popover" data-bs-placement="top" data-bs-content="Top popover">
@@ -36,3 +35,11 @@ Popover on left
 {% endcapture %}
 {% include example.html code=code %}
 
+## Popover on hover
+
+Popover can be triggered `manual`, with a `click` and on `focus` and on `hover`. This one reacts on hover.
+
+{% capture code %}
+<button type="button" class="btn btn-primary" data-bs-trigger="hover" data-bs-toggle="popover" title="Popover title" data-bs-content="And here's some amazing content. It's very engaging. Right?">Hover to toggle popover</button>
+{% endcapture %}
+{% include example.html code=code %}


### PR DESCRIPTION
This adds an example page to showcase Popovers:
https://getbootstrap.com/docs/5.0/components/popovers/

Currently there is a bug in dark mode, probably due to #1145, which I initially wanted to work on:
<img width="632" alt="Bildschirmfoto 2022-06-21 um 23 18 21" src="https://user-images.githubusercontent.com/533162/174899003-3b244564-2138-4d3e-bf5e-c7ce80093b44.png">

But my frontend voodoo is not good enough.

The component is already using variables, but those seem to be defined for light only:
<img width="404" alt="Bildschirmfoto 2022-06-21 um 23 19 19" src="https://user-images.githubusercontent.com/533162/174899113-baec9779-592e-4771-91ba-3b49611a3c46.png">

Anyway, I wanted to add the docs page in this PR only:

<img width="991" alt="Bildschirmfoto 2022-06-21 um 23 21 34" src="https://user-images.githubusercontent.com/533162/174899452-aa3d7183-caf9-48e2-9a54-59c02a5e5828.png">

The content was improved and one example added after taking the screenshot, please check the Vercel deployment:
https://tabler-git-fork-kevinpapst-popover-tabler-ui.vercel.app/docs/popover.html
