### PR TITLE
List group item hoverable only with .list-group-hoverable class

### DIFF
--- a/.changeset/smart-apples-glow.md
+++ b/.changeset/smart-apples-glow.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fix list group item hoverable only with `.list-group-hoverable` class

--- a/core/scss/ui/_lists.scss
+++ b/core/scss/ui/_lists.scss
@@ -31,14 +31,6 @@
 }
 
 .list-group-item {
-  &:active,
-  &:focus,
-  &:hover {
-    background-color: $dropdown-link-hover-bg;
-  }
-}
-
-.list-group-item {
   &.disabled,
   &:disabled {
     color: $gray-500;
@@ -58,6 +50,14 @@
 }
 
 .list-group-hoverable {
+  .list-group-item {
+    &:active,
+    &:focus,
+    &:hover {
+      background-color: $dropdown-link-hover-bg;
+    }
+  }
+
   .list-group-item-actions {
     opacity: 0;
     @include transition(opacity $transition-time);


### PR DESCRIPTION
In "Last commits" example (https://preview.tabler.io/lists.html) there is example with classes "list-group list-group-flush list-group-hoverable" but the fact is that "list-group-hoverable" is ignored and items are hoverable even without that.