### PR TITLE
Update bootstrap path in config.scss file

### DIFF
--- a/src/scss/_config.scss
+++ b/src/scss/_config.scss
@@ -1,4 +1,4 @@
-@import "~bootstrap/scss/functions";
+@import "../../node_modules/bootstrap/scss/functions";
 
 @import "variables";
 @import "utilities";


### PR DESCRIPTION
As part the PR #1384, the bootstrap file import path have been fixed. However, the `_config.scss` still has the old reference and this PR is address it. 