### PR TITLE
Use callback for loading Google Maps

### DIFF
--- a/src/pages/_data/libs.json
+++ b/src/pages/_data/libs.json
@@ -13,7 +13,7 @@
     "lists": "list.js/dist/list.min.js",
     "masonry": "https://cdnjs.cloudflare.com/ajax/libs/masonry/4.2.2/masonry.pkgd.min.js",
     "mapbox": "https://api.mapbox.com/mapbox-gl-js/v1.8.0/mapbox-gl.js",
-    "google-maps": "https://maps.googleapis.com/maps/api/js?key=GOOGLE_MAPS_KEY",
+    "google-maps": "https://maps.googleapis.com/maps/api/js?key=GOOGLE_MAPS_KEY&callback=initMap",
     "litepicker": "litepicker/dist/litepicker.js",
     "tom-select": "tom-select/dist/js/tom-select.base.min.js",
     "jsvectormap": "jsvectormap/dist/js/jsvectormap.min.js",

--- a/src/pages/map-fullsize.html
+++ b/src/pages/map-fullsize.html
@@ -17,14 +17,16 @@ menu: base.map-fullsize
 	let map;
 	{% if jekyll.environment == 'development' %}window.tabler_map = window.tabler_map || {};{% endif %}
 
-	document.addEventListener("DOMContentLoaded", function() {
+	function initMap() {
 		map = new google.maps.Map(document.getElementById("map-{{ map-id }}"), {
 			center: { lat: -34.397, lng: 150.644 },
 			zoom: 8,
 		});
+	}
+
+	window.initMap = initMap;
 
 		{% if jekyll.environment == 'development' %}window.tabler_map["map-{{ map-id }}"] = map;{% endif %}
-	});
 // @formatter:on
 </script>
 {% endcapture_global %}


### PR DESCRIPTION
Adjusting the maps call, according to the docs:
https://developers.google.com/maps/documentation/javascript/overview?#maps_map_simple-javascript

Maybe fixes #1537

Not sure if it would work, as access from the Vercel domain is blocked. 

<img width="865" alt="Bildschirmfoto 2023-05-14 um 23 44 35" src="https://github.com/tabler/tabler/assets/533162/42f327e5-c6b3-4b1a-81c4-cf092e9790e6">
