### PR TITLE
fix: Fix white space on left side when scrollbar is present

### DIFF
--- a/.changeset/fix-white-space-scrollbar.md
+++ b/.changeset/fix-white-space-scrollbar.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed white space on left side when scrollbar is present by replacing `margin-inline-start: calc(100vw - 100%)` with `scrollbar-gutter: stable` on `html` element, with `overflow-y: scroll` fallback for unsupported browsers.

--- a/core/scss/layout/_core.scss
+++ b/core/scss/layout/_core.scss
@@ -1,5 +1,13 @@
 @use 'sass:map';
 
+html {
+  scrollbar-gutter: stable;
+
+  @supports not (scrollbar-gutter: stable) {
+    overflow-y: scroll;
+  }
+}
+
 // stylelint-disable property-no-vendor-prefix
 body {
   letter-spacing: $body-letter-spacing;

--- a/core/scss/layout/_root.scss
+++ b/core/scss/layout/_root.scss
@@ -2,11 +2,6 @@
 :host {
   font-size: 16px;
   height: 100%;
-
-  @include media-breakpoint-up(lg) {
-    margin-inline-start: calc(100vw - 100%);
-    margin-inline-end: 0;
-  }
 }
 
 :root,


### PR DESCRIPTION
This PR replaces the problematic `calc(100vw - 100%)` margin approach with the modern CSS `scrollbar-gutter: stable` property, which:

- Reserves space for the scrollbar without showing it when not needed
- Prevents layout shift when scrollbars appear/disappear
- Fixes the white space issue (#2271)
- Maintains the scrollbar visibility fix (#1648)

For browsers that don't support `scrollbar-gutter` (Safari < 16.4), a fallback using `overflow-y: scroll` is provided to always show the scrollbar.

Fixes #2271