### PR TITLE
Fix transparent background on alerts after v1.2.0 update

### DIFF
--- a/core/scss/_bootstrap-override.scss
+++ b/core/scss/_bootstrap-override.scss
@@ -76,3 +76,7 @@
 @function opaque($background, $foreground) {
   @return mix(rgba($foreground, 1), $background, opacity($foreground) * 100%);
 }
+.alert {
+  --tblr-alert-bg: color-mix(in srgb, var(--tblr-alert-color) 20%, var(--tblr-bg-surface));
+  --tblr-alert-border-color: color-mix(in srgb, var(--tblr-alert-color) 40%, var(--tblr-bg-surface));
+}

--- a/package.json
+++ b/package.json
@@ -45,5 +45,11 @@
     "shx": "^0.4.0",
     "terser": "^5.39.0",
     "turbo": "^2.4.4"
+  },
+  "dependencies": {
+    "@docsearch/css": "^3.9.0",
+    "@docsearch/js": "^3.9.0",
+    "@popperjs/core": "^2.11.8",
+    "bootstrap": "^5.3.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,19 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@docsearch/css':
+        specifier: ^3.9.0
+        version: 3.9.0
+      '@docsearch/js':
+        specifier: ^3.9.0
+        version: 3.9.0(@algolia/client-search@5.23.1)(search-insights@2.17.3)
+      '@popperjs/core':
+        specifier: ^2.11.8
+        version: 2.11.8
+      bootstrap:
+        specifier: ^5.3.5
+        version: 5.3.5(@popperjs/core@2.11.8)
     devDependencies:
       '@argos-ci/playwright':
         specifier: ^4.1.0


### PR DESCRIPTION
I noticed that after updating to v1.2.0, the alert backgrounds were turning transparent, especially when changing the card color — it didn’t look great visually.

I’ve added a small fix by adjusting the CSS variables for the alert background and border using color-mix. This brings back proper visibility for all alert types.

Tested it locally and it seems to do the trick! Let me know if any adjustments are needed