### PR TITLE
Introduce Docker Compose Config to build and run tabler locally

### DIFF
--- a/.changeset/lucky-impalas-smash.md
+++ b/.changeset/lucky-impalas-smash.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Introduce Docker Compose Config to build and run Ttabler locally

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ npm install --save @tabler/core
 ## Running with Docker
 
 **Plain Docker**
+
 If you don't want to install node/npm/ruby and the dependencies on your local environment, you can use the provided Dockerfile to build a docker image.
 This Dockerfile is provided as an example to spin-up a container running Tabler.
 
@@ -149,6 +150,7 @@ docker run -p 3000:3000 -p 3001:3001 -v $(pwd)/src:/app/src -v $(pwd)/_config.ym
 Now open your browser to [http://localhost:3000](http://localhost:3000). Edit anything in the `src/` folder and watch your browser refresh the page after it has been rebuilt.
 
 **Docker Compose**
+
 You can also use the docker compose config from this repo. Use `docker compose build && docker compose up` or `docker compose up --build` to build and start the container. Edit anything in the `src/` folder the same way as with plain docker and access the same URLs and ports in your browser.
 
 ### CDN support

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ npm install --save @tabler/core
 
 ## Running with Docker
 
+**Plain Docker**
 If you don't want to install node/npm/ruby and the dependencies on your local environment, you can use the provided Dockerfile to build a docker image.
 This Dockerfile is provided as an example to spin-up a container running Tabler.
 
@@ -147,6 +148,8 @@ docker run -p 3000:3000 -p 3001:3001 -v $(pwd)/src:/app/src -v $(pwd)/_config.ym
 
 Now open your browser to [http://localhost:3000](http://localhost:3000). Edit anything in the `src/` folder and watch your browser refresh the page after it has been rebuilt.
 
+**Docker Compose**
+You can also use the docker compose config from this repo. Use `docker compose build && docker compose up` or `docker compose up --build` to build and start the container. Edit anything in the `src/` folder the same way as with plain docker and access the same URLs and ports in your browser.
 
 ### CDN support
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+---
+version: "3.3"
+services:
+
+  tabler:
+    image: tabler
+    container_name: tabler
+    build: .
+    ports:
+      - 3000:3000
+      - 3001:3001
+    volumes:
+      - ./src:/app/src
+      - ./_config.yml:/app/_config.yml
+    tty: true


### PR DESCRIPTION
This pull request introduces a Docker Compose configuration to streamline the process of building and starting Tabler in a Docker environment locally. 

### Changes

. A new docker-compose.yml file has been added to the repository.
. The README file has been updated to include instructions on how to use Docker Compose to build and start Tabler.