### PR TITLE
Fixes #1923: Added correct borders to the ribbon start class

### DIFF
--- a/src/scss/ui/_ribbons.scss
+++ b/src/scss/ui/_ribbons.scss
@@ -87,6 +87,7 @@
 .ribbon-start {
   right: auto;
   left: calc(-1 * var(--#{$prefix}ribbon-margin));
+  border-radius: 0 var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius);
 
   &:before {
     top: auto;


### PR DESCRIPTION
This PR fixes issue #1923 

WHAT DOES THIS PR DO?
It solves the issue of incorrect borders in the ribbon-start class as mentioned in the issue.