### PR TITLE
Fix missing tfoot styling

### DIFF
--- a/src/pages/_includes/ui/table.html
+++ b/src/pages/_includes/ui/table.html
@@ -86,5 +86,25 @@
 		</tr>
 		{% endfor %}
 		</tbody>
+		{% if include.footer %}
+		<thead>
+			<tr>
+				<th>Name</th>
+				<th>Title</th>
+	
+				{% unless include.avatars %}
+				<th>Email</th>
+				{% endunless %}
+	
+				<th>Role</th>
+	
+				{% if include.nowrap %}
+				<th></th>
+				{% endif %}
+	
+				<th class="w-1"></th>
+			</tr>
+		</tfoot>
+		{% endif %}
 	</table>
 </div>

--- a/src/pages/_includes/ui/table.html
+++ b/src/pages/_includes/ui/table.html
@@ -87,7 +87,7 @@
 		{% endfor %}
 		</tbody>
 		{% if include.footer %}
-		<thead>
+		<tfoot>
 			<tr>
 				<th>Name</th>
 				<th>Title</th>

--- a/src/pages/tables.html
+++ b/src/pages/tables.html
@@ -6,7 +6,7 @@ menu: base.tables
 <div class="row row-cards">
 	<div class="col-lg-8">
 		<div class="card">
-			{% include ui/table.html card=true limit=8 %}
+			{% include ui/table.html card=true limit=8 footer=true %}
 		</div>
 	</div>
 

--- a/src/pages/tables.html
+++ b/src/pages/tables.html
@@ -6,7 +6,7 @@ menu: base.tables
 <div class="row row-cards">
 	<div class="col-lg-8">
 		<div class="card">
-			{% include ui/table.html card=true limit=8 footer=true %}
+			{% include ui/table.html card=true limit=8 %}
 		</div>
 	</div>
 
@@ -16,7 +16,7 @@ menu: base.tables
 
 	<div class="col-12">
 		<div class="card">
-			{% include ui/table.html card=true stripped=true offset=5 %}
+			{% include ui/table.html card=true stripped=true offset=5 footer=true %}
 		</div>
 	</div>
 

--- a/src/scss/ui/_tables.scss
+++ b/src/scss/ui/_tables.scss
@@ -1,5 +1,6 @@
 .table {
-  thead {
+  thead,
+  tfoot {
     th {
       color: $table-th-color;
       background: $table-th-bg;
@@ -26,7 +27,8 @@
 }
 
 .table-transparent {
-  thead {
+  thead,
+  tfoot {
     th {
       background: transparent;
     }
@@ -62,7 +64,8 @@
       @include media-breakpoint-down($breakpoint) {
         display: block;
 
-        thead {
+        thead,
+        tfoot {
           display: none;
         }
 
@@ -145,7 +148,8 @@ Table sort
 }
 
 .table-borderless {
-  thead th {
+  thead th,
+  tfoot th {
     background: transparent;
   }
 }


### PR DESCRIPTION
`tfoot` doesn't have the same behaviour as `thead`, leading to this behaviour;

![image](https://github.com/tabler/tabler/assets/1838187/6ebb015d-9bc5-4204-87ba-5c0159c74768)

This PR aims to fix it 👌