### PR TITLE
Fixed dark mode theme .btn from `color-text` to `body-color`

### DIFF
--- a/src/scss/ui/_buttons.scss
+++ b/src/scss/ui/_buttons.scss
@@ -65,8 +65,8 @@
 // Button color variations
 //
 .btn-white {
-  --#{$prefix}btn-bg: var(--#{$prefix}card-bg);
-  --#{$prefix}btn-hover-bg: var(--#{$prefix}card-bg);
+  //--#{$prefix}btn-bg: var(--#{$prefix}card-bg);
+  //--#{$prefix}btn-hover-bg: var(--#{$prefix}card-bg);
 }
 
 @each $color, $value in $theme-colors {

--- a/src/scss/ui/_buttons.scss
+++ b/src/scss/ui/_buttons.scss
@@ -3,7 +3,7 @@
 //
 .btn {
   --#{$prefix}btn-icon-size: #{$icon-size};
-  --#{$prefix}btn-color: var(--#{$prefix}color-text);
+  --#{$prefix}btn-color: var(--#{$prefix}body-color);
   --#{$prefix}btn-border-color: var(--#{$prefix}border-color);
   //background-color: var(--#{$prefix}btn-color, var(--#{$prefix}card-bg));
   //color: var(--#{$prefix}btn-color-text);


### PR DESCRIPTION
This PR is recreate to #1220 fixed btn-white dark mode theme

bootstrap v5.2 has change the ::root variable to `--#{$prefix}body-color: #{$body-color};` for text color. Changing this would fix issue #1177 also, 

![image](https://user-images.githubusercontent.com/10666633/187607769-0cac9a9c-7f1a-43ae-b248-5eb17ef7d11d.png)

In which you can now resolve this issue.

![image](https://user-images.githubusercontent.com/10666633/187609329-45864094-d0bb-43c9-ad77-d788155cb476.png)

This is from investigating the root cause.

![image](https://user-images.githubusercontent.com/10666633/187610279-3f0bb5d8-6f65-4c6b-b967-8bdf93c5fe48.png)

Therefore, after all the corrections we would have much more clean css stylesheet.

![image](https://user-images.githubusercontent.com/10666633/187611912-872eeb09-d45f-45e1-9f00-806f54e42994.png)

What do you think @kevinpapst ?