### PR TITLE
Fix: Exclude headings in the carousel and modal examples from ToC

### DIFF
--- a/.changeset/stale-cherries-draw.md
+++ b/.changeset/stale-cherries-draw.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Fix: Exclude headings in the carousel and modal examples from ToC

--- a/docs/eleventy.config.mjs
+++ b/docs/eleventy.config.mjs
@@ -226,7 +226,7 @@ export default function (eleventyConfig) {
 	eleventyConfig.addFilter("toc", function (name) {
 		const toc = [];
 
-		const contentWithoutExamples = name.replace(/<div[^>]*\bclass=["'][^"']*\bexample\b[^"']*".*?>.*?<\/div>/gs, '');
+		const contentWithoutExamples = name.replace(/<div[^>]*\bclass=["'][^"']*\b(example|modal-body|carousel-caption)\b[^"']*".*?>.*?<\/div>/gs, '');
 		const headings = contentWithoutExamples.match(/<h([23])>([^<]+)<\/h\1>/g);
 
 		if (headings) {

--- a/docs/eleventy.config.mjs
+++ b/docs/eleventy.config.mjs
@@ -226,7 +226,7 @@ export default function (eleventyConfig) {
 	eleventyConfig.addFilter("toc", function (name) {
 		const toc = [];
 
-		const contentWithoutExamples = name.replace(/<div[^>]*\bclass=["'][^"']*\b(example|modal-body|carousel-caption)\b[^"']*".*?>.*?<\/div>/gs, '');
+		const contentWithoutExamples = name.replace(/<!--EXAMPLE-->[\s\S]*?<!--\/EXAMPLE-->/g, '');
 		const headings = contentWithoutExamples.match(/<h([23])>([^<]+)<\/h\1>/g);
 
 		if (headings) {

--- a/shared/includes/docs/example.html
+++ b/shared/includes/docs/example.html
@@ -1,3 +1,4 @@
+<!--EXAMPLE-->
 <div
 	class="example fs-base border rounded my-5{% unless include.raw %} d-flex flex-wrap justify-content-center{% endunless %} overflow-{{ include.overflow | default: 'auto' }} position-relative {% if include.bg %}bg-{{ include.bg }}{% endif %}{% if include.class %} {{ include.class }}{% endif %}"{% if include.height %} style="height: {{ include.height }}"{% endif %}{% unless include.bg %} style="background: url('data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\' width=\'20\' height=\'20\' viewBox=\'0 0 20 20\'><rect fill=\'rgba(0, 0, 0, .01)\' x=\'0\' y=\'0\' width=\'10\' height=\'10\' /><rect fill=\'rgba(0, 0, 0, .01)\' x=\'10\' y=\'10\' width=\'10\' height=\'10\' /></svg>')"{% endunless %}}>
 	{%- unless include.raw -%}<div class="p-6 w-full{% if include.column %} d-flex gap-3 flex-column{% elsif include.centered %} justify-content-center flex-fill flex-wrap gap-2{% if include.vertical %} flex-column{% endif %}{% endif %}" {% if include.column %}style="max-width: 25rem;"{% endif %}>{%- endunless -%}
@@ -10,3 +11,4 @@
 {{ html }}
 ```
 {% endunless %}
+<!--/EXAMPLE-->


### PR DESCRIPTION
Previous fix omitted the examples where any `<div>` was closed before the headings.

Added additional classes in the Regex expression.

Closes #2291