### PR TITLE
Switch active and default colors of list groups

### DIFF
--- a/src/scss/ui/_lists.scss
+++ b/src/scss/ui/_lists.scss
@@ -21,11 +21,11 @@
 }
 
 .list-group-item {
-  background-color: rgba(27,125,241,0.02);
+  background-color: inherit;
 }
 
 .list-group-item.active {
-  background-color: inherit;
+  background-color: rgba(27,125,241,0.02);
   border-left-color: $yellow;
   border-left-width: $border-width-wide;
 }
@@ -34,7 +34,7 @@
   &:active,
   &:focus,
   &:hover{
-    background-color: inherit;
+    background-color: rgba(27,125,241,0.02);
   }
 }
 


### PR DESCRIPTION
List groups look a little of because they are by default darker than the rest of the content. This PR switches the default color with the active color.

Old:
https://preview.tabler.io/lists.html?theme=light
https://preview.tabler.io/lists.html?theme=dark

New:
https://tabler-git-switch-list-group-colors-tabler-ui.vercel.app/lists.html?theme=light
https://tabler-git-switch-list-group-colors-tabler-ui.vercel.app/lists.html?theme=dark