### PR TITLE
Make marketing pages fully support dark mode

### DIFF
--- a/src/pages/_includes/marketing/sections/testimonials.html
+++ b/src/pages/_includes/marketing/sections/testimonials.html
@@ -18,7 +18,7 @@
 					{% for testimonial in group %}
 					{% assign person = people[i] %}
 					<div class="col-12">
-						<a href="#" class="card bg-light">
+						<a href="#" class="card bg-body">
 							<div class="card-body">
 								<div class="row mb-3">
 									<div class="col-auto">{% include "ui/avatar.html" person=person size="md" %}</div>

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -808,7 +808,7 @@ $popover-body-color: inherit !default;
 
 // Footer
 $footer-padding-y: 2rem !default;
-$footer-bg: $white !default;
+$footer-bg: var(--#{$prefix}bg-surface) !default;
 $footer-border-color: var(--#{$prefix}border-color) !default;
 $footer-color: var(--#{$prefix}gray-500) !default;
 

--- a/src/scss/marketing/_pricing.scss
+++ b/src/scss/marketing/_pricing.scss
@@ -15,7 +15,7 @@ $pricing-card-width: 22rem;
   flex: 1;
   display: flex;
   flex-direction: column;
-  background: $white;
+  background: var(--#{$prefix}bg-surface);
   border: 1px solid $border-color;
   padding: 2rem;
   margin: 0 0 1rem;


### PR DESCRIPTION
- [x] Testimonials: bg-light to bg-body
- [x] Footers: change color to surface variable
- [x] Pricing: change `#fff` to `--tblr-bg-surface`

Maybe we should change the border for pricing cards on dark mode too, or does this look good?

![Screenshot of pricing cards](https://github.com/user-attachments/assets/1ea1e638-2587-476e-b2f1-f7a1c067448d)