### PR TITLE
Fix tom-select options text without space when highlighting

### DIFF
--- a/src/pages/_includes/ui/select.html
+++ b/src/pages/_includes/ui/select.html
@@ -66,7 +66,7 @@
 		window.TomSelect && ({% if jekyll.environment == 'development' %}window.tabler_select["select-{{ id }}"] = {% endif %}new TomSelect(el = document.getElementById('select-{{ id }}'), {
 			copyClassesToDropdown: false,
 			dropdownClass: 'dropdown-menu ts-dropdown',
-			optionClass:'dropdown-item',
+			optionClass:'dropdown-item d-block',
 
 			{% unless include.show-search %}
 			controlInput: '<input>',


### PR DESCRIPTION
When a whole word or the last few letters are highlighted, the words appear without space and it doesn't look very good. With a small change applied in this pull request the bug is fixed.

fix #1505 