### PR TITLE
Security measure: fail PR if a lock file was changed

### DIFF
--- a/.github/workflows/lockfiles.yaml
+++ b/.github/workflows/lockfiles.yaml
@@ -1,9 +1,15 @@
-name: Check .lock files
+name: Check for changed lock files
 on:
     pull_request: null
     push:
         branches:
-            - master
+            - main
+            - dev
+
+permissions:
+    contents: read
+    pull-requests: read
+
 jobs:
     lockfiles:
         runs-on: ubuntu-latest

--- a/.github/workflows/lockfiles.yaml
+++ b/.github/workflows/lockfiles.yaml
@@ -1,0 +1,21 @@
+name: Check .lock files
+on:
+    pull_request: null
+    push:
+        branches:
+            - master
+jobs:
+    lockfiles:
+        runs-on: ubuntu-latest
+        name: Verify lock file integrity
+        steps:
+
+            - name: Clone Kimai
+              uses: actions/checkout@v2
+
+            - name: Prevent file change
+              uses: xalvarez/prevent-file-change-action@v1
+              with:
+                  githubToken: ${{ secrets.GITHUB_TOKEN }}
+                  pattern: Gemfile.lock|package-lock.json
+                  trustedAuthors: codecalm, dependabot

--- a/.github/workflows/lockfiles.yaml
+++ b/.github/workflows/lockfiles.yaml
@@ -7,7 +7,6 @@ on:
             - dev
 
 permissions:
-    contents: read
     pull-requests: read
 
 jobs:

--- a/.github/workflows/lockfiles.yaml
+++ b/.github/workflows/lockfiles.yaml
@@ -1,4 +1,4 @@
-name: Check for changed lock files
+name: Changed lock files
 on:
     pull_request: null
     push:
@@ -16,10 +16,10 @@ jobs:
         name: Verify lock file integrity
         steps:
 
-            - name: Clone Kimai
+            - name: Clone Tabler
               uses: actions/checkout@v2
 
-            - name: Prevent file change
+            - name: Prevent lock file change
               uses: xalvarez/prevent-file-change-action@v1
               with:
                   githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There were quite a lot of PRs in the past, which shipped changed **lock files**.

Those were mostly introduced by unexperienced contributors, but considering the popularity of Tabler and the amount of potential targets, this could be a real security risk:
https://snyk.io/blog/why-npm-lockfiles-can-be-a-security-blindspot-for-injecting-malicious-modules/

There is a simple way to prevent that, which I am using in all my projects: a workflow that checks the PR for changed lock files and fails directly if a changed lockfile was included. The only persons allowed to push changes for those files are @codecalm and @dependabot (see e.g. #1296).

The used workflow is: https://github.com/xalvarez/prevent-file-change-action

What do you think @codecalm about the idea in general?

~~This PR is a draft for now, because I am not sure about the required [token permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication). I posted a question in the action repo and will update the workflow file accordingly if there are more required.~~