### PR TITLE
Added Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+demo/
+.git/
+.github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:20.04
+
+# check https://github.com/nodesource/distributions for setup_XX versions
+ARG NODE_SETUP=setup_14
+ARG RUBY_VERSION=2.7
+
+# RUBY installation
+RUN apt-get update \
+    && apt-get -y install curl gcc g++ make software-properties-common \
+    && apt-add-repository ppa:brightbox/ruby-ng && apt-get update \
+    && apt-get -y --no-install-recommends install ruby$RUBY_VERSION ruby$RUBY_VERSION-dev ruby-switch \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN ruby-switch --set ruby$RUBY_VERSION && gem$RUBY_VERSION install bundler
+
+# NODEJS installation
+RUN curl -sL https://deb.nodesource.com/$NODE_SETUP.x | bash -
+RUN apt-get update && apt-get -y --no-install-recommends install nodejs && npm install -g npm@latest && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# install app in image
+ADD package.json /app/
+ADD package-lock.json /app/
+ADD package.json /app/
+ADD Gemfile /app/
+ADD Gemfile.lock /app/
+ADD _config.yml /app/
+ADD gulpfile.js /app/
+
+RUN npm install
+RUN bundle config --global silence_root_warning 1 && bundler install --verbose
+
+# website
+EXPOSE 3000
+
+# website management (browser auto reload)
+EXPOSE 3001
+
+# run tabler
+ENTRYPOINT [ "npm", "run", "start-plugins" ]

--- a/README.md
+++ b/README.md
@@ -123,6 +123,25 @@ Tabler is distributed via npm.
 npm install --save @tabler/core
 ```
 
+## Running with Docker
+
+If you don't want to install node/npm/ruby and the dependencies on your local environment, you can use the provided Dockerfile to build a docker image.
+This Dockerfile is provided as an example to spin-up a container running Tabler.
+
+Example of how to use this image:
+
+1. Build the tabler image : `docker build -t tabler .`
+2. Run the tabler image while mounting the `src` directory as well as the `_config.yml` file into the container.
+
+Don't forget to expose the port 3000 so you can browse the website locally.
+You can also expose the port 3001 to have access to BrowserSync
+
+```sh
+docker run -p 3000:3000 -p 3001:3001 -v $(pwd)/src:/app/src -v $(pwd)/_config.yml:/app/_config.yml tabler
+```
+
+Now open your browser to [http://localhost:3001](http://localhost:3001). Edit anything in the `src/` folder and watch your browser refresh the page after it has been rebuilt.
+
 ### CDN support
 
 All files included in `@tabler/core` npm package are available over a CDN.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ You can also expose the port 3001 to have access to BrowserSync
 docker run -p 3000:3000 -p 3001:3001 -v $(pwd)/src:/app/src -v $(pwd)/_config.yml:/app/_config.yml tabler
 ```
 
-Now open your browser to [http://localhost:3001](http://localhost:3001). Edit anything in the `src/` folder and watch your browser refresh the page after it has been rebuilt.
+Now open your browser to [http://localhost:3000](http://localhost:3000). Edit anything in the `src/` folder and watch your browser refresh the page after it has been rebuilt.
 
 ### CDN support
 


### PR DESCRIPTION
## Running with Docker

If you don't want to install node/npm/ruby and the dependencies on your local environment, you can use the provided Dockerfile to build a docker image.
This Dockerfile is provided as an example to spin-up a container running Tabler.

Example of how to use this image:

1. Build the tabler image : `docker build -t tabler .`
2. Run the tabler image while mounting the `src` directory as well as the `_config.yml` file into the container.

Don't forget to expose the port 3000 so you can browse the website locally.
You can also expose the port 3001 to have access to BrowserSync

```sh
docker run -p 3000:3000 -p 3001:3001 -v $(pwd)/src:/app/src -v $(pwd)/_config.yml:/app/_config.yml tabler
```

Now open your browser to [http://localhost:3000](http://localhost:3000). Edit anything in the `src/` folder and watch your browser refresh the page after it has been rebuilt.
