### PR TITLE
Fixed wrong CDN url in webfont.mdx

### DIFF
--- a/.changeset/silver-years-tap.md
+++ b/.changeset/silver-years-tap.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed wrong CDN link in `webfont.mdx`

--- a/docs/icons/webfont.mdx
+++ b/docs/icons/webfont.mdx
@@ -27,7 +27,7 @@ or just [download from Github](https://github.com/tabler/tabler-icons/releases).
 ### CDN
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@$ICONS_VERSION/tabler-icons.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@$ICONS_VERSION/dist/tabler-icons.min.css">
 ```
 
 ## Usage


### PR DESCRIPTION
Currently, entering the CDN will throw an error **Couldn't find the requested file /tabler-icons.min.css" in @tabler/icons-webfont.** I found that the real tabler-icons.min.css is stored in the dist folder. As a result, I have changed the link to https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@${version}/dist/tabler-icons.min.css to avoid confusion for users entering the page.