### PR TITLE
Fix link to webfont icons

### DIFF
--- a/.changeset/webfont-unpkg.md
+++ b/.changeset/webfont-unpkg.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fix link to webfont version of Tabler Icons

--- a/src/pages/_includes/layout/css.html
+++ b/src/pages/_includes/layout/css.html
@@ -1,6 +1,6 @@
 <!-- CSS files -->
 {% if site.use-iconfont %}
-<link href="https://cdn.statically.io/gh/tabler/tabler-icons/master/iconfont/tabler-icons.min.css" rel="stylesheet" />
+<link href="https://www.unpkg.com/@tabler/icons-webfont@latest/dist/tabler-icons.min.css" rel="stylesheet" />
 {% endif %}
 
 {% assign libs = page.libs | default: layout.libs %}


### PR DESCRIPTION
https://www.unpkg.com/@tabler/icons-webfont@latest/dist/tabler-icons.min.css used instead of https://cdn.statically.io/gh/tabler/tabler-icons/master/iconfont/tabler-icons.min.css