### PR TITLE
Fix `.steps` horizontal overflow on mobile

### DIFF
--- a/core/scss/ui/_steps.scss
+++ b/core/scss/ui/_steps.scss
@@ -13,6 +13,17 @@
   margin: 0;
   list-style: none;
 }
+//
+// Steps responsive (mobile)
+//
+@media (max-width: 576px) {
+  .steps {
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
 
 @each $name, $color in $extra-colors {
   .steps-#{$name} {


### PR DESCRIPTION
## Summary

- `.steps` items don't wrap, so on narrow viewports the list overflowed the page horizontally instead of scrolling.
- Replaces the raw `@media (max-width: 576px)` block with Tabler's own `media-breakpoint-down(sm)` mixin, nested inside `.steps` — the same pattern already used in `_forms.scss` for `.form-control`/`.form-select`. This keeps the breakpoint in sync with `$grid-breakpoints` instead of a hardcoded pixel value.
- Below the `sm` breakpoint, `.steps` now scrolls horizontally (`overflow-x: auto`, `-webkit-overflow-scrolling: touch`) instead of overflowing the viewport.

## Preview

- This PR is from a fork branch, so no Vercel preview deploy is available.
- How to test: open `/steps.html`, resize the viewport below 576px width, and confirm `.steps` scrolls horizontally instead of overflowing the page. Above 576px, confirm no extra scroll container is added.

## Notes / rollout

- Closes #2577.
- CSS-only change, no breaking changes.