### PR TITLE
Increase contrast of active dropdown-item in vertical layout

### DIFF
--- a/.changeset/small-avocados-end.md
+++ b/.changeset/small-avocados-end.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Increase contrast of active `dropdown-item` in vertical layout

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -732,7 +732,7 @@ $navbar-light-color: var(--#{$prefix}body-color) !default;
 $navbar-light-brand-color: var(--#{$prefix}body-color) !default;
 $navbar-light-active-color: var(--#{$prefix}body-color) color !default;
 $navbar-light-disabled-color: var(--#{$prefix}disabled-color) !default;
-$navbar-light-active-bg: rgba(0, 0, 0, 0.06) !default;
+$navbar-light-active-bg: rgba(0, 0, 0, 0.2) !default;
 
 $navbar-dark-color: rgba($white, $text-secondary-opacity) !default;
 $navbar-dark-brand-color: $white !default;


### PR DESCRIPTION
Before change:  

![image](https://github.com/user-attachments/assets/a5be6da6-6e33-4ed5-82e7-dc4a69724bc5)  
![image](https://github.com/user-attachments/assets/bdc19235-6918-44be-bcd9-66da7c6ba930)

After change:  
![image](https://github.com/user-attachments/assets/f6a0338a-f8c3-48a2-ac8e-279c6530c817)  
![image](https://github.com/user-attachments/assets/537a3732-367d-4ac6-a909-6101fa595a10)

Fixes #1890 