### PR TITLE
Add missing TOC item on the preview's form elements page

### DIFF
--- a/docs/content/ui/forms/form-elements.md
+++ b/docs/content/ui/forms/form-elements.md
@@ -545,7 +545,7 @@ Include a link in your input control to add a clickable element within the contr
 {%- endcapture %}
 {% include "docs/example.html" html=html %}
 
-## Input with appended `<kbd>`
+## Input with appended kbd
 
 Include a `<kbd>` in your input control to add a shortcut hint to the control.
 


### PR DESCRIPTION
Previously, the section heading for 'Input with appended `<kbd>`' was not appearing on that page's table of contents. This was due to how the headings on pages were parsed when constructing the TOC.

This change updates the heading. It seems reasonable to simplify the heading, rather than modify the code that constructs the TOC.

Before this change:
![Screenshot 2025-05-05 231202](https://github.com/user-attachments/assets/b50e3ed6-3623-4f97-b993-fda030aa88fd)

After this change:
![image](https://github.com/user-attachments/assets/a99c5a4d-5267-4ca9-89c2-2d9835dedbc5)
