### PR TITLE
fix: remove css that overrides dark theme color

### DIFF
--- a/src/pages/_includes/cards/invoices.html
+++ b/src/pages/_includes/cards/invoices.html
@@ -27,7 +27,7 @@
 			<thead>
 			<tr>
 				<th class="w-1"><input class="form-check-input m-0 align-middle" type="checkbox" aria-label="Select all invoices"></th>
-				<th class="w-1">No. {% include ui/icon.html icon="chevron-up" class="icon-sm text-dark icon-thick" %}</th>
+				<th class="w-1">No. {% include ui/icon.html icon="chevron-up" class="icon-sm icon-thick" %}</th>
 				<th>Invoice Subject</th>
 				<th>Client</th>
 				<th>VAT No.</th>


### PR DESCRIPTION
This fixes the issue mentioned here https://github.com/tabler/tabler/issues/1292