### PR TITLE
Fix input mask example in docs

### DIFF
--- a/.changeset/dry-spiders-double.md
+++ b/.changeset/dry-spiders-double.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Fix input mask example in docs

--- a/docs/content/ui/forms/form-input-mask.md
+++ b/docs/content/ui/forms/form-input-mask.md
@@ -2,6 +2,7 @@
 title: Input mask
 summary: An input mask is used to clarify the input format required in a given field and is helpful for users, removing confusion and reducing the number of validation errors.
 description: Clarify input formats for users.
+docs-libs: imask
 ---
 
 ## Installation


### PR DESCRIPTION
There was a missing lib that needed to be added to the front-matter of the form input mask documentation page.

Fixes #2308