### PR TITLE
Move installing PNPM above setting up Node.js

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,16 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
+      - name: Install PNPM
+        uses: pnpm/action-setup@v2
+        with:
+          version: 7
+
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           node-version: "${{ env.NODE }}"
           cache: pnpm
-
-      - name: Install PNPM
-        uses: pnpm/action-setup@v2
-        with:
-          version: 7
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
From what I know the CI test build fails, as tabler is using `pnpm` as cache while setting up Node.js. Due to that fact, `pnpm` should be set up first.