### PR TITLE
fix: add missing border-radius to .card-header-tabs

### DIFF
--- a/.changeset/tidy-hairs-wonder.md
+++ b/.changeset/tidy-hairs-wonder.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fix missing border-radius to `.card-header-tabs`

--- a/core/scss/ui/_cards.scss
+++ b/core/scss/ui/_cards.scss
@@ -205,6 +205,7 @@ Stacked card
   flex: 1;
   margin: calc(var(--#{$prefix}card-cap-padding-y) * -1) calc(var(--#{$prefix}card-cap-padding-x) * -1) calc(var(--#{$prefix}card-cap-padding-y) * -1);
   padding: calc(var(--#{$prefix}card-cap-padding-y) * .5) calc(var(--#{$prefix}card-cap-padding-x) * .5) 0;
+  border-radius: var(--#{$prefix}card-border-radius) var(--#{$prefix}card-border-radius) 0 0;
 }
 
 .card-header-pills {


### PR DESCRIPTION
## What this PR does

This PR adds a missing `border-radius` to the `.card-header-tabs` class to match the style applied to `.card-header:first-child`. This ensures visual consistency across card headers that use tabs.

## Why it's needed

Without this fix, `.card-header-tabs` has sharp corners, which breaks the rounded card appearance and leads to inconsistent UI.

## Screenshot (before/after)

### Before
![image](https://github.com/user-attachments/assets/465ea08b-68f0-4c97-af2c-f894c1cb7b72)

### After
![image](https://github.com/user-attachments/assets/96a78918-d913-4b56-9a63-f5b80e31e5eb)

## Notes
Let me know if this should be applied in a different place or if there's a related variable that should be used instead.
First-time contributor — thanks for the awesome work on Tabler!
