### PR TITLE
fix: Fix `.btn-icon` size by aligning `min-width` calculation

### DIFF
--- a/.changeset/btn-icon-square.md
+++ b/.changeset/btn-icon-square.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed `.btn-icon` to be square by aligning `min-width` calculation with base `.btn` formula.

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -601,7 +601,7 @@ $input-btn-focus-width: 0.25rem !default;
 $input-btn-padding-y-sm: 0.3125rem !default;
 $input-btn-padding-x-sm: 0.5rem !default;
 $input-btn-font-size-sm: $h5-font-size !default;
-$input-btn-line-height-sm: divide(1rem, $input-btn-font-size-sm) !default;
+$input-btn-line-height-sm: 1rem !default;
 $input-btn-icon-size-sm: 1rem !default;
 
 $input-btn-padding-y: 0.5625rem !default;
@@ -617,9 +617,9 @@ $input-btn-font-size-lg: $h3-font-size !default;
 $input-btn-icon-size-lg: 1.5rem !default;
 
 $input-btn-padding-y-xl: 0.6875rem !default;
-$input-btn-padding-x-xl: 2rem !default;
+$input-btn-padding-x-xl: 1.75rem !default;
 $input-btn-font-size-xl: $h1-font-size !default;
-$input-btn-line-height-xl: divide(2rem, $input-btn-font-size-lg) !default;
+$input-btn-line-height-xl: 2rem !default;
 $input-btn-icon-size-xl: 2rem !default;
 
 

--- a/core/scss/ui/_buttons.scss
+++ b/core/scss/ui/_buttons.scss
@@ -197,8 +197,7 @@
   }
   //[BUG] btn-sm and btn-xl with an icon looks broken
   //issue #2470 fixed
-  min-width: calc(var(--#{$prefix}btn-icon-size) + (var(--#{$prefix}btn-padding-x) * 2));
-  min-height: calc(var(--#{$prefix}btn-icon-size) + (var(--#{$prefix}btn-padding-y) * 2));
+  min-width: calc(var(--#{$prefix}btn-line-height) + (var(--#{$prefix}btn-padding-y) * 2) + (var(--#{$prefix}btn-border-width) * 2));
 }
 
 //


### PR DESCRIPTION
## Fix: Make `.btn-icon` buttons square

Fixed `.btn-icon` buttons not rendering as squares due to different padding values used in `min-width` and `min-height` calculations.

### Changes

- Updated `min-width` calculation to match base `.btn` class formula
- Removed `min-height` override to inherit square dimensions from `.btn`

### Code

```scss
// Before
min-width: calc(var(--#{$prefix}btn-icon-size) + (var(--#{$prefix}btn-padding-x) * 2));
min-height: calc(var(--#{$prefix}btn-icon-size) + (var(--#{$prefix}btn-padding-y) * 2));

// After
min-width: calc(var(--#{$prefix}btn-line-height) + (var(--#{$prefix}btn-padding-y) * 2) + (var(--#{$prefix}btn-border-width) * 2));
// min-height now inherits from .btn class
```
