### PR TITLE
FIX: ensure border color works in dark mode

### DIFF
--- a/src/scss/_utilities.scss
+++ b/src/scss/_utilities.scss
@@ -1,8 +1,8 @@
 $border-values: (
   null: var(--#{$prefix}border-width) var(--#{$prefix}border-style)
-    $border-color-translucent,
+    var(--#{$prefix}border-color-translucent),
   wide: $border-width-wide var(--#{$prefix}border-style)
-    $border-color-translucent,
+    var(--#{$prefix}border-color-translucent),
   0: 0,
 );
 


### PR DESCRIPTION
This fix was needed because in dark mode the border color of these utility classes was not changing to its dark mode equivalent.
