### PR TITLE
Demonstrate sticky header table more clearly in docs

### DIFF
--- a/.changeset/silent-hornets-appear.md
+++ b/.changeset/silent-hornets-appear.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Demonstrate sticky header table more clearly in docs

--- a/docs/content/ui/components/tables.md
+++ b/docs/content/ui/components/tables.md
@@ -396,7 +396,52 @@ If you don't want the table cell content to wrap to another line, use the `table
       <td>Cell</td>
       <td>Cell</td>
     </tr>
+    <tr>
+      <th scope="row">Default</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+    <tr>
+      <th scope="row">Primary</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+    <tr>
+      <th scope="row">Secondary</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+    <tr>
+      <th scope="row">Success</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+    <tr>
+      <th scope="row">Danger</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+    <tr>
+      <th scope="row">Warning</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+    <tr>
+      <th scope="row">Info</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+    <tr>
+      <th scope="row">Light</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
+    <tr class="table-dark">
+      <th scope="row">Dark</th>
+      <td>Cell</td>
+      <td>Cell</td>
+    </tr>
   </tbody>
 </table>
 {%- endcapture %}
-{% include "docs/example.html" html=html %}
+{% include "docs/example.html" html=html height="42rem" %}


### PR DESCRIPTION
Previously, the example in the documentation for sticky header tables did not actually show the sticky header behaviour, since the table was not scrollable. This update increases the number of rows in the table and forces the table's wrapper to have a specific height, causing the table to become scrollable and thus demonstrating the sticky header behaviour.

~~I'm not 100% sure that it is enough to add a height prop to the include statement at the bottom of the file here, as I am still not sure how to access a local copy of the documentation app to test it (since the docs link on the development build of the preview site leads to the _production_ documentation site). Hopefully this fix is correct though.~~ Figured out how to access documentation in development. This fix appears to be correct.