### PR TITLE
README Update for `site` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ We've created this admin panel for everyone who wants to create templates based 
 
 Documentation is available as a part of Tabler preview: https://tabler.io/docs/
 
+To run the documentation site locally, follow instructions in the [Documentation README](https://github.com/tabler/tabler/blob/dev/site/README.md).
+
 ## 🪴 Project Activity
 
 ![Alt](https://repobeats.axiom.co/api/embed/61d1db34446967b0848af68198a392067e0f5870.svg "Repobeats analytics image")

--- a/site/README.md
+++ b/site/README.md
@@ -1,1 +1,34 @@
-# Tabler website and Docs
+<p align="center">
+<a href="https://github.com/tabler/tabler"><img src="https://raw.githubusercontent.com/tabler/tabler/dev/src/static/logo.svg" alt="A premium and open source dashboard template with a responsive and high-quality UI." width="300"></a><br><br>
+A premium and open source dashboard template with a responsive and high-quality UI.
+</p>
+
+## 📦 Setup environment
+
+To run our documentation locally, first follow the steps in the main [Tabler README](https://github.com/tabler/tabler/blob/dev/README.md) to set up dependencies.
+
+## Build documentation locally
+
+You need to have `pnpm` installed.
+
+1. From the `/tabler/site` directory, run `pnmp install` to install dependencies in the command line.
+2. Then execute `pnpm run build` to build the Next site which holds Tabler documentation.
+3. Execute `pnpm run start` to start the Next site.
+   - A success may look like
+   ```
+    > start
+    > next start
+
+    ▲ Next.js 13.5.3
+    - Local:        http://localhost:3000
+
+    ✓ Ready in 1513ms
+
+   ```
+4. Open [http://localhost:3000](http://localhost:3000) in your browser to see the documentation site, a local version of [tabler.io/docs](https://tabler.io/docs).
+
+**Note**: *To see a full list of possible documentation site command line commands, go to `tabler/site/package.json`.*
+
+## License
+
+See the [LICENSE](https://github.com/tabler/tabler/blob/master/LICENSE) file.


### PR DESCRIPTION
# Description

Adds documentation in `tabler/site/README.md` pointing users to how to run documentation site locally. Reflects change in main README. 

# Purpose

For developers to be able to change the documentation site or run it locally, this clarifies the process. Furthermore, the `README.md` in the `site` directory was previously empty, this fills it in.

## Type of change

Documentation only change for clarity in local runs of doc site, no testing or production changes