### PR TITLE
Updated terms-of-service.html page

### DIFF
--- a/demo/terms-of-service.html
+++ b/demo/terms-of-service.html
@@ -31,7 +31,7 @@
   </head>
   <body  class=" d-flex flex-column">
     <script src="./dist/js/demo-theme.min.js?1692870487"></script>
-    <div class="page page-center">
+    <div class="page my-auto">
       <div class="container container-narrow py-4">
         <div class="text-center mb-4">
           <a href="." class="navbar-brand navbar-brand-autodark">


### PR DESCRIPTION
### [BUG] Terms of Service demo page is cut off #1820 
The issue is that, it is not displaying the top side's content like navbar and 1st point of "termes and services".

I fixed that bug and now properly showing things as per expectation.


**Before fixing bug** 
![image](https://github.com/tabler/tabler/assets/105334015/7aa2e732-7b2d-4083-a6ea-5b54eba12942)


**After fixing bug**
![image](https://github.com/tabler/tabler/assets/105334015/09a119cd-1de0-41f4-ba4a-05fa2c41f1fc)
