### PR TITLE
Use `.nvmrc` for Node version in CI workflows

### DIFF
--- a/.changeset/large-needles-sing.md
+++ b/.changeset/large-needles-sing.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Use `.nvmrc` for Node version in CI workflows

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   FORCE_COLOR: 2
-  NODE: 22
 
 jobs:
   bundlewatch:
@@ -33,7 +32,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "${{ env.NODE }}"
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
 
       - name: Set up Bundler

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,9 +3,6 @@ name: Lint
 on:
   pull_request: null
 
-env:
-  NODE: 22
-
 permissions:
   contents: read
 
@@ -22,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "${{ env.NODE }}"
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
 
       - name: Install pnpm dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Install PNPM
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js 18
+      - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "${{ env.NODE }}"
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,6 @@ name: Test build
 on:
   pull_request: null
 
-env:
-  NODE: 22
-
 permissions:
   contents: read
 
@@ -30,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "${{ env.NODE }}"
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
 
       - run: node --version

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -7,9 +7,6 @@ on:
       - main
       - dev
 
-env:
-  NODE: 20
-
 permissions:
   contents: read
 
@@ -34,7 +31,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "${{ env.NODE }}"
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
 
       - name: Install pnpm dependencies


### PR DESCRIPTION
## Summary
- Use `.nvmrc` as the single source of truth for the Node.js version across all GitHub Actions workflows.

## Changes
- Switched `actions/setup-node` to `node-version-file: '.nvmrc'` in all workflows using Node.
- Removed per-workflow `env: NODE` to avoid drift and keep version configuration consistent.