### PR TITLE
fix: refactor Bootstrap exports for consistency

### DIFF
--- a/.changeset/bootstrap-exports-cleanup.md
+++ b/.changeset/bootstrap-exports-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Refactored Bootstrap exports to use single source of truth in `bootstrap.js` and removed duplicate exports from `tabler.js` for better maintainability.

--- a/core/js/src/bootstrap.js
+++ b/core/js/src/bootstrap.js
@@ -1,3 +1,20 @@
 export * as Popper from '@popperjs/core'
 
-export { Dropdown, Tooltip, Popover, Tab, Toast } from 'bootstrap'
+// Export all Bootstrap components directly for consistent usage
+export {
+  Alert,
+  Button,
+  Carousel,
+  Collapse,
+  Dropdown,
+  Modal,
+  Offcanvas,
+  Popover,
+  ScrollSpy,
+  Tab,
+  Toast,
+  Tooltip
+} from 'bootstrap'
+
+// Re-export everything as namespace for backward compatibility
+export * as bootstrap from 'bootstrap'

--- a/core/js/tabler.js
+++ b/core/js/tabler.js
@@ -9,7 +9,8 @@ import './src/tab'
 import './src/toast'
 import './src/sortable'
 
-export * as bootstrap from 'bootstrap'
-export * as tabler from './src/tabler'
+// Re-export everything from bootstrap.js (single source of truth)
+export * from './src/bootstrap'
 
-export { Alert, Modal, Toast, Tooltip, Tab, Button, Carousel, Collapse, Dropdown, Popover, ScrollSpy, Offcanvas } from 'bootstrap'
+// Re-export tabler namespace
+export * as tabler from './src/tabler'


### PR DESCRIPTION
## Description

This PR refactors Bootstrap exports to eliminate duplication and establish a single source of truth for all Bootstrap component exports. This addresses issue #2541.

## Problem

Previously, Bootstrap components were exported inconsistently across two files:
- `core/js/src/bootstrap.js` - exported only 5 components: `Dropdown`, `Tooltip`, `Popover`, `Tab`, `Toast`
- `core/js/tabler.js` - exported everything as namespace `bootstrap` AND separately exported 12 components

This inconsistency caused confusion about which import style to use (`new Modal()` vs `new bootstrap.Modal()`) and led to issues like #2517.

## Solution

### Changes Made

1. **`core/js/src/bootstrap.js`** - Now serves as the single source of truth:
   - Exports all Bootstrap components directly: `Alert`, `Button`, `Carousel`, `Collapse`, `Dropdown`, `Modal`, `Offcanvas`, `Popover`, `ScrollSpy`, `Tab`, `Toast`, `Tooltip`
   - Re-exports everything as `bootstrap` namespace for backward compatibility

2. **`core/js/tabler.js`** - Simplified:
   - Removed duplicate exports
   - Now re-exports everything from `./src/bootstrap` using `export * from './src/bootstrap'`
   - Maintains `tabler` namespace export

## Related Issues

Closes #2541