### PR TITLE
Update _nav.scss

### DIFF
--- a/core/scss/ui/_nav.scss
+++ b/core/scss/ui/_nav.scss
@@ -36,7 +36,7 @@
   .nav-link {
     padding-left: 0;
     padding-right: 0;
-    margin: 0 0 (- $nav-bordered-border-width);
+    margin: 0 0 ($nav-bordered-border-width);
     border: 0;
     border-bottom: $nav-bordered-link-active-border-width var(--#{$prefix}border-style) transparent;
   }


### PR DESCRIPTION
### Issue: Dash (`-`) causing W3C validator error and CSS issues

**Problem**:
The use of a dash (`-`) in certain areas is triggering errors in the W3C validator and affecting the proper functioning of CSS.

1. **HTML Issue**: The dash might be incorrectly placed in attribute names or element IDs, causing validation errors.
   - Example: `data-name` is fine, but ensure it's used correctly and within the valid context.

2. **CSS Issue**: If the dash is used improperly in class or ID names, it can cause selector issues in CSS.
   - Example: `.my-class-name` is correct, but make sure that the class is correctly applied to the element and styled properly in CSS.
