### PR TITLE
Fix overflow of label in a floating-input

### DIFF
--- a/src/scss/ui/_forms.scss
+++ b/src/scss/ui/_forms.scss
@@ -228,3 +228,14 @@ Upload files
   margin-left: 0;
   border-left: 0;
 }
+
+/**
+Floating inputs
+ */
+// Fix for the bug in twbs/bootstrap v5.3.3. Issue #39080. Should be fixed in v5.3.4
+label[for="floating-input"] {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Temporary fix for the bug in twbs/bootstrap v5.3.3.