### PR TITLE
Use tabs-package include to show webfont install steps

### DIFF
--- a/.changeset/short-hounds-promise.md
+++ b/.changeset/short-hounds-promise.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Use tabs-package include to show webfont install steps

--- a/docs/content/icons/libraries/webfont.md
+++ b/docs/content/icons/libraries/webfont.md
@@ -9,21 +9,7 @@ summary: Tabler Icons as a webfont allows you to easily include icons in your pr
 
 ## Installation
 
-```
-yarn add @tabler/icons-webfont
-```
-
-or
-
-```
-npm install @tabler/icons-webfont
-```
-
-or
-
-```
-pnpm install @tabler/icons-webfont
-```
+{% include "docs/tabs-package.html" name="@tabler/icons-webfont" %}
 
 or just [download from Github](https://github.com/tabler/tabler-icons/releases).
 


### PR DESCRIPTION
Since the install guides for other Tabler libraries use the tabs-package for showing the steps, it would appear to make sense to use it for the webfont install guide also.