### PR TITLE
Fix rendering of modal examples on docs page

### DIFF
--- a/src/pages/_docs/modals.md
+++ b/src/pages/_docs/modals.md
@@ -7,9 +7,11 @@ menu: docs.components.modals
 ## Default markup
 
 {% capture code %}
-<div class="modal-dialog" role="document">
-    <div class="modal-content">
-        {% include parts/modals/simple.html %}
+<div class="modal{% hide %} d-block position-relative{% endhide %}" tabindex="-1">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            {% include parts/modals/simple.html %}
+        </div>
     </div>
 </div>
 {% endcapture %}
@@ -19,18 +21,22 @@ menu: docs.components.modals
 ## Prompt and alert
 
 {% capture code %}
-<div class="modal-dialog modal-sm" role="document">
-    <div class="modal-content">
-        {% include parts/modals/danger.html %}
+<div class="modal{% hide %} d-block position-relative{% endhide %}" tabindex="-1">
+    <div class="modal-dialog modal-sm" role="document">
+        <div class="modal-content">
+            {% include parts/modals/danger.html %}
+        </div>
     </div>
 </div>
 {% endcapture %}
 {% include example.html code=code modal=true %}
 
 {% capture code %}
-<div class="modal-dialog modal-sm" role="document">
-    <div class="modal-content">
-        {% include parts/modals/success.html %}
+<div class="modal{% hide %} d-block position-relative{% endhide %}" tabindex="-1">
+    <div class="modal-dialog modal-sm" role="document">
+        <div class="modal-content">
+            {% include parts/modals/success.html %}
+        </div>
     </div>
 </div>
 {% endcapture %}
@@ -40,9 +46,11 @@ menu: docs.components.modals
 ## Modal with form
 
 {% capture code %}
-<div class="modal-dialog modal-lg" role="document">
-    <div class="modal-content">
-        {% include parts/modals/report.html %}
+<div class="modal{% hide %} d-block position-relative{% endhide %}" tabindex="-1">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            {% include parts/modals/report.html %}
+        </div>
     </div>
 </div>
 {% endcapture %}


### PR DESCRIPTION
fix for modal bugs reported in https://github.com/tabler/tabler/issues/1145

Bootstrap 5.2 moved to using CSS variables for modals (https://github.com/twbs/bootstrap/pull/36060) which are set on the `modal` class. As this class is not included in the sample code, the other modal classes (like `modal-dialog` and `modal-content`) could not find the correct variables to set things like the padding/margin etc.

This PR will add the `modal` class to the sample code as it is required for both the end user and correctly rendering the modals in the documentation.