### PR TITLE
Enhance markdown typography configuration

### DIFF
--- a/.cursor/rules/branch-naming.mdc
+++ b/.cursor/rules/branch-naming.mdc
@@ -1,0 +1,38 @@
+---
+description: Git Branch Naming Rules
+globs:
+alwaysApply: true
+---
+
+## Branch naming
+
+- Use lowercase branch names.
+- Use a type prefix and a short description in kebab-case.
+- Format: `<type>/<short-description>` or `<type>/<issue-id>-<short-description>`
+- Use `gh-123` as the issue id format (avoid `#` in branch names).
+
+### Allowed types
+
+- `feat` - new features
+- `fix` - bug fixes
+- `docs` - documentation changes
+- `chore` - maintenance / tooling
+- `refactor` - code refactoring (no behavior change)
+- `test` - tests only
+- `build` - build system changes
+- `ci` - CI changes
+- `perf` - performance improvements
+- `style` - formatting / lint-only changes
+- `revert` - reverting prior changes
+
+### Examples
+
+- `feat/gh-123-add-stepper-component`
+- `fix/markdown-table-overflow`
+- `docs/gh-45-update-contributing`
+- `chore/update-pnpm-lock`
+
+### Notes
+
+- Branch off `dev` by default (unless maintainers request otherwise).
+- Avoid spaces, uppercase letters, and special characters other than `/` and `-`.

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -495,6 +495,11 @@ $line-heights: (
   h4: $h4-line-height,
   h5: $h5-line-height,
   h6: $h6-line-height,
+
+  base: $line-height-base,
+  sm: $line-height-sm,
+  lg: $line-height-lg,
+  xl: $line-height-xl,
 ) !default;
 
 $display-font-sizes: (

--- a/core/scss/ui/_markdown.scss
+++ b/core/scss/ui/_markdown.scss
@@ -1,8 +1,12 @@
+$markdown-font-size: var(--#{$prefix}font-size-h3) !default;
+$markdown-line-height: var(--#{$prefix}line-height-lg) !default;
+
 /**
 Markdown
  */
 .markdown {
-  line-height: $line-height-xl;
+  line-height: $markdown-line-height;
+  font-size: $markdown-font-size;
 
   > :first-child {
     margin-top: 0;


### PR DESCRIPTION
## Summary
- Make `.markdown` typography configurable via dedicated SCSS variables.
- Add a branch naming guideline for consistent contributor workflows.

## Changes
- Add `$markdown-font-size` and `$markdown-line-height` (defaulting to CSS variables) and use them in `.markdown`.
- Extend `$line-heights` map with `base`, `sm`, `lg`, `xl`.
- Add `.cursor/rules/branch-naming.mdc` describing the branch naming convention.