### PR TITLE
fix  gulp 'copy-libs' don't work

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -448,9 +448,12 @@ gulp.task('copy-libs', (cb) => {
 	files.forEach((file) => {
 		if (!file.match(/^https?/)) {
 			let dirname = path.dirname(file).replace('@', '')
-			let cmd = `mkdir -p "${distDir}/libs/${dirname}" && cp -r node_modules/${dirname}/* ${distDir}/libs/${dirname}`
+			 //it don't work in my project,but I'm not sure it's just me
+			 //let cmd = `mkdir -p "${distDir}/libs/${dirname}" && cp -r node_modules/${dirname}/** ${distDir}/libs/${dirname}`
+			 //cp.exec(cmd)
 
-			cp.exec(cmd)
+			 //so i fix it
+			 gulp.src(`node_modules/${dirname}/**`,).pipe(gulp.dest(`${distDir}/libs/${dirname}`))
 		}
 	})
 


### PR DESCRIPTION
When I ran the project, everything worked except  that it couldn't copy the files from node_moduls to dist.
but i dot't sure it's just me having this problem...
so...i try fix it