### PR TITLE
corrects spelling from "eneded" to "ended"

### DIFF
--- a/src/pages/_data/menu.yml
+++ b/src/pages/_data/menu.yml
@@ -230,9 +230,9 @@ extra:
       title: Settings
       url: settings.html
       badge: New
-    trial-eneded:
+    trial-ended:
       title: Trial ended
-      url: trial-eneded.html
+      url: trial-ended.html
       badge: New
     job-listing:
       title: Job listing


### PR DESCRIPTION
Fixes a spelling mistake causing a 404 error.