### PR TITLE
Fix: Exclude headings inside `.example` from the Table of Contents

### DIFF
--- a/.changeset/strong-frogs-brush.md
+++ b/.changeset/strong-frogs-brush.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Exclude headings inside `.example` from the Table of Contents

--- a/docs/eleventy.config.mjs
+++ b/docs/eleventy.config.mjs
@@ -1,4 +1,3 @@
-
 import { appFilters } from "../shared/e11ty/filters.mjs"
 import { appData, getCopyList } from "../shared/e11ty/data.mjs";
 import { readFileSync, existsSync } from 'node:fs';

--- a/docs/eleventy.config.mjs
+++ b/docs/eleventy.config.mjs
@@ -227,7 +227,8 @@ export default function (eleventyConfig) {
 	eleventyConfig.addFilter("toc", function (name) {
 		const toc = [];
 
-		const headings = name.match(/<h([2-3])>([^<]+)<\/h\1>/g);
+		const contentWithoutExamples = name.replace(/<div[^>]*\bclass=["'][^"']*\bexample\b[^"']*".*?>.*?<\/div>/gs, '');
+		const headings = contentWithoutExamples.match(/<h([23])>([^<]+)<\/h\1>/g);
 
 		if (headings) {
 			headings.forEach(heading => {


### PR DESCRIPTION
Fixes #2291 