### PR TITLE
FIX: Fixed the z-index value of the nav-tab inside card-tab #1933

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -605,6 +605,8 @@ $card-header-tabs-bg: var(--#{$prefix}bg-surface-tertiary) !default;
 $cards-grid-gap: var(--#{$prefix}page-padding) !default;
 $cards-grid-breakpoint: lg !default;
 
+$zindex-dropdown: 1;
+
 // Carousel
 $carousel-control-color: $white !default;
 $carousel-control-icon-width: 1.5rem !default;

--- a/src/scss/ui/_ribbons.scss
+++ b/src/scss/ui/_ribbons.scss
@@ -87,6 +87,7 @@
 .ribbon-start {
   right: auto;
   left: calc(-1 * var(--#{$prefix}ribbon-margin));
+  border-radius: 0 var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius);
 
   &:before {
     top: auto;


### PR DESCRIPTION
This PR fixes the issue of nav-tab's z-index topping over any other dropdown menu.
Successfully changed the value of z-index of nav-tab inside card-tab.

Fixes #1933 
