### PR TITLE
Fix sidebar narrow when scrollbar appears

### DIFF
--- a/src/scss/layout/_navbar.scss
+++ b/src/scss/layout/_navbar.scss
@@ -388,6 +388,11 @@ Navbar vertical
             @include transition(transform $transition-time);
             overflow-x: auto;
             padding: 0;
+            scrollbar-width: none;
+
+            &::-webkit-scrollbar {
+              display: none;
+            }
 
             &.navbar-right {
               left: auto;


### PR DESCRIPTION
When a scroll bar appears, the sidebar narrows. It can be a little annoying.
We can hide the scroll bar while retaining the behavior.