### PR TITLE
[modals]: style btn-close only when in .modal-header

### DIFF
--- a/src/scss/ui/_modals.scss
+++ b/src/scss/ui/_modals.scss
@@ -1,4 +1,4 @@
-.modal-content {
+.modal-header {
   .btn-close {
     position: absolute;
     top: 0;

--- a/src/scss/ui/_modals.scss
+++ b/src/scss/ui/_modals.scss
@@ -1,4 +1,4 @@
-.modal-container, .modal-header {
+.modal-content, .modal-header {
   > .btn-close {
     position: absolute;
     top: 0;

--- a/src/scss/ui/_modals.scss
+++ b/src/scss/ui/_modals.scss
@@ -1,5 +1,5 @@
-.modal-header {
-  .btn-close {
+.modal-container, .modal-header {
+  > .btn-close {
     position: absolute;
     top: 0;
     right: 0;


### PR DESCRIPTION
Currently if you put a .btn-close element in Modal body, the element is displayed in top right.

See below how  the below code (a .tag with a .btn-close) is rendered  (look at the smaller close below the header close):

```html
<div class="modal-body">
  <span class="tag"> Test <button type="button" class="btn-close"></button></span>
</div>

```
![image](https://github.com/user-attachments/assets/c162b85f-a871-4034-8b2e-a5a95b983bf9)


This PR fixes it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved modal layout with updated styling for better usability.
	- Enhanced specificity of the close button positioning within modals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->