### PR TITLE
Fix WYSIWYG dark mode detection

### DIFF
--- a/core/scss/_bootstrap-override.scss
+++ b/core/scss/_bootstrap-override.scss
@@ -76,3 +76,7 @@
 @function opaque($background, $foreground) {
   @return mix(rgba($foreground, 1), $background, opacity($foreground) * 100%);
 }
+.alert {
+  --tblr-alert-bg: color-mix(in srgb, var(--tblr-alert-color) 20%, var(--tblr-bg-surface));
+  --tblr-alert-border-color: color-mix(in srgb, var(--tblr-alert-color) 40%, var(--tblr-bg-surface));
+}

--- a/package.json
+++ b/package.json
@@ -45,5 +45,11 @@
     "shx": "^0.4.0",
     "terser": "^5.39.0",
     "turbo": "^2.4.4"
+  },
+  "dependencies": {
+    "@docsearch/css": "^3.9.0",
+    "@docsearch/js": "^3.9.0",
+    "@popperjs/core": "^2.11.8",
+    "bootstrap": "^5.3.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,19 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@docsearch/css':
+        specifier: ^3.9.0
+        version: 3.9.0
+      '@docsearch/js':
+        specifier: ^3.9.0
+        version: 3.9.0(@algolia/client-search@5.23.1)(search-insights@2.17.3)
+      '@popperjs/core':
+        specifier: ^2.11.8
+        version: 2.11.8
+      bootstrap:
+        specifier: ^5.3.5
+        version: 5.3.5(@popperjs/core@2.11.8)
     devDependencies:
       '@argos-ci/playwright':
         specifier: ^4.1.0


### PR DESCRIPTION
Hey folks ,I stumbled upon the WYSIWYG dark mode issue and saw that the problem comes from checking localStorage for tablerTheme instead of tabler-theme.

Rather than just swapping the key, I figured it’d be safer to handle both cases — just in case someone out there still has the old key saved. So now, it checks for both. Tested it locally, and dark mode kicks in as expected