### PR TITLE
Update _variables.scss

### DIFF
--- a/.changeset/late-zoos-sparkle.md
+++ b/.changeset/late-zoos-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fix `rgba` color values in `_variables.scss`

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -467,7 +467,7 @@ $box-shadow-border: inset 0 0 0 1px var(--#{$prefix}border-color-translucent) !d
 $box-shadow-input: 0 1px 1px rgba(var(--#{$prefix}body-color-rgb), 0.06) !default;
 $box-shadow-card: 0 0 4px rgba(var(--#{$prefix}body-color-rgb), 0.04) !default;
 $box-shadow-card-hover: rgba(var(--#{$prefix}body-color-rgb), 0.16) 0 2px 16px 0 !default;
-$box-shadow-dropdown: 0 16px 24px 2px rgb(0, 0, 0, 0.07), 0 6px 30px 5px rgb(0, 0, 0, 0.06), 0 8px 10px -5px rgb(0, 0, 0, 0.1) !default;
+$box-shadow-dropdown: 0 16px 24px 2px rgba(0, 0, 0, 0.07), 0 6px 30px 5px rgba(0, 0, 0, 0.06), 0 8px 10px -5px rgba(0, 0, 0, 0.1) !default;
 
 $box-shadows: (
   box-shadow: $box-shadow,


### PR DESCRIPTION
1. Various style loads will throw error with incorrect CSS and fail.
2. Fix CSS syntax in general.