### PR TITLE
Add a few small documentation fixes and updates

### DIFF
--- a/.changeset/fresh-ways-begin.md
+++ b/.changeset/fresh-ways-begin.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Fix links in Tabler Emails introduction, improve "How to contribute" and other small fixes

--- a/docs/content/emails/introduction/contents.md
+++ b/docs/content/emails/introduction/contents.md
@@ -44,8 +44,8 @@ The **Tabler Emails** package is organized into a clear and efficient folder str
 
 ### 1. Email Templates: `emails/`
 This folder contains {{ emailsCount }} email subfolders, each with a specific template. Each email folder contains the following files:
-* Compiled HTML files for light and dark themes. Read more about their usage in the [Compiled HTML](/img/emails/compiled-html) section.
-* Source HTML files for light and dark themes. Find more information in the [Source HTML](/img/emails/source-html) section.
+* Compiled HTML files for light and dark themes. Read more about their usage in the [Compiled HTML](/emails/introduction/compiled-html) section.
+* Source HTML files for light and dark themes. Find more information in the [Source HTML](/emails/introduction/source-html) section.
 * Screenshot images for desktop and mobile views.
 * Assets folder with images used in the email template and the CSS file with styles.
 

--- a/docs/content/ui/components/icons.md
+++ b/docs/content/ui/components/icons.md
@@ -5,7 +5,7 @@ banner: icons
 description: Enhance dashboards with custom icons.
 ---
 
-If you need to add icons to your website, you can use the [Tabler Icons library]({{ site.icons.link }}). It contains over 5000 icons that you can use in your projects. All icons are under the MIT license, so you can use them without any problem both in private and commercial projects. You can find the Tabler Icons library [here](https://tabler-icons.io/).
+If you need to add icons to your website, you can use the [Tabler Icons library]({{ site.icons.link }}). It contains over 5000 icons that you can use in your projects. All icons are under the MIT license, so you can use them without any problem both in private and commercial projects.
 
 ## Base icon
 

--- a/docs/content/ui/forms/form-elements.md
+++ b/docs/content/ui/forms/form-elements.md
@@ -418,8 +418,6 @@ Add a range slider to make it possible for users to set a value or range, such a
 <div class="mb-3">
   <label class="form-label">Range input</label>
   <input type="range" class="form-range mb-2" value="40" min="0" max="100" step="10" />
-  <div class="form-range mb-2" id="range-simple"></div>
-  <div class="form-range mb-2" id="range-connect"></div>
   <div class="form-range mb-2 text-green" id="range-color"></div>
 </div>
 <script>

--- a/docs/content/ui/getting-started/how-to-contribute.md
+++ b/docs/content/ui/getting-started/how-to-contribute.md
@@ -39,16 +39,16 @@ To set up Tabler for development, follow these steps:
 
 <div class="steps steps-vertical">
 
-### Ensure Node.js and npm are installed
+### Ensure Node.js and pnpm are installed
 
 You’ll need Node.js (v20 or higher) and pnpm to compile Tabler’s files. If you don’t have them installed, download and install them from the official websites:
 
 - [Node.js](https://nodejs.org/)
-- [pnpm](https://pnpm.io/)
+- [pnpm](https://pnpm.io/) (we use pnpm over other package managers for faster installation).
 
 ### Install dependencies
 
-Run the following command to install all required npm packages. We recommend using pnpm for faster installation:
+Run the following command to install all required npm packages:
 
 ```bash
 pnpm install
@@ -56,7 +56,7 @@ pnpm install
 
 ### Start developer mode
 
-Use the following command to enable autocompilation with live reload. This will start a local server at `http://localhost:3000/`:
+Use the following command to enable autocompilation with live reload. This will start up the preview website at `http://localhost:3000/`, and the documentation website at `http://localhost:3010/`:
 
 ```bash
 pnpm run dev
@@ -64,7 +64,7 @@ pnpm run dev
 
 ### Make changes
 
-Make your changes in the appropriate folders, such as `./src/` or `./docs/`. Avoid modifying files in `./dist/`, as they are auto-generated during the build process and will be overwritten.
+Make your changes in the appropriate folders, such as `./core/`, `./preview/` or `./docs/`. Avoid modifying files in any `dist` folders, as they are auto-generated during the build process and will be overwritten.
 </div>
 
 ## Compiling for Production


### PR DESCRIPTION
- The links to the email 'compiled-html' and 'source-html' documentation pages were broken.
- Fixed an updated link label that was accidentally overwritten during a previous merge conflict resolution.
- Changed references to 'npm' in 'how to contribute' docs to 'pnpm' and reworded things slightly for better readability.
- Added notes to 'how to contribute' docs about viewing local copies of both the preview site _and_ the documentation site
- Changed outdated source folder references in 'how to contribute' docs
- Remove some empty divs on the form elements page's range sliders example
