### PR TITLE
Fix incorrect label text on form elements docs page

### DIFF
--- a/.changeset/short-balloons-smile.md
+++ b/.changeset/short-balloons-smile.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Fix incorrect label text on form elements docs page

--- a/docs/content/ui/forms/form-elements.md
+++ b/docs/content/ui/forms/form-elements.md
@@ -551,7 +551,7 @@ Include a `<kbd>` in your input control to add a shortcut hint to the control.
 
 {% capture html -%}
 <div class="mb-3">
-  <label class="form-label">Input with appended link</label>
+  <label class="form-label">Input with appended kbd</label>
   <div class="input-group input-group-flat">
     <input type="password" class="form-control" value="ultrastrongpassword" autocomplete="off" />
     <span class="input-group-text">


### PR DESCRIPTION
The example of an input with an appended `<kbd>` previously had a change introduced in https://github.com/tabler/tabler/pull/1492 to its label that was incorrect. 

This commit brings it back to what it was originally, as first written in https://github.com/tabler/tabler/pull/1391.

Before this change:
![image](https://github.com/user-attachments/assets/64f310d1-7108-43e0-8339-6db98f88ae33)

After this change:
![image](https://github.com/user-attachments/assets/74f3cd50-6e3a-422f-b364-2ae2e01119bf)
