### PR TITLE
Replace hard to see flag in documentation

### DIFF
--- a/demo/docs/flags.html
+++ b/demo/docs/flags.html
@@ -960,20 +960,20 @@
                       <p>Using Bootstrap’s typical naming structure, you can create a standard flag, or scale it up or down to different sizes based on what’s needed.</p>
                       <div class="example no_toc_section">
                         <div class="example-content">
-                          <span class="flag flag-xl flag-country-pl me-1"></span>
-                          <span class="flag flag-lg flag-country-pl me-1"></span>
-                          <span class="flag flag-md flag-country-pl"></span>
-                          <span class="flag flag-sm flag-country-pl me-1"></span>
-                          <span class="flag flag-xs flag-country-pl me-1"></span>
+                          <span class="flag flag-xl flag-country-aq me-1"></span>
+                          <span class="flag flag-lg flag-country-aq me-1"></span>
+                          <span class="flag flag-md flag-country-aq"></span>
+                          <span class="flag flag-sm flag-country-aq me-1"></span>
+                          <span class="flag flag-xs flag-country-aq me-1"></span>
                         </div>
                       </div>
                       <div class="example-code">
                         <figure class="highlight">
-                          <pre><code class="language-html" data-lang="html"><span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"flag flag-xl flag-country-pl me-1"</span><span class="nt">&gt;&lt;/span&gt;</span>
-<span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"flag flag-lg flag-country-pl me-1"</span><span class="nt">&gt;&lt;/span&gt;</span>
-<span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"flag flag-md flag-country-pl"</span><span class="nt">&gt;&lt;/span&gt;</span>
-<span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"flag flag-sm flag-country-pl me-1"</span><span class="nt">&gt;&lt;/span&gt;</span>
-<span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"flag flag-xs flag-country-pl me-1"</span><span class="nt">&gt;&lt;/span&gt;</span></code></pre>
+                          <pre><code class="language-html" data-lang="html"><span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"flag flag-xl flag-country-aq me-1"</span><span class="nt">&gt;&lt;/span&gt;</span>
+<span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"flag flag-lg flag-country-aq me-1"</span><span class="nt">&gt;&lt;/span&gt;</span>
+<span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"flag flag-md flag-country-aq"</span><span class="nt">&gt;&lt;/span&gt;</span>
+<span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"flag flag-sm flag-country-aq me-1"</span><span class="nt">&gt;&lt;/span&gt;</span>
+<span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"flag flag-xs flag-country-aq me-1"</span><span class="nt">&gt;&lt;/span&gt;</span></code></pre>
                         </figure>
                       </div>
                       <h2 id="types">Types</h2>


### PR DESCRIPTION
This PR replaces the PL flag in the Flags documentation with the rather neutral antarctica flag, as the white part of the PL flag is hard to see on the white background, which doesn't look too good in this example.

Before:
![grafik](https://user-images.githubusercontent.com/6287093/205490870-019c7988-1c32-421d-8154-9b945432ebd5.png)

After:
![grafik](https://user-images.githubusercontent.com/6287093/205490889-78841ef1-97f2-490f-8dda-b1e4cf652d2c.png)
