### PR TITLE
Fix for datepicker background

### DIFF
--- a/src/scss/vendor/_litepicker.scss
+++ b/src/scss/vendor/_litepicker.scss
@@ -12,6 +12,7 @@
   --litepicker-container-months-color-bg: var(--#{$prefix}card-bg);
   font: inherit;
   user-select: none;
+  background-color: white;
 
   svg {
     fill: none !important;


### PR DESCRIPTION
Fixes issue #1273.

Datepicker background color should now be white for light mode and respond appropriately for dark mode.