### PR TITLE
added "start" command to package.json scripts as alias for dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ node_modules/
 /.tmp/
 /tmp-dist/
 /yarn.lock
-pnpm-lock.yaml
 .DS_Store
 /_site/
 /.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 /.tmp/
 /tmp-dist/
 /yarn.lock
+pnpm-lock.yaml
 .DS_Store
 /_site/
 /.cache/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "bundlewatch": "turbo bundlewatch",
     "version": "changeset version",
     "publish": "changeset publish",
-    "reformat-mdx": "node build/reformat-mdx.mjs"
+    "reformat-mdx": "node build/reformat-mdx.mjs",
+    "start": "pnpm dev"
   },
   "packageManager": "pnpm@9.15.4",
   "devDependencies": {


### PR DESCRIPTION
Added missing **"start"** alias in the scripts section of the _package.json_ file to allow the command: 

```bash
pnpm run start
```
to work as per documentation.

Added "pnpm-lock.yaml" to ".gitignore" to remove conflict as suggested in #2123 