### PR TITLE
fix: use relative line heights to make calculations work (#2258)

### DIFF
--- a/.changeset/brave-books-listen.md
+++ b/.changeset/brave-books-listen.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fix relative line heights in buttons

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -595,13 +595,13 @@ $input-btn-icon-size: $icon-size !default;
 $input-btn-font-size-sm: $h5-font-size !default;
 $input-btn-padding-x-sm: 0.25rem !default;
 $input-btn-padding-y-sm: 0.125rem - 0.0625rem !default;
-$input-btn-line-height-sm: 1rem !default;
+$input-btn-line-height-sm: divide(1rem, $input-btn-font-size-sm) !default;
 $input-btn-icon-size-sm: 1rem !default;
 
 $input-btn-font-size-lg: $h2-font-size !default;
 $input-btn-padding-x-lg: 1.5rem !default;
 $input-btn-padding-y-lg: 0.75rem - 0.0625rem !default;
-$input-btn-line-height-lg: 2rem !default;
+$input-btn-line-height-lg: divide(2rem, $input-btn-font-size-lg) !default;
 $input-btn-icon-size-lg: 2rem !default;
 
 $input-btn-focus-width: 0.25rem !default;


### PR DESCRIPTION
This PR corrects the line height setups for `.btn-sm` and `.btn-lg` which should fix #2258.