### PR TITLE
Fix icon alignment for btn-sm and btn-xl sizes

### DIFF
--- a/.changeset/icon-sizing.md
+++ b/.changeset/icon-sizing.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": minor
+---
+
+fix: btn-sm and btn-xl with icon sizing issue (#2470)

--- a/core/scss/ui/_buttons.scss
+++ b/core/scss/ui/_buttons.scss
@@ -186,6 +186,10 @@
   .icon {
     margin: calc(-1 * var(--#{$prefix}btn-padding-x));
   }
+  //[BUG] btn-sm and btn-xl with an icon looks broken 
+  //issue #2470 fixed
+  min-width: calc(var(--#{$prefix}btn-icon-size) + (var(--#{$prefix}btn-padding-x) * 2));
+  min-height: calc(var(--#{$prefix}btn-icon-size) + (var(--#{$prefix}btn-padding-y) * 2));
 }
 
 //


### PR DESCRIPTION
Adds min-width and min-height calculations to button styles to resolve broken appearance when using icons with btn-sm and btn-xl. Addresses issue #2470.
<img width="808" height="522" alt="image" src="https://github.com/user-attachments/assets/853d7472-e452-443b-a564-fd27becd446a" />
