### PR TITLE
fix #1348: job listing is not responsive

### DIFF
--- a/src/pages/job-listing.html
+++ b/src/pages/job-listing.html
@@ -8,8 +8,8 @@ menu: extra.job-listing
 {% assign types = 'Programming,Design,Management / Finance,Customer Support,Sales / Marketing' | split: ',' %}
 {% assign salaries = '$20K - $50K,$50K - $100K,> $100K,Drawing / Painting' | split: ',' %}
 
-<div class="row g-4">
-	<div class="col-3">
+<div class="row g-3">
+	<div class="col-md-3">
 		<form action="./" method="get" autocomplete="off" novalidate class="sticky-top">
 
 			<div class="form-label">Job Types</div>
@@ -64,9 +64,8 @@ menu: extra.job-listing
 				</a>
 			</div>
 		</form>
-
 	</div>
-	<div class="col-9">
+	<div class="col-md-9">
 		<div class="row row-cards">
 			<div class="space-y">
 				{% for job in site.data.jobs %}
@@ -80,11 +79,11 @@ menu: extra.job-listing
 						<div class="col">
 							<div class="card-body ps-0">
 								<div class="row">
-									<div class="col"><h3 class="mb-0"><a href="#">{{ job.title }}</a></h3></div>
+									<div class="col-md"><h3 class="mb-0"><a href="#">{{ job.title }}</a></h3></div>
 									{% if job.salary %}<div class="col-auto fs-3 text-green">{{ job.salary }}</div>{% endif %}
 								</div>
 								<div class="row">
-									<div class="col">
+									<div class="col-md">
 										<div class="mt-3 list-inline list-inline-dots mb-0 text-muted">
 											<div class="list-inline-item">{% include ui/icon.html icon="building-community" class="icon-inline" %} {{ job.company }}</div>
 											<div class="list-inline-item">{% include ui/icon.html icon="license" class="icon-inline" %} {{ job.type }}</div>


### PR DESCRIPTION
will look better if I add a toggle menu in the content 

fixes: #1348 

![localhost_3000_job-listing html(iPhone SE) (1)](https://user-images.githubusercontent.com/1282324/201380748-2590e36d-9823-436b-9fc4-607d0331d0b3.png)
![localhost_3000_job-listing html(iPhone SE)](https://user-images.githubusercontent.com/1282324/201380759-e2943bde-e147-4270-8f84-c10b7cc136a5.png)
