### PR TITLE
Add the possibility to include Tabler as a Composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "tabler/tabler",
+    "description": "Tabler is free and open-source HTML Dashboard UI Kit built on Bootstrap.",
+    "keywords": [
+        "css",
+        "js",
+        "sass",
+        "mobile-first",
+        "responsive",
+        "front-end",
+        "web"
+    ],
+    "homepage": "https://tabler.io/admin-template",
+    "authors": [
+        {
+            "name": "Paweł Kuna",
+            "email": "hello@tabler.io"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/tabler/tabler/issues"
+    },
+    "license": "MIT"
+}


### PR DESCRIPTION
I would like to add the possibility to inlcude Tabler as a Composer package, so that PHP projects would be able to include it as a vendor and be able to use the SCSS or JS code.