### PR TITLE
Fix `--tblr-gray-*-fg` tokens resolving to white

### DIFF
--- a/.changeset/fix-gray-fg-token-mapping.md
+++ b/.changeset/fix-gray-fg-token-mapping.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed `--tblr-gray-*-fg` token generation to map directly to `--tblr-gray-*` instead of contrast-based fallbacks that could resolve to white.

--- a/core/scss/_props.scss
+++ b/core/scss/_props.scss
@@ -45,7 +45,7 @@
 
   /** Gray colors */
   @each $name, $color in $gray-colors {
-    --#{$prefix}#{$name}-fg: #{if(contrast-ratio($color, white) > $min-contrast-ratio, var(--#{$prefix}white), var(--#{$prefix}body-color))};
+    --#{$prefix}#{$name}-fg: var(--#{$prefix}#{$name});
   }
 
   /** Spacers */

--- a/core/scss/_props.scss
+++ b/core/scss/_props.scss
@@ -45,7 +45,7 @@
 
   /** Gray colors */
   @each $name, $color in $gray-colors {
-    --#{$prefix}#{$name}-fg: #{if(sass(contrast-ratio($color, white) > $min-contrast-ratio): var(--#{$prefix}white); else: var(--#{$prefix}body-color))};
+    --#{$prefix}#{$name}-fg: var(--#{$prefix}#{$name});
   }
 
   /** Spacers */


### PR DESCRIPTION
## Summary

- Stops generating `--tblr-gray-*-fg` with contrast-ratio fallbacks that could resolve to `--tblr-white`.
- Maps each gray foreground token directly to its matching `--tblr-gray-*` custom property (as before the regression).
- Adds a patch changeset for `@tabler/core` ([#2571](https://github.com/tabler/tabler/issues/2571)).

## Preview

- **URL:** [Colors](https://tabler-git-fix-2571-tabler-io.vercel.app/colors.html) · [Docs: colors](https://tabler-git-fix-2571-tabler-io.vercel.app/ui/base/colors/)
- **How to test:** Inspect computed CSS for `--tblr-gray-500-fg` (and other gray `*-fg` vars). They should be `var(--tblr-gray-500)` (etc.), not `var(--tblr-white)`. Spot-check text/icons that use gray foreground tokens for readable color.

## Notes / rollout

- Patch release for `@tabler/core` via changeset.
- Fixes [#2571](https://github.com/tabler/tabler/issues/2571).