### PR TITLE
Allow usage of version 7.x of the `tinymce` peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "nouislider": "^15.7.0",
     "plyr": "^3.7.8",
     "star-rating.js": "^4.3.0",
-    "tinymce": "^6.4.2",
+    "tinymce": "^6.4.2 || ^7.0.0",
     "tom-select": "^2.2.2"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
TinyMCE 7.0 have only some small BC breaks and it should be possible to use the new v7.0.0 version without having any issues.

This would prevent the following error when trying to upgrade to `tinymce@^7.0.0`:
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @tabler/core@1.0.0-beta20
npm ERR! Found: tinymce@7.0.0
npm ERR! node_modules/tinymce
npm ERR!   tinymce@"^7.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peerOptional tinymce@"^6.4.2" from @tabler/core@1.0.0-beta20
npm ERR! node_modules/@tabler/core
npm ERR!   @tabler/core@"^1.0.0-beta20" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: tinymce@6.8.3
npm ERR! node_modules/tinymce
npm ERR!   peerOptional tinymce@"^6.4.2" from @tabler/core@1.0.0-beta20
npm ERR!   node_modules/@tabler/core
npm ERR!     @tabler/core@"^1.0.0-beta20" from the root project
```