### PR TITLE
Use dark table variant colors in dark mode

### DIFF
--- a/src/pages/_docs/tables.md
+++ b/src/pages/_docs/tables.md
@@ -54,3 +54,65 @@ If you don't want the table cell content to wrap to another line, use the `table
 {% include ui/table.html nowrap=true responsive=true %}
 {% endcapture %}
 {% include example.html code=code %}
+
+## Table Variants
+
+{% capture code %}
+<table class="table">
+    <thead>
+      <tr>
+        <th scope="col">Class</th>
+        <th scope="col">Heading</th>
+        <th scope="col">Heading</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">Default</th>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+        <tr class="table-primary">
+          <th scope="row">Primary</th>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr class="table-secondary">
+          <th scope="row">Secondary</th>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr class="table-success">
+          <th scope="row">Success</th>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr class="table-danger">
+          <th scope="row">Danger</th>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr class="table-warning">
+          <th scope="row">Warning</th>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr class="table-info">
+          <th scope="row">Info</th>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr class="table-light">
+          <th scope="row">Light</th>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr class="table-dark">
+          <th scope="row">Dark</th>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+    </tbody>
+  </table>
+{% endcapture %}
+{% include example.html code=code %}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -552,6 +552,7 @@ $spinner-height-sm: 1rem !default;
 $spinner-border-width: 2px !default;
 
 //tables
+$table-bg-scale-dark: 40% !default;
 $table-color: inherit !default;
 $table-cell-padding-x: .75rem !default;
 $table-cell-padding-y: .75rem !default;

--- a/src/scss/ui/_tables.scss
+++ b/src/scss/ui/_tables.scss
@@ -1,3 +1,20 @@
+@include dark-mode {
+  $table-variants: (
+    "primary":    shift-color($primary, $table-bg-scale-dark),
+    "secondary":  shift-color($secondary, $table-bg-scale-dark),
+    "success":    shift-color($success, $table-bg-scale-dark),
+    "info":       shift-color($info, $table-bg-scale-dark),
+    "warning":    shift-color($warning, $table-bg-scale-dark),
+    "danger":     shift-color($danger, $table-bg-scale-dark),
+    "light":      $light,
+    "dark":       $dark,
+  );
+
+  @each $color, $value in $table-variants {
+    @include table-variant($color, $value);
+  }
+}
+
 .table {
   thead {
     th {

--- a/src/scss/ui/_tables.scss
+++ b/src/scss/ui/_tables.scss
@@ -6,8 +6,6 @@
     "info":       shift-color($info, $table-bg-scale-dark),
     "warning":    shift-color($warning, $table-bg-scale-dark),
     "danger":     shift-color($danger, $table-bg-scale-dark),
-    "light":      $light,
-    "dark":       $dark,
   );
 
   @each $color, $value in $table-variants {


### PR DESCRIPTION
I am not exactly an expert on scss, variables or mixins so i am not sure if this is the desired approach but the PR will shift the colors for variant tables to shade instead of tint when in dark mode.

fixes: https://github.com/tabler/tabler/issues/1193

![Screenshot 2022-08-11 at 11 32 37](https://user-images.githubusercontent.com/516028/184104933-d5f42172-1c8f-4863-83bd-5eec4f14e1ed.png)
