### PR TITLE
fix: update dark theme SCSS variables

### DIFF
--- a/.changeset/fix-border-color-translucent-dark.md
+++ b/.changeset/fix-border-color-translucent-dark.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Updated `$border-color-translucent-dark` from `rgba(72, 110, 149, 0.14)` to `rgba(128, 150, 172, 0.2)` to improve visibility of form checkboxes and other form elements in dark mode.

--- a/core/scss/_variables-dark.scss
+++ b/core/scss/_variables-dark.scss
@@ -6,7 +6,7 @@
 $darken-dark: color.adjust($dark, $lightness: -2%) !default;
 $lighten-dark: color.adjust($dark, $lightness: 2%) !default;
 $border-color-dark: color.adjust($dark, $lightness: 8%) !default;
-$border-color-translucent-dark: rgba(72, 110, 149, 0.14) !default;
+$border-color-translucent-dark: rgba(128, 150, 172, 0.2) !default;
 $border-dark-color-dark: color.adjust($dark, $lightness: 4%) !default;
 $border-active-color-dark: color.adjust($dark, $lightness: 12%) !default;
 

--- a/core/scss/ui/forms/_form-check.scss
+++ b/core/scss/ui/forms/_form-check.scss
@@ -83,8 +83,3 @@ Form switch
     padding-top: 0.125rem;
   }
 }
-
-/*Correction of Form-check position*/
-.form-check-input:checked {
-  border: none;
-}


### PR DESCRIPTION
## Description

This PR fixes the visibility issue of form checkboxes (and other form elements) in dark mode by updating the translucent border color variable. This addresses issue #2543.

## Problem

In dark mode, checkboxes inside `.form-fieldset` elements were barely visible or invisible because the translucent border color (`$border-color-translucent-dark`) had insufficient contrast. The previous value `rgba(72, 110, 149, 0.14)` was too dark and transparent, making form elements hard to see against dark backgrounds.
