### PR TITLE
Fix colour swatches on small screens

### DIFF
--- a/.changeset/poor-spoons-deny.md
+++ b/.changeset/poor-spoons-deny.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": "patch"
+---
+
+Fix colour swatches on small screens

--- a/shared/includes/docs/colors.html
+++ b/shared/includes/docs/colors.html
@@ -1,7 +1,7 @@
-<div class="row g-4">
+<div class="row row-cols-4 row-cols-md-6 g-3 g-md-4">
 	{%- for color in include.colors -%}
-	<div class="col-2 text-center">
-		<div class="p-6 rounded border" style="background-color: {{ color[1].hex }}"></div>
+	<div class="col text-center">
+		<div class="p-5 p-md-6 rounded border" style="background-color: {{ color[1].hex }}"></div>
 		<div class="small">{{ color[1].title }}</div>
 	</div>
 	{% endfor -%}


### PR DESCRIPTION
Previously, a fixed padding amount was causing the colour swatches to overlap each other on small screens. They are now responsive: on small screens, they shrink slightly and spread out more across each line of their layout.

The markup was also changed slightly to make use of the `row-cols-*` shortcuts.

Fixes #2327.