### PR TITLE
docs: switch unpkg to jsdelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ All files included in `@tabler/core` npm package are available over a CDN.
 #### Javascript
 
 ```html
-<script src="https://unpkg.com/@tabler/core@latest/dist/js/tabler.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tabler/core@latest/dist/js/tabler.min.js"></script>
 ```
 
 #### Styles
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/@tabler/core@latest/dist/css/tabler.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@latest/dist/css/tabler.min.css">
 ```
 
 ## Feature requests

--- a/demo/docs/download.html
+++ b/demo/docs/download.html
@@ -838,21 +838,21 @@
                         </div>
                         <p class="mb-4 text-muted">Download Tabler to get the compiled CSS and JavaScript, source code, or include it with your favorite package managers like npm, yarn and more.</p>
                       </div>
-                      <h2 id="cdn-via-unpkg">CDN via unpkg</h2>
-                      <p>All files included in <code class="language-plaintext highlighter-rouge">@tabler/core</code> npm package are available over a unpkg CDN. Use it to deliver cached version of Tabler’s compiled CSS and JS to your project.</p>
+                      <h2 id="cdn-via-jsDelivr">CDN via jsDelivr</h2>
+                      <p>All files included in <code class="language-plaintext highlighter-rouge">@tabler/core</code> npm package are available over a jsDelivr CDN. Use it to deliver cached version of Tabler’s compiled CSS and JS to your project.</p>
                       <div class="language-html highlighter-rouge">
                         <div class="highlight">
-                          <pre class="highlight"><code><span class="nt">&lt;script </span><span class="na">src=</span><span class="s">"https://unpkg.com/@tabler/core@1.0.0-beta10/dist/js/tabler.min.js"</span><span class="nt">&gt;&lt;/script&gt;</span>
-<span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"stylesheet"</span> <span class="na">href=</span><span class="s">"https://unpkg.com/@tabler/core@1.0.0-beta10/dist/css/tabler.min.css"</span><span class="nt">&gt;</span>
+                          <pre class="highlight"><code><span class="nt">&lt;script </span><span class="na">src=</span><span class="s">"https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta10/dist/js/tabler.min.js"</span><span class="nt">&gt;&lt;/script&gt;</span>
+<span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"stylesheet"</span> <span class="na">href=</span><span class="s">"https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta10/dist/css/tabler.min.css"</span><span class="nt">&gt;</span>
 </code></pre>
                         </div>
                       </div>
                       <p>You can also include additional Tabler plugins:</p>
                       <div class="language-html highlighter-rouge">
                         <div class="highlight">
-                          <pre class="highlight"><code><span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"stylesheet"</span> <span class="na">href=</span><span class="s">"https://unpkg.com/@tabler/core@1.0.0-beta10/dist/css/tabler-flags.min.css"</span><span class="nt">&gt;</span>
-<span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"stylesheet"</span> <span class="na">href=</span><span class="s">"https://unpkg.com/@tabler/core@1.0.0-beta10/dist/css/tabler-payments.min.css"</span><span class="nt">&gt;</span>
-<span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"stylesheet"</span> <span class="na">href=</span><span class="s">"https://unpkg.com/@tabler/core@1.0.0-beta10/dist/css/tabler-vendors.min.css"</span><span class="nt">&gt;</span>
+                          <pre class="highlight"><code><span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"stylesheet"</span> <span class="na">href=</span><span class="s">"https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta10/dist/css/tabler-flags.min.css"</span><span class="nt">&gt;</span>
+<span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"stylesheet"</span> <span class="na">href=</span><span class="s">"https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta10/dist/css/tabler-payments.min.css"</span><span class="nt">&gt;</span>
+<span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"stylesheet"</span> <span class="na">href=</span><span class="s">"https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta10/dist/css/tabler-vendors.min.css"</span><span class="nt">&gt;</span>
 </code></pre>
                         </div>
                       </div>

--- a/demo/docs/flags.html
+++ b/demo/docs/flags.html
@@ -842,7 +842,7 @@
                           <p>This part of Tabler is distributed as plugin. To enable it you should include <code>tabler-flags.css</code> or <code>tabler-flags.min.css</code> file to your page.</p>
                           <p>You can also include plugin via CDN:</p>
                           <figure class="highlight">
-                            <pre><code class="language-html" data-lang="html"><span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"stylesheet"</span> <span class="na">href=</span><span class="s">"https://unpkg.com/@tabler/core@1.0.0-beta10/dist/css/tabler-flags.min.css"</span><span class="nt">&gt;</span></code></pre>
+                            <pre><code class="language-html" data-lang="html"><span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"stylesheet"</span> <span class="na">href=</span><span class="s">"https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta10/dist/css/tabler-flags.min.css"</span><span class="nt">&gt;</span></code></pre>
                           </figure>
                         </div>
                       </div>

--- a/demo/docs/payments.html
+++ b/demo/docs/payments.html
@@ -842,7 +842,7 @@
                           <p>This part of Tabler is distributed as plugin. To enable it you should include <code>tabler-payments.css</code> or <code>tabler-payments.min.css</code> file to your page.</p>
                           <p>You can also include plugin via CDN:</p>
                           <figure class="highlight">
-                            <pre><code class="language-html" data-lang="html"><span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"stylesheet"</span> <span class="na">href=</span><span class="s">"https://unpkg.com/@tabler/core@1.0.0-beta10/dist/css/tabler-payments.min.css"</span><span class="nt">&gt;</span></code></pre>
+                            <pre><code class="language-html" data-lang="html"><span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"stylesheet"</span> <span class="na">href=</span><span class="s">"https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta10/dist/css/tabler-payments.min.css"</span><span class="nt">&gt;</span></code></pre>
                           </figure>
                         </div>
                       </div>

--- a/src/pages/_docs/download.md
+++ b/src/pages/_docs/download.md
@@ -5,13 +5,13 @@ description: Download Tabler to get the compiled CSS and JavaScript, source code
 ---
 
 
-## CDN via unpkg
+## CDN via jsDelivr
 
-All files included in `{{ site.npm-package }}` npm package are available over a unpkg CDN. Use it to deliver cached version of Tabler’s compiled CSS and JS to your project.
+All files included in `{{ site.npm-package }}` npm package are available over a jsDelivr CDN. Use it to deliver cached version of Tabler’s compiled CSS and JS to your project.
 
 ```html
-<script src="https://unpkg.com/{{ site.npm-package }}@{{ site.data.package.version }}/dist/js/tabler.min.js"></script>
-<link rel="stylesheet" href="https://unpkg.com/{{ site.npm-package }}@{{ site.data.package.version }}/dist/css/tabler.min.css">
+<script src="https://cdn.jsdelivr.net/npm/{{ site.npm-package }}@{{ site.data.package.version }}/dist/js/tabler.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/{{ site.npm-package }}@{{ site.data.package.version }}/dist/css/tabler.min.css">
 ```
 
 You can also include additional Tabler plugins:
@@ -19,7 +19,7 @@ You can also include additional Tabler plugins:
 ```html
 {% removeemptylines %}
 {% for plugin in site.tabler-css-plugins %}
-<link rel="stylesheet" href="https://unpkg.com/{{ site.npm-package }}@{{ site.data.package.version }}/dist/css/{{ plugin }}.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/{{ site.npm-package }}@{{ site.data.package.version }}/dist/css/{{ plugin }}.min.css">
 {% endfor %}
 {% endremoveemptylines %}
 ```

--- a/src/pages/_includes/docs/plugin.html
+++ b/src/pages/_includes/docs/plugin.html
@@ -5,5 +5,5 @@
 
 	<p>You can also include plugin via CDN:</p>
 
-	{% highlight html %}<link rel="stylesheet" href="https://unpkg.com/{{ site.npm-package }}@{{ site.data.package.version }}/dist/css/tabler-{{ include.plugin }}.min.css">{% endhighlight %}
+	{% highlight html %}<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/{{ site.npm-package }}@{{ site.data.package.version }}/dist/css/tabler-{{ include.plugin }}.min.css">{% endhighlight %}
 </div>


### PR DESCRIPTION
Continuing on from https://github.com/tabler/tabler-icons/pull/265.

I also noticed that the latest tag on NPM is actually linked to beta9 instead of 10 as seen here: https://www.npmjs.com/package/@tabler/core?activeTab=versions

That has a side-effect of the CDNs linking to beta9 instead of 10 when you use the `@latest` tag on it. Is that intentional?