### PR TITLE
Update Dockerfile and docker-compose.yml structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM ruby:3.2-alpine
 
 WORKDIR /app
-ADD _config.yml /app/
-ADD _config_prod.yml /app/
-ADD package.json /app/
-ADD pnpm-lock.yaml /app/
-ADD gulpfile.js /app/
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json README.md LICENSE ./
+
+COPY core/ core/
+COPY preview/ preview/
+COPY docs/ docs/
+COPY shared/ shared/
 
 RUN apk add --virtual build-dependencies build-base npm
 RUN apk upgrade
@@ -15,6 +16,6 @@ RUN pnpm install
 # website
 EXPOSE 3000
 # website management (browser auto reload)
-EXPOSE 3001
+EXPOSE 3010
 # run tabler
 ENTRYPOINT [ "pnpm", "run", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,12 @@
----
-version: "3.3"
 services:
 
   tabler:
     image: tabler
     container_name: tabler
     build: .
+    environment:
+      - NODE_OPTIONS=--no-deprecation
     ports:
       - 3000:3000
-      - 3001:3001
-    volumes:
-      - ./src:/app/src
-      - ./_config.yml:/app/_config.yml
+      - 3010:3010
     tty: true


### PR DESCRIPTION
The Dockerfile and docker-compose.yml have been updated to match the new project structure.
After starting with `docker compose up --build`, the preview is available at http://localhost:3000 and the docs at http://localhost:3010.

Issue: https://github.com/tabler/tabler/issues/2112