### PR TITLE
Fix `.card-header` to respect `--tblr-card-cap-bg`

### DIFF
--- a/.changeset/fix-card-header-cap-bg.md
+++ b/.changeset/fix-card-header-cap-bg.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed `.card-header` background-color to respect the `--tblr-card-cap-bg` CSS variable instead of being silently overridden by a `background: transparent` shorthand.

--- a/core/scss/ui/_cards.scss
+++ b/core/scss/ui/_cards.scss
@@ -218,7 +218,7 @@ Stacked card
   color: inherit;
   display: flex;
   align-items: center;
-  background: transparent;
+  background-color: var(--#{$prefix}card-cap-bg);
 
   &:first-child {
     @include border-radius(var(--#{$prefix}card-border-radius) var(--#{$prefix}card-border-radius) 0 0);


### PR DESCRIPTION
## Summary

- `.card-header` used the shorthand `background: transparent`, which resets all background sub-properties and silently overrode Bootstrap's `background-color: var(--tblr-card-cap-bg)` rule. That made the `--tblr-card-cap-bg` custom property have no visible effect, so consumers couldn't customize the card header background through it.
- Replaced the shorthand with `background-color: var(--#{$prefix}card-cap-bg)`, keeping the same default look while restoring the ability to override it via the variable.

## Preview

- Vercel needs a maintainer to authorize this external contributor's deployment first (see the bot comment on this PR). Once authorized: set `--tblr-card-cap-bg` on a `.card-header` (e.g. via devtools on any cards preview page) and confirm the background now reflects it.

## Notes / rollout

- Closes #2417.