### PR TITLE
Fix hover background colors

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -209,7 +209,7 @@ $active-bg: rgba(var(--#{$prefix}primary-rgb), 0.04) !default;
 $active-color: var(--#{$prefix}primary) !default;
 $active-border-color: var(--#{$prefix}primary) !default;
 
-$hover-bg: rgba(var(--#{$prefix}text-secondary-rgb), 0.04) !default;
+$hover-bg: rgba(var(--#{$prefix}secondary-rgb), 0.04) !default;
 
 $disabled-bg: var(--#{$prefix}bg-surface-secondary) !default;
 $disabled-color: var(--#{$prefix}gray-300) !default;


### PR DESCRIPTION
I am not very familiar with SCSS but I found that renaming `--tblr-text-secondary-rgb` (which is not defined) to `--tblr-secondary-rgb` made it work for me :man_shrugging: