### PR TITLE
Update heading of carousel with thumbnail indicators

### DIFF
--- a/preview/pages/carousel.html
+++ b/preview/pages/carousel.html
@@ -29,6 +29,6 @@ permalink: carousel.html
 		{% include "cards/carousel.html" id="indicators-dot-vertical" title="Carousel with vertical dot indicators" indicators=true indicators-vertical=true indicators-dot=true offset=30 fade=true %}
 	</div>
 	<div class="col-md-6">
-		{% include "cards/carousel.html" id="indicators-thumb-vertical" title="Carousel with thumbnail indicators" indicators=true indicators-vertical=true indicators-thumb=true indicators-thumb-ratio=true offset=22 fade=true %}
+		{% include "cards/carousel.html" id="indicators-thumb-vertical" title="Carousel with vertical thumbnail indicators" indicators=true indicators-vertical=true indicators-thumb=true indicators-thumb-ratio=true offset=22 fade=true %}
 	</div>
 </div>


### PR DESCRIPTION
The carousel example that shows vertical thumbnail indicators had the same heading as the example with horizontal thumbnail indicators. This change updates the vertical thumbnail example's heading.
(This follows the pattern of the dot indicator examples, which have different headings).

Before this change:
![image](https://github.com/user-attachments/assets/e4c740be-bc60-43aa-8b45-3cef902769c9)

After this change:
![image](https://github.com/user-attachments/assets/9529b9df-ae7d-4b73-a8d6-e568dca9fb72)
