### PR TITLE
Rename several Theme builder labels

### DIFF
--- a/shared/includes/layout/navbar.html
+++ b/shared/includes/layout/navbar.html
@@ -64,7 +64,7 @@
 											{% include "ui/icon.html" icon="settings" %}
 										</span>
 										<span class="nav-link-title">
-											Settings
+											Theme Settings
 										</span>
 									</a>
 								</li>

--- a/shared/includes/settings.html
+++ b/shared/includes/settings.html
@@ -1,11 +1,11 @@
 <div class="settings">
-	<a href="#" class="btn btn-floating btn-icon btn-primary" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSettings" aria-controls="offcanvasSettings" aria-label="Theme Builder">
+	<a href="#" class="btn btn-floating btn-icon btn-primary" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSettings" aria-controls="offcanvasSettings" aria-label="Theme Settings">
 		{% include "ui/icon.html" icon="brush" %}
 	</a>
 
 	<form class="offcanvas offcanvas-start offcanvas-narrow" tabindex="-1" id="offcanvasSettings">
 		<div class="offcanvas-header">
-			<h2 class="offcanvas-title">Theme Builder</h2>
+			<h2 class="offcanvas-title">Theme Settings</h2>
 			<button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
 		</div>
 		<div class="offcanvas-body d-flex flex-column">
@@ -96,8 +96,7 @@
 					Reset changes
 				</button>
 				<a href="#" class="btn btn-primary w-100" data-bs-dismiss="offcanvas">
-					{% include "ui/icon.html" icon="settings" %}
-					Save settings
+					Save
 				</a>
 			</div>
 


### PR DESCRIPTION
We have updated the heading on the top nav button, the heading inside the theme
settings side panel, and the side panel's save button.

There were a couple of reasons why this change was recommended:
1)  the name 'Settings' in the top nav was not really clear about what _kind_ of
settings it represented
2) There is already a link in the 'Extra' nav menu called 'Settings', and having
both items named the same was potentially confusing.
3) Theme Settings seemed less jargon-y and more straightforward for
non-technical folks to understand than Theme Builder.
4) 'Save' seemed shorter and still simple enough to understand over 'Save
settings'.
5) The settings icon on the save button has been removed as it seemed
superfluous and/or unrelated.