### PR TITLE
fix: broken cdn link in install webfont docs

### DIFF
--- a/docs/icons/webfont.mdx
+++ b/docs/icons/webfont.mdx
@@ -27,7 +27,7 @@ or just [download from Github](https://github.com/tabler/tabler-icons/releases).
 ### CDN
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@$ICONS_VERSION/tabler-icons.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@$ICONS_VERSION/dist/tabler-icons.min.css">
 ```
 
 ## Usage


### PR DESCRIPTION
Documentation at [https://tabler.io/docs/icons/webfont](https://tabler.io/docs/icons/webfont) contains a broken link for the CDN usage of the webfont. It simply needs `dist/` to be added to it in order to work.