### PR TITLE
Fixed "Tables of Contents" overlaping to navbar

### DIFF
--- a/shared/includes/docs/toc.html
+++ b/shared/includes/docs/toc.html
@@ -1,8 +1,9 @@
 {% assign toc = content | toc %}
 {% if toc.size > 0 %}
-<h3>
-	Table of Contents
-</h3>
+<div style="position: sticky; top: 50px; background: white; z-index: 500; font-size: 0.875rem; padding: 1rem; border-radius: 0.5rem; box-shadow: 0 2px 8px rgba(0,0,0,0.05); max-height: calc(100vh - 100px); overflow-y: auto;">
+	<h3>
+		Table of Contents
+	</h3>
 <div class="nav nav-vertical" id="toc">
 	{% for item in toc %}
 	<a href="#{{ item.id }}" class="nav-link{% if item.level == 3 %} ms-3{% endif %}">
@@ -19,3 +20,4 @@
 		<h4>{{ illustrations | size }} sleek illustrations for your startup's visual identity.</h4>
 	</div>
 </a>
+</div>

--- a/shared/layouts/docs/default.html
+++ b/shared/layouts/docs/default.html
@@ -148,7 +148,10 @@
 					</div>
 				</div>
 				<div class="col-2 d-none d-xxl-block">
-					<div class="py-6 sticky-top">
+				<div class="py-6 sticky-top" style="background: white; z-index: 1020;">
+					
+
+
 						{% include "docs/toc.html" %} 
 					</div>
 				</div>


### PR DESCRIPTION
This Bug Was found at #2421 
🛠️ What this PR does
Fixes layout issue in the Installation page Table of Contents.
The Table of Contents section was previously overlapping with the navbar while scrolling.
Converted the ToC container to a properly positioned sticky element with appropriate top offset and padding.
Adjusted styles to ensure all ToC links scroll correctly without visual overlap.
Ensured ToC visibility and user experience remain consistent across screen sizes.

Before:
<img width="1919" height="958" alt="image" src="https://github.com/user-attachments/assets/226494d7-f2b4-4852-b44c-838c61fefcb6" />

After:
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/37a3a0a7-43a1-46aa-afed-4dd8cbff3fc7" />
