### PR TITLE
Use primary color for `::selection` inside `<code>` in docs

### DIFF
--- a/.changeset/grumpy-bobcats-kick.md
+++ b/.changeset/grumpy-bobcats-kick.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Use primary color for `::selection` inside `<code>` in docs

--- a/docs/scss/docs.scss
+++ b/docs/scss/docs.scss
@@ -53,3 +53,9 @@
   background: var(--tblr-gray-900) !important;
   color: var(--tblr-gray-300) !important;
 }
+
+code {
+  ::selection {
+    background: var(--tblr-primary);
+  }
+}


### PR DESCRIPTION
Fixes #2376 (copy button will be added in https://github.com/tabler/tabler/pull/2378)

Selection of code block changed from:  
![image](https://github.com/user-attachments/assets/d08f2864-f5e5-40ab-a0c5-59a7c273e36d)

to:  
![image](https://github.com/user-attachments/assets/4058f876-bd23-4bcf-a5af-d276273f395e)
