### PR TITLE
Remove text-decoration on hovering a element with child having an icon class

### DIFF
--- a/.changeset/popular-news-sell.md
+++ b/.changeset/popular-news-sell.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Remove `text-decoration` on hovering `a` element with class having `icon` class

--- a/src/pages/_data/menu.yml
+++ b/src/pages/_data/menu.yml
@@ -152,7 +152,6 @@ base:
     pagination:
       url: pagination.html
       title: Pagination
-      icon: pie-chart
     placeholder:
       url: placeholder.html
       title: Placeholder

--- a/src/scss/ui/_type.scss
+++ b/src/scss/ui/_type.scss
@@ -163,6 +163,10 @@ Links
   }
 }
 
+a:hover:has(.icon) {
+  text-decoration: none;
+}
+
 /**
 Subheader
  */


### PR DESCRIPTION
\+ Remove icon from pagination menu item.

Fixes #1836 