### PR TITLE
Fix `.form-select` box-shadow inside `.input-group`

### DIFF
--- a/.changeset/fix-form-select-input-group-shadow.md
+++ b/.changeset/fix-form-select-input-group-shadow.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed `.form-select` keeping its default box-shadow inside `.input-group` by adding it to the existing `.form-control`/`.btn` box-shadow reset.

--- a/core/scss/ui/_forms.scss
+++ b/core/scss/ui/_forms.scss
@@ -169,6 +169,7 @@ Input group
   @include border-radius($input-border-radius);
 
   .form-control,
+  .form-select,
   .btn {
     box-shadow: none;
   }


### PR DESCRIPTION
## Summary

- `.input-group` already resets `box-shadow` to `none` on `.form-control` and `.btn`, so those don't show a stray focus/default shadow when grouped. `.form-select` was missing from that list, so a select inside an input-group kept its own box-shadow, looking inconsistent next to the other grouped controls.
- Added `.form-select` to the existing selector.

## Preview

- Vercel needs a maintainer to authorize this external contributor's deployment first (see the bot comment on this PR). Once authorized: find an `.input-group` containing a `.form-select` (e.g. on the form-elements preview page) and confirm it no longer shows a box-shadow, matching the `.form-control`/`.btn` siblings in the same group.