### PR TITLE
wysiwyg.html: Remove license_key option from HugeRTE init object

### DIFF
--- a/shared/includes/ui/wysiwyg.html
+++ b/shared/includes/ui/wysiwyg.html
@@ -13,7 +13,6 @@
       height: 300,
       menubar: false,
       statusbar: false,
-		license_key: 'gpl',
       plugins: [
         'advlist', 'autolink', 'lists', 'link', 'image', 'charmap', 'preview', 'anchor',
         'searchreplace', 'visualblocks', 'code', 'fullscreen',


### PR DESCRIPTION
This is a leftover of TinyMCE 7 initialization; HugeRTE is provided under the MIT license.