### PR TITLE
Required form label for horizontal forms

### DIFF
--- a/src/pages/_includes/cards/form/layout.html
+++ b/src/pages/_includes/cards/form/layout.html
@@ -6,7 +6,7 @@
 	<div class="card-body">
 		<form>
 			<div class="form-group mb-3 {% if horizontal %}row{% endif %}">
-				<label class="form-label{% if horizontal %} col-3 col-form-label{% endif %}">Email address</label>
+				<label class="{% if horizontal %}col-3 col-form-label{% else %}form-label{% endif %} required">Email address</label>
 				<div {% if horizontal %}class="col"{% endif %}>
 					<input type="email" class="form-control" aria-describedby="emailHelp" placeholder="Enter email">
 					<small class="form-hint">We'll never share your email with anyone else.</small>
@@ -14,7 +14,7 @@
 			</div>
 
 			<div class="form-group mb-3 {% if horizontal %}row{% endif %}">
-				<label class="form-label{% if horizontal %} col-3 col-form-label{% endif %}">Password</label>
+				<label class="{% if horizontal %}col-3 col-form-label{% else %}form-label{% endif %} required">Password</label>
 				<div {% if horizontal %}class="col"{% endif %}>
 					<input type="password" class="form-control" placeholder="Password">
 					<small class="form-hint">
@@ -25,7 +25,7 @@
 			</div>
 
 			<div class="form-group mb-3 {% if horizontal %}row{% endif %}">
-				<label class="form-label{% if horizontal %} col-3 col-form-label{% endif %}">Select</label>
+				<label class="{% if horizontal %}col-3 col-form-label{% else %}form-label{% endif %}">Select</label>
 				<div {% if horizontal %}class="col"{% endif %}>
 					<select class="form-select">
 						<option>Option 1</option>
@@ -49,7 +49,7 @@
 			</div>
 
 			<div class="form-group {% if horizontal %}row{% else %}mb-3{% endif %}">
-				<label class="form-label{% if horizontal %} col-3 col-form-label pt-0{% endif %}">Checkboxes</label>
+				<label class="{% if horizontal %}col-3 col-form-label pt-0{% else %}form-label{% endif %}">Checkboxes</label>
 				<div {% if horizontal %}class="col"{% endif %}>
 					<label class="form-check">
 						<input class="form-check-input" type="checkbox" checked="">

--- a/src/scss/ui/_forms.scss
+++ b/src/scss/ui/_forms.scss
@@ -7,6 +7,7 @@ textarea {
 /**
 Form label
  */
+.col-form-label,
 .form-label {
   display: block;
   font-weight: $font-weight-medium;


### PR DESCRIPTION
According to the Bootstrap docs labels do get `col-form-label` in horizontal forms and not `form-label` as in classical form layout. See examples at https://getbootstrap.com/docs/5.2/forms/layout/#horizontal-form . Some frameworks that render forms (e.g. PHP Symfony) do stick to the original definition and I was missing the * in some forms.

Tabler until now does only style `form-label`, there is no mention of `col-form-label`.
This was okay in most cases, but the `required` class isn't applied (compare before and after screenshots).

I adjusted the demo, so there is a showcase of the `required` class as well in horizontal forms. I also adjusted the used label class, so the demo HTML matches the HTML from the Bootstrap docs. 

Before:
![Bildschirmfoto 2022-07-02 um 23 50 17](https://user-images.githubusercontent.com/533162/177017266-f30673bb-8325-45d5-8185-a1dbeef10a2d.png)

After:
![Bildschirmfoto 2022-07-02 um 23 50 41](https://user-images.githubusercontent.com/533162/177017276-53c0ae4b-4306-4476-87dd-708a2d901f73.png)

The screenshots were taken after adjusting the HTML (see required * on the left) but before adjusting the CSS.