### PR TITLE
Fix description of alerts with a description

### DIFF
--- a/.changeset/light-beers-study.md
+++ b/.changeset/light-beers-study.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fix description of alerts with a description

--- a/src/pages/alerts.html
+++ b/src/pages/alerts.html
@@ -45,7 +45,7 @@ page-header: Alerts
 		<div class="card">
 			<div class="card-body">
 				<h2 class="card-title">Alert with a description</h2>
-				<p class="text-secondary">Build on any alert by adding an optional <code>.alert-dismissible</code> and close button.</p>
+				<p class="text-secondary">Add a description to the alert to provide additional information.</p>
 				{% include ui/alert.html type="success" show-description=true show-icon=true %}
 				{% include ui/alert.html type="warning" show-description=true show-icon=true %}
 				{% include ui/alert.html type="danger" show-description=true show-icon=true %}


### PR DESCRIPTION
The previous description was copied from "Dismissible alerts"

Fixes #1844 