### PR TITLE
[FIX] Make .alert-action visible inside .alert-important

### DIFF
--- a/core/scss/ui/_alerts.scss
+++ b/core/scss/ui/_alerts.scss
@@ -89,6 +89,16 @@
   }
 }
 
+
+.alert-action {
+    color: inherit;
+    text-decoration: underline;
+    display: inline;
+
+    &:hover {
+      text-decoration: none;
+    }
+
 .alert-minor {
   background: transparent;
   border-color: var(--tblr-border-color);
@@ -98,4 +108,6 @@
   .alert-#{$name} {
     --#{$prefix}alert-color: var(--#{$prefix}#{$name});
   }
+}
+
 }


### PR DESCRIPTION
[FIX] Make .alert-action visible inside .alert-important
### Issue
The `.alert-action` links inside `.alert-important` alerts were not visible, 
as the `.alert-important` class sets a background color and text color that 
overrides the default `.alert-action` styles.

This bug was reported in issue #2507.

### Solution
Added a nested style inside `.alert-important` to ensure `.alert-action` is visible:

```scss
.alert-important {
  .alert-action {
    display: inline;
    color: inherit;           // ensures the link is visible on alert background
    text-decoration: underline;

    &:hover {
      text-decoration: none;
    }
  }
}
testing

Verified in the local preview at http://localhost:3000/alerts.html

.alert-action links are now visible in .alert-important alerts

Other alerts remain unchanged

This ensures proper visibility of action links in all important alerts.


**Optional Tags/Notes:**  
- `Fixes #2507` (link to the original bug)  
- Tested locally in Firefox and Chrome  

---

