### PR TITLE
Fix background of scrollbar in dropdown menu

### DIFF
--- a/src/scss/ui/_dropdowns.scss
+++ b/src/scss/ui/_dropdowns.scss
@@ -1,5 +1,6 @@
 .dropdown-menu {
   user-select: none;
+  background-clip: border-box;
 
   &.card {
     padding: 0;


### PR DESCRIPTION
Fixes transparent scrollbar background in dropdown-menu, by setting `background-clip` to `border-box` for `dropdown-menu` class.