### PR TITLE
Add `changelog-spy.html` for Dynamic Changelog Navigation

### DIFF
--- a/preview/pages/_data/menu.json
+++ b/preview/pages/_data/menu.json
@@ -449,6 +449,11 @@
         "url": "changelog.html",
         "title": "Changelog"
       },
+      "changelog-spy": {
+        "url": "changelog-spy.html",
+        "title": "Changelog Spy",
+        "badge": "new"
+      },
       "source-code": {
         "url": "https://github.com/tabler/tabler",
         "title": "Source code"

--- a/preview/pages/changelog-spy.html
+++ b/preview/pages/changelog-spy.html
@@ -1,0 +1,31 @@
+---
+title: Changelog scroll
+layout: default
+permalink: changelog-spy.html
+page-header: Changelog scroll
+---
+
+{% assign headers = "1.0.0,1.0.0-beta24,1.0.0-beta24,1.0.0-beta24" | split: "," %}
+
+<div class="row g-5">
+	<div class="col-sm-2">
+		<div class="sticky-top">
+			<h3>Menu</h3>
+			<nav class="nav nav-vertical nav-pills" id="pills">
+				{% for header in headers %}
+				<a class="nav-link" href="#pills-{{ header | slugify }}">v{{ header }}</a>
+				{% endfor %}
+			</nav>
+		</div>
+	</div>
+	<div class="col-sm" data-bs-spy="scroll" data-bs-target="#pills" data-bs-offset="0">
+		<div class="card card-lg">
+			<div class="card-body">
+				{% for header in headers %}
+				<h3 id="pills-{{ header | slugify }}">v{{ header }}</h3>
+				{{ changelog | renderContent: "md" }}
+				{% endfor %}
+			</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
# Add `changelog-spy.html` for Dynamic Changelog Navigation

## Summary
This PR introduces a new page, `changelog-spy.html`, that automatically builds a **scroll spy** navigation from the `##` headings in a Markdown-based changelog.

![Changelog Spy Preview](https://i.ibb.co/rKYyYy4w/screenshot-2025-02-20-07-47-40.png)

## Features
- **Automatic Navigation:** Generates sidebar links for each `##` heading in the changelog.  
- **Improved Readability:** Organizes large release notes into clear, scrollable sections.  

## Known Issues
- **Heading Splitting:** Currently, the Markdown must be split by `##` to properly identify headings.  
- **Project Requirements:** Further discussion may be needed to refine how headings or sections are generated if the owner wants more flexibility.  
- **Regex or Plugin Approach:** A more robust solution (like a TOC plugin or advanced parsing) might be considered based on the project’s long-term needs.

## Implementation
- Renders Markdown via `{{ changelog | renderContent: "md" }}`.  
- Builds a left-hand menu with anchor links, and displays matching sections on the right.  

## How to Test
1. Navigate to `/scroll-docs.html`.  
2. Verify that each `##` heading from `changelog` is listed in the sidebar.  
3. Click a heading to confirm the page scrolls to that section.  
4. Scroll to check that the active section is highlighted correctly.

## Why?
- Regex-based heading extraction can yield a dynamic TOC without manual updates.  
- Splitting Markdown by heading level is straightforward but may need refinement.  
- Users gain a streamlined way to locate specific versions or details in large changelogs.

This PR proposes a valuable addition to Tabler, helping users quickly find the right changelog version through a convenient scroll-spy interface. Feedback and further improvements welcome!
