### PR TITLE
Update _navbar.scss with disabled dropdown menu items colour

### DIFF
--- a/.changeset/mighty-mirrors-drum.md
+++ b/.changeset/mighty-mirrors-drum.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Update `_navbar.scss` with disabled dropdown menu items color

--- a/src/scss/layout/_navbar.scss
+++ b/src/scss/layout/_navbar.scss
@@ -40,6 +40,12 @@
         padding-left: add(calc(#{$container-padding-x} / 2), 1.75rem);
         color: inherit;
 
+      &.disabled {
+          color: var(--#{$prefix}gray-300);
+          pointer-events: none;
+          background-color: transparent;
+      }
+
         &.active,
         &:active {
           background: var(--#{$prefix}navbar-active-bg);

--- a/src/scss/layout/_navbar.scss
+++ b/src/scss/layout/_navbar.scss
@@ -1,4 +1,3 @@
-
 @mixin navbar-vertical-nav {
   .navbar-collapse {
     flex-direction: column;
@@ -14,7 +13,7 @@
       margin-right: 0;
 
       .nav-link {
-        padding: .5rem calc(#{$container-padding-x} / 2);
+        padding: 0.5rem calc(#{$container-padding-x} / 2);
         justify-content: flex-start;
       }
     }
@@ -40,11 +39,11 @@
         padding-left: add(calc(#{$container-padding-x} / 2), 1.75rem);
         color: inherit;
 
-      &.disabled {
+        &.disabled {
           color: var(--#{$prefix}gray-300);
           pointer-events: none;
           background-color: transparent;
-      }
+        }
 
         &.active,
         &:active {
@@ -116,8 +115,8 @@ Navbar
 
       .badge {
         position: absolute;
-        top: .375rem;
-        right: .375rem;
+        top: 0.375rem;
+        right: 0.375rem;
         transform: translate(50%, -50%);
       }
     }
@@ -153,7 +152,7 @@ Navbar
             position: absolute;
             left: 0;
             right: 0;
-            bottom: -.25rem;
+            bottom: -0.25rem;
             border: 0 var(--#{$prefix}border-style) var(--#{$prefix}navbar-active-border-color);
             border-bottom-width: 2px;
           }
@@ -221,7 +220,12 @@ Navbar toggler
   width: 1.25em;
   background: currentColor;
   border-radius: 10px;
-  @include transition(top $navbar-toggler-animation-time $navbar-toggler-animation-time, bottom $navbar-toggler-animation-time $navbar-toggler-animation-time, transform $navbar-toggler-animation-time, opacity 0s $navbar-toggler-animation-time);
+  @include transition(
+    top $navbar-toggler-animation-time $navbar-toggler-animation-time,
+    bottom $navbar-toggler-animation-time $navbar-toggler-animation-time,
+    transform $navbar-toggler-animation-time,
+    opacity 0s $navbar-toggler-animation-time
+  );
   position: relative;
 
   &:before,
@@ -238,11 +242,11 @@ Navbar toggler
   }
 
   &:before {
-    top: -.45em;
+    top: -0.45em;
   }
 
   &:after {
-    bottom: -.45em;
+    bottom: -0.45em;
   }
 
   .navbar-toggler[aria-expanded="true"] & {
@@ -322,7 +326,7 @@ Navbar vertical
             }
 
             .navbar-brand {
-              padding: (($navbar-height - $navbar-brand-image-height) * .5) 0;
+              padding: (($navbar-height - $navbar-brand-image-height) * 0.5) 0;
               justify-content: center;
             }
 
@@ -336,8 +340,8 @@ Navbar vertical
               min-height: auto;
 
               .nav-link {
-                padding-top: .5rem;
-                padding-bottom: .5rem;
+                padding-top: 0.5rem;
+                padding-bottom: 0.5rem;
               }
             }
 
@@ -370,7 +374,6 @@ Navbar vertical
     }
   }
 }
-
 
 .navbar-overlap {
   &:after {


### PR DESCRIPTION
This PR aims to resolve the issue mentioned in #1473 

Steps taken to resolve:

1. Identified reason for discrepancy between horizontal and verticaldrop down menu items in the navbar - issue identified to be correlated to lack of distinction of colours for disabled items in vertical dropdown menu. 

2. Manually recreated issue by disabling all level 2 dropdown menu items in /src/…/navbar-menu.html (i.e. all components under Interface, Extra, Layout and Help are disabled).

<img width="182" alt="Screenshot 1" src="https://github.com/tabler/tabler/assets/65524500/37a24af0-98e9-4216-bb07-7983db60440e">

NOTE: Issue (mentioned in #1473) persists as there is no clear visual distinction between disabled and enabled dropdown menu items; all are displayed in the same colour, even though the Layout’s dropdown items are disabled.


3. Identified the .scss file corresponding to navbar-menu.html in /src/…/_navbar.scss and incorporated a separate .disabled class to address dropdown menu items that are disabled. 

4. Set disabled dropdown menu items to color gray-300 to match with horizontal dropdown menu disabled items, as opposed to ‘inherit’ which results in it being the same colour as the element’s parent.

<img width="246" alt="Screenshot 2" src="https://github.com/tabler/tabler/assets/65524500/186fe741-aad4-4313-8a85-fc435b97ff3d">

NOTE: As can be seen in the screenshot above, the disabled dropdown menu items in the vertical layout are now rendered in the color gray-300 (as in the horizontal layout) so disabled and enabled menu items are now clearly distinguishable.


This change was tested on an OSX environment using the Google Chrome browser. All variables mentioned under the /src directory are being displayed as expected.