### PR TITLE
Avoid scss color dependency on :focus

### DIFF
--- a/.changeset/stupid-dingos-train.md
+++ b/.changeset/stupid-dingos-train.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Avoid SCSS color dependency on `:focus`

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -486,8 +486,6 @@ $focus-ring-width: 0.25rem !default;
 $focus-ring-opacity: 0.25 !default;
 $focus-ring-color: rgba(var(--#{$prefix}primary-rgb), $focus-ring-opacity) !default;
 $focus-ring-blur: 0 !default;
-$focus-ring-border-color: rgba(var(--#{$prefix}primary-rgb), 50%) !default;
-$focus-ring-box-shadow: 0 0 $focus-ring-blur $focus-ring-width $focus-ring-color !default;
 
 // Transitions
 $transition-time: 0.3s !default;

--- a/src/scss/mixins/_mixins.scss
+++ b/src/scss/mixins/_mixins.scss
@@ -63,6 +63,6 @@
   box-shadow: 0 0 $focus-ring-blur $focus-ring-width rgba(var(--tblr-primary-rgb), 0.25);
 
   @if($show-border) {
-    border-color: rgba(var(--tblr-primary-rgb), 0.5);
+    border-color: rgba(var(--tblr-primary-rgb), 0.25);
   }
 }

--- a/src/scss/mixins/_mixins.scss
+++ b/src/scss/mixins/_mixins.scss
@@ -60,9 +60,9 @@
 
 @mixin focus-ring($show-border: false) {
   outline: 0;
-  box-shadow: $focus-ring-box-shadow;
+  box-shadow: 0 0 $focus-ring-blur $focus-ring-width rgba(var(--tblr-primary-rgb), 0.25);
 
   @if($show-border) {
-    border-color: $focus-ring-border-color;
+    border-color: rgba(var(--tblr-primary-rgb), 0.5);
   }
 }


### PR DESCRIPTION
As of now, focus border and shadow color depend on scss variables, therefore tabler compilation.
IMO it shouldn't, actually nothing should depended on scss variables, specially colors.

This PR allows inputs border and shadow to depend on primary color css variable, devs will be able to do this;

![image](https://github.com/tabler/tabler/assets/1838187/b8ccd06b-37ba-4c93-81bf-642235ba7cdc)

