### PR TITLE
fixed noUISlider on demo | page problem #1127

### DIFF
--- a/demo/docs/range-slider.html
+++ b/demo/docs/range-slider.html
@@ -1066,7 +1066,7 @@
       </div>
     </div>
     <!-- Libs JS -->
-    <script src="../dist/libs/nouislider/dist/nouislider.min.js" defer></script>
+    <script src="../dist/libs/nouislider/dist/nouislider.min.js"></script>
     <!-- Tabler Core -->
     <script src="../dist/js/tabler.min.js" defer></script>
     <script src="../dist/js/demo.min.js" defer></script>


### PR DESCRIPTION
### Issue Number : 1127 & 1150
#### range components were not displaying on the demo page, which was problematic for users to view and find the perfect slider and snippet.
#### Issues are resolved by updating the import "script" tag.
