### PR TITLE
fix: Use CSS variables for status colors and include social colors

### DIFF
--- a/.changeset/fix-status-colors-variables.md
+++ b/.changeset/fix-status-colors-variables.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed status color classes to use CSS variables instead of hardcoded values and include social colors (bitbucket, facebook, etc.) in status class generation.

--- a/core/scss/ui/_status.scss
+++ b/core/scss/ui/_status.scss
@@ -74,10 +74,10 @@
   color: var(--#{$prefix}body-color) !important;
 }
 
-@each $name, $color in $theme-colors {
+@each $name, $color in map.merge($theme-colors, $social-colors) {
   .status-#{$name} {
-    --#{$prefix}status-color: #{$color};
-    --#{$prefix}status-color-rgb: #{to-rgb($color)};
+    --#{$prefix}status-color: var(--#{$prefix}#{$name});
+    --#{$prefix}status-color-rgb: var(--#{$prefix}#{$name}-rgb);
   }
 }
 

--- a/core/scss/ui/_status.scss
+++ b/core/scss/ui/_status.scss
@@ -1,3 +1,5 @@
+@use 'sass:map';
+
 @keyframes status-pulsate-main {
   40% {
     transform: scale(1.25, 1.25);


### PR DESCRIPTION
## Description

This PR fixes two related issues with status color classes:
1. Status classes now use CSS variables instead of hardcoded color values
2. Social colors (bitbucket, facebook, github, etc.) are now included in status class generation

## Problems Fixed

### Issue #2404 - Social status colors broken since v1.2
- `status-bitbucket`, `status-facebook`, `status-github` and other social color classes were not being generated
- This was because the status class generation only iterated over `$theme-colors`, which doesn't include `$social-colors`

### Issue #2434 - Status classes use hardcoded colors
- Classes like `status-primary` used hardcoded color values (`#066fd1`) instead of CSS variables (`--tblr-primary`)
- This prevented status colors from responding to custom theme color changes

Fixes #2404
Fixes #2434