### PR TITLE
Fix for #1397 - Bottom border in Card Table is too thick

### DIFF
--- a/src/scss/ui/_cards.scss
+++ b/src/scss/ui/_cards.scss
@@ -419,6 +419,23 @@ Card table
       }
     }
   }
+  
+  tbody {
+		tr {
+			&:last-child {
+				td {
+					border-bottom: 0;
+				}
+			}
+		}
+	}
+	tfoot {
+		tr {
+			&:last-child {
+				border-bottom: 0;
+			}
+		}
+	}
 
   thead,
   tbody,


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fix issue #1397 and #1619