### PR TITLE
Add `.text-gray-*` utility classes

### DIFF
--- a/.changeset/add-text-gray-utilities.md
+++ b/.changeset/add-text-gray-utilities.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": minor
+---
+
+Added `.text-gray-*` utility classes (`.text-gray-50` through `.text-gray-950`) alongside the existing `.bg-gray-*` and `.text-gray-*-fg` utilities.

--- a/core/scss/utils/_colors.scss
+++ b/core/scss/utils/_colors.scss
@@ -76,6 +76,10 @@
   .text-#{'' + $color}-fg {
     color: var(--#{$prefix}#{$color}-fg) !important;
   }
+
+  .text-#{'' + $color} {
+    color: var(--#{$prefix}#{$color}) !important;
+  }
 }
 
 @each $color, $value in $social-colors {


### PR DESCRIPTION
## Summary

- `$gray-colors` already generated `.bg-gray-*` and `.text-gray-*-fg` utilities, but not the plain `.text-gray-*` color utility that `$theme-colors` has (e.g. `.text-primary`).
- Added `.text-#{$color}` inside the `$gray-colors` loop, so `.text-gray-50` through `.text-gray-950` now work the same way as the theme-color text utilities.

## Preview

- Vercel needs a maintainer to authorize this external contributor's deployment first (see the bot comment on this PR). Once authorized: check any preview page and confirm a class like `text-gray-500` sets the element's text color.