### PR TITLE
Fix carousel with captions demo on preview website

### DIFF
--- a/shared/includes/cards/carousel.html
+++ b/shared/includes/cards/carousel.html
@@ -3,6 +3,6 @@
       <h3 class="card-title">{{ include.title | default: 'Carousel' }}</h3>
    </div>
    <div class="card-body">
-      {% include "ui/carousel.html" id=include.id indicators=include.indicators indicators-thumb=include.indicators-thumb indicators-thumb-ratio=include.indicators-thumb-ratio indicators-dot=include.indicators-dot controls=include.controls offset=include.offset fade=include.fade limit=include.limit indicators-vertical=include.indicators-vertical %}
+      {% include "ui/carousel.html" id=include.id indicators=include.indicators indicators-thumb=include.indicators-thumb indicators-thumb-ratio=include.indicators-thumb-ratio indicators-dot=include.indicators-dot controls=include.controls offset=include.offset fade=include.fade limit=include.limit indicators-vertical=include.indicators-vertical captions=include.captions %}
    </div>
 </div>


### PR DESCRIPTION
It seems that previously a prop was not being passed to the relevant carousel include file to enable captions for that specific example.