### PR TITLE
Remove redundant nullish coalescing operators in popover and tooltip

### DIFF
--- a/.changeset/redundant-nullish-operator.md
+++ b/.changeset/redundant-nullish-operator.md
@@ -1,0 +1,6 @@
+---
+"@tabler/core": patch
+---
+
+Removed redundant nullish coalescing operator from `html` option in popover and tooltip initialization.
+

--- a/core/js/src/popover.js
+++ b/core/js/src/popover.js
@@ -7,7 +7,7 @@ let popoverTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggl
 popoverTriggerList.map(function (popoverTriggerEl) {
   let options = {
     delay: { show: 50, hide: 50 },
-    html: popoverTriggerEl.getAttribute('data-bs-html') === 'true' ?? false,
+    html: popoverTriggerEl.getAttribute('data-bs-html') === 'true',
     placement: popoverTriggerEl.getAttribute('data-bs-placement') ?? 'auto',
   }
   return new Popover(popoverTriggerEl, options)

--- a/core/js/src/tooltip.js
+++ b/core/js/src/tooltip.js
@@ -4,7 +4,7 @@ let tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggl
 tooltipTriggerList.map(function (tooltipTriggerEl) {
   let options = {
     delay: { show: 50, hide: 50 },
-    html: tooltipTriggerEl.getAttribute('data-bs-html') === 'true' ?? false,
+    html: tooltipTriggerEl.getAttribute('data-bs-html') === 'true',
     placement: tooltipTriggerEl.getAttribute('data-bs-placement') ?? 'auto',
   }
   return new Tooltip(tooltipTriggerEl, options)


### PR DESCRIPTION
The left side always returns a boolean value, the ?? operator is not needed.

This was pointed out by the Angular compiler:
<img width="2198" height="372" alt="2025-11-26_11-33-24" src="https://github.com/user-attachments/assets/46822f69-a252-4f39-83c1-4c8f55081dea" />
