### PR TITLE
Fix broken 'top pages' table

### DIFF
--- a/preview/pages/_includes/cards/tables/progressbg.html
+++ b/preview/pages/_includes/cards/tables/progressbg.html
@@ -10,15 +10,15 @@
 			</tr>
 			</thead>
 			<tbody>
-			{% for page in pages %}
+			{% for url in urls %}
 			<tr>
 				<td>
 					<div class="progressbg">
-						{% include "ui/progress.html" value=page.bounce class="progressbg-progress" color="primary-lt" %}
-						<div class="progressbg-text">{{ page.uri }}</div>
+						{% include "ui/progress.html" value=url.bounce class="progressbg-progress" color="primary-lt" %}
+						<div class="progressbg-text">{{ url.uri }}</div>
 					</div>
 				</td>
-				<td class="w-1 fw-bold text-end">{{ page.visitors }}</td>
+				<td class="w-1 fw-bold text-end">{{ url.visitors }}</td>
 			</tr>
 			{% endfor %}
 			</tbody>


### PR DESCRIPTION
After a recent refactor in #2130, it appears some references to old variables were not updated, which caused the top pages table demo to break.

Fixes #2143