### PR TITLE
Fix #1754: Revert dropdown spacing to .5 rem

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -642,7 +642,7 @@ $dropdown-link-active-bg: var(--#{$prefix}active-bg) !default;
 $dropdown-box-shadow: var(--#{$prefix}box-shadow-dropdown) !default;
 
 $dropdown-divider-bg: $dropdown-border-color !default;
-$dropdown-divider-margin-y: var(--#{$prefix}spacer) !default;
+$dropdown-divider-margin-y: var(--#{$prefix}spacer-2) !default;
 
 // Tooltip
 $tooltip-bg: var(--#{$prefix}bg-surface-dark) !default;


### PR DESCRIPTION
![2023-11-09T15:20:16,904978959+01:00](https://github.com/tabler/tabler/assets/160743/f326489d-0e81-431e-bed9-c3412f777e75)
