### PR TITLE
fix autofill text color, not matching in dark mode

### DIFF
--- a/src/scss/ui/_forms.scss
+++ b/src/scss/ui/_forms.scss
@@ -69,6 +69,7 @@ Form control
   &:-webkit-autofill {
     box-shadow: 0 0 0 1000px var(--#{$prefix}body-bg) inset;
     color: var(--#{$prefix}body-color);
+    -webkit-text-fill-color: var(--#{$prefix}body-color);
   }
 
   &:disabled,


### PR DESCRIPTION
Fixes Autofill text on Chrome.

Apparently due to security concerns, Chrome has limited customisation of prefilled Autofill content.

This PR simply adds `-webkit-text-fill-color: var(--#{$prefix}body-color);`, which seems to match the text color, both when typed and auto filled. 

**Before:**
![image](https://user-images.githubusercontent.com/76273853/209649303-b9a017a4-85fb-4239-ac3e-dda30ed46cc5.png)

**After:**
![image](https://user-images.githubusercontent.com/76273853/209649327-a6cdb3ac-6701-4f76-a485-2876e809fe93.png)
