### PR TITLE
Fix layout of search results for small and medium screens

### DIFF
--- a/.changeset/perfect-trainers-rush.md
+++ b/.changeset/perfect-trainers-rush.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fix layout of search results for small and medium screens

--- a/src/pages/search-results.html
+++ b/src/pages/search-results.html
@@ -5,10 +5,10 @@ menu: extra.search-results
 ---
 
 <div class="row g-4">
-	<div class="col-3">
+	<div class="col-md-3">
 		{% include parts/nav/nav-aside.html %}
 	</div>
-	<div class="col-9">
+	<div class="col-md-9">
 		<div class="row row-cards">
 			{% assign photos = site.data.photos | where: "horizontal", true %}
 


### PR DESCRIPTION
Fixes #1870

Before changes:  
![image](https://github.com/user-attachments/assets/10105f94-915c-4543-ae99-9ce951289887)

After changes:
![image](https://github.com/user-attachments/assets/24693576-473b-4861-9742-b8df22201fb5)

