### PR TITLE
Fix non full width selects #1392

### DIFF
--- a/src/scss/vendor/_tom-select.scss
+++ b/src/scss/vendor/_tom-select.scss
@@ -3,6 +3,11 @@ $input-border-width: 1px;
 
 @import "~tom-select/src/scss/tom-select.bootstrap5.scss";
 
+::root {
+  --ts-pr-clear-button: 0rem;
+  --ts-pr-caret: 0rem;
+}
+
 .ts-input {
   color: inherit;
 }
@@ -13,5 +18,14 @@ $input-border-width: 1px;
   .dropdown-menu {
     width: 100%;
     height: auto;
+  }
+}
+
+.ts-wrapper {
+  &.is-invalid,
+  &.is-valid {
+    .ts-control {
+      --ts-pr-clear-button: 1.5rem;
+    }
   }
 }

--- a/src/scss/vendor/_tom-select.scss
+++ b/src/scss/vendor/_tom-select.scss
@@ -3,7 +3,7 @@ $input-border-width: 1px;
 
 @import "~tom-select/src/scss/tom-select.bootstrap5.scss";
 
-::root {
+:root {
   --ts-pr-clear-button: 0rem;
   --ts-pr-caret: 0rem;
 }


### PR DESCRIPTION
This is a fix for the issue reported in #1392.

With this fix, select inputs may now be `fit-content`.

![image](https://user-images.githubusercontent.com/1838187/204831475-7cb05871-d435-43c3-b2c5-65cb2ea0f98f.png)
