### PR TITLE
Increase z-index of ts-dropdown

### DIFF
--- a/.changeset/ten-beds-walk.md
+++ b/.changeset/ten-beds-walk.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Increase z-index of ts-dropdown to prevent overlapping by buttons

--- a/src/scss/vendor/_tom-select.scss
+++ b/src/scss/vendor/_tom-select.scss
@@ -42,6 +42,7 @@ $input-border-width: 1px;
   background: var(--#{$prefix}bg-surface);
   color: var(--#{$prefix}body-color);
   box-shadow: var(--#{$prefix}box-shadow-dropdown);
+  z-index: 2;
 
   .option {
     padding: $dropdown-item-padding-y $dropdown-item-padding-x;


### PR DESCRIPTION
Fix to prevent overlapping by buttons.

Before change:  
![image](https://github.com/user-attachments/assets/460061af-ea92-456a-8247-33e84eb49233)

After change:  
![image](https://github.com/user-attachments/assets/cdac141e-c489-4216-9407-ea76dac61009)

