### PR TITLE
Fix cells with inline icons

### DIFF
--- a/.changeset/sixty-spoons-move.md
+++ b/.changeset/sixty-spoons-move.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fix cells with inline icons

--- a/src/scss/ui/_type.scss
+++ b/src/scss/ui/_type.scss
@@ -135,8 +135,7 @@ kbd,
   border-radius: $kbd-border-radius;
 }
 
-img,
-svg {
+img {
   max-width: 100%;
   height: auto;
 }


### PR DESCRIPTION
`max-width` removed from `<svg/>` element

fixes #1977