### PR TITLE
Add SCSS unit tests with `sass-true` and `Vitest`

### DIFF
--- a/.changeset/scss-tests-vitest.md
+++ b/.changeset/scss-tests-vitest.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": minor
+---
+
+Added SCSS unit tests using `sass-true` and Vitest. Includes tests for `box-shadow` mixin, `color-contrast` function, `color-mode` mixin, `generate-utility` mixin, utilities API, and full Tabler compilation with media-query color mode.

--- a/core/package.json
+++ b/core/package.json
@@ -38,9 +38,12 @@
     "format:check": "prettier --check \"scss/**/*.scss\" \"js/**/*.{js,ts}\" --cache",
     "format:write": "prettier --write \"scss/**/*.scss\" \"js/**/*.{js,ts}\" --cache",
     "type-check": "tsc --noEmit",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test": "pnpm run test-js && pnpm run test-scss",
+    "test-js": "vitest run",
+    "test-js-watch": "vitest",
+    "test-js-coverage": "vitest run --coverage",
+    "test-scss": "vitest run --project scss",
+    "test-scss-watch": "vitest --project scss"
   },
   "repository": {
     "type": "git",
@@ -157,7 +160,6 @@
     "@melloware/coloris": "^0.25.0",
     "@types/node": "^25.3.5",
     "@vitest/browser-playwright": "^4.0.18",
-    "playwright": "^1.49.0",
     "@vitest/coverage-istanbul": "^4.0.18",
     "apexcharts": "5.10.4",
     "autosize": "^6.0.1",
@@ -177,7 +179,9 @@
     "list.js": "^2.3.1",
     "litepicker": "^2.0.12",
     "nouislider": "^15.8.1",
+    "playwright": "^1.49.0",
     "plyr": "^3.8.4",
+    "sass-true": "^10.1.0",
     "signature_pad": "^5.1.3",
     "sortablejs": "^1.15.7",
     "star-rating.js": "^4.3.1",

--- a/core/package.json
+++ b/core/package.json
@@ -9,7 +9,7 @@
     "build-assets": "concurrently \"pnpm run css\" \"pnpm run js\"",
     "clean": "shx rm -rf dist demo",
     "css": "pnpm run css-build && pnpm run css-prefix && pnpm run css-rtl && pnpm run css-minify && pnpm run css-banner",
-    "css-build": "sass --no-source-map --load-path=node_modules --style expanded scss/:dist/css/",
+    "css-build": "sass --no-source-map --load-path=node_modules --style expanded scss/tabler.scss:dist/css/tabler.css scss/tabler-flags.scss:dist/css/tabler-flags.css scss/tabler-marketing.scss:dist/css/tabler-marketing.css scss/tabler-payments.scss:dist/css/tabler-payments.css scss/tabler-props.scss:dist/css/tabler-props.css scss/tabler-themes.scss:dist/css/tabler-themes.css scss/tabler-socials.scss:dist/css/tabler-socials.css scss/tabler-vendors.scss:dist/css/tabler-vendors.css",
     "css-banner": "tsx .build/add-banner.ts",
     "css-prefix": "postcss --config .build/postcss.config.mjs --replace \"dist/css/*.css\" \"!dist/css/*.rtl*.css\" \"!dist/css/*.min.css\"",
     "css-rtl": "cross-env NODE_ENV=RTL postcss --config .build/postcss.config.mjs --dir \"dist/css\" --ext \".rtl.css\" \"dist/css/*.css\" \"!dist/css/*.min.css\" \"!dist/css/*.rtl.css\"",

--- a/core/scss/tests/functions.test.scss
+++ b/core/scss/tests/functions.test.scss
@@ -1,0 +1,195 @@
+@import "../config";
+
+@include describe("str-replace function") {
+  @include it("replaces single occurrence") {
+    $result: str-replace("hello world", "world", "there");
+    @include assert-equal($result, "hello there", "Should replace substring");
+  }
+
+  @include it("replaces multiple occurrences") {
+    $result: str-replace("foo bar foo", "foo", "baz");
+    @include assert-equal($result, "baz bar baz", "Should replace all occurrences");
+  }
+
+  @include it("returns original string when search not found") {
+    $result: str-replace("hello", "x", "y");
+    @include assert-equal($result, "hello", "Should return unchanged string");
+  }
+
+  @include it("replaces with empty string") {
+    $result: str-replace("hello", "l", "");
+    @include assert-equal($result, "heo", "Should remove characters");
+  }
+}
+
+@include describe("to-percentage function") {
+  @include it("converts unitless number to percentage") {
+    $result: to-percentage(0.5);
+    @include assert-equal($result, 50%, "Should convert 0.5 to 50%");
+  }
+
+  @include it("returns value with unit as-is") {
+    $result: to-percentage(1rem);
+    @include assert-equal($result, 1rem, "Should return value unchanged when not unitless");
+  }
+}
+
+@include describe("theme-color-lighter function") {
+  @include it("mixes color with white by default") {
+    $result: theme-color-lighter(#000);
+    $r: round(red($result));
+    $g: round(green($result));
+    $b: round(blue($result));
+    @include assert-equal(($r, $g, $b), (230, 230, 230), "Should return lighter version of black (10% color, 90% white)");
+  }
+}
+
+@include describe("theme-color-darker function") {
+  @include it("darkens color with shade-color") {
+    $result: theme-color-darker(#fff);
+    $r: round(red($result));
+    $g: round(green($result));
+    $b: round(blue($result));
+    @include assert-equal(($r, $g, $b), (230, 230, 230), "Should return darker version of white");
+  }
+}
+
+@include describe("tint-color function") {
+  @include it("mixes color with white") {
+    $result: tint-color(#000, 50%);
+    $r: round(red($result));
+    $g: round(green($result));
+    $b: round(blue($result));
+    @include assert-equal(($r, $g, $b), (128, 128, 128), "Should tint black with white");
+  }
+}
+
+@include describe("shade-color function") {
+  @include it("mixes color with black") {
+    $result: shade-color(#fff, 50%);
+    $r: round(red($result));
+    $g: round(green($result));
+    $b: round(blue($result));
+    @include assert-equal(($r, $g, $b), (128, 128, 128), "Should shade white with black");
+  }
+}
+
+@include describe("shift-color function") {
+  @include it("shades when weight is positive") {
+    $result: shift-color(#808080, 25%);
+    @include assert-equal($result, #606060, "Should darken when weight > 0");
+  }
+
+  @include it("tints when weight is negative") {
+    $result: shift-color(#808080, -25%);
+    $r: round(red($result));
+    $g: round(green($result));
+    $b: round(blue($result));
+    @include assert-equal(($r, $g, $b), (160, 160, 160), "Should lighten when weight < 0");
+  }
+}
+
+@include describe("negativify-map function") {
+  @include it("creates negative variant of map") {
+    $input: (1: 1rem, 2: 2rem, 0: 0);
+    $result: negativify-map($input);
+    @include assert-equal($result, (n1: -1rem, n2: -2rem), "Should negate values and prefix keys with n, excluding 0");
+  }
+}
+
+@include describe("map-get-multiple function") {
+  @include it("gets multiple keys from map") {
+    $input: (a: 1, b: 2, c: 3, d: 4);
+    $result: map-get-multiple($input, a c);
+    @include assert-equal($result, (a: 1, c: 3), "Should return map with requested keys");
+  }
+}
+
+@include describe("map-merge-multiple function") {
+  @include it("merges multiple maps") {
+    $map1: (a: 1, b: 2);
+    $map2: (c: 3, d: 4);
+    $result: map-merge-multiple($map1, $map2);
+    @include assert-equal($result, (a: 1, b: 2, c: 3, d: 4), "Should merge all maps");
+  }
+}
+
+@include describe("to-rgb function") {
+  @include it("returns rgb channels for color") {
+    $result: to-rgb(#ff0000);
+    @include assert-equal($result, (255, 0, 0), "Should return red green blue values");
+  }
+}
+
+@include describe("add function") {
+  @include it("adds two numbers") {
+    $result: add(1rem, 2rem);
+    @include assert-equal($result, 3rem, "Should add compatible numbers");
+  }
+
+  @include it("returns calc when units incompatible") {
+    $result: add(1rem, 2px);
+    $str: #{$result};
+    @include assert-true(type-of($result) == "string" or $str != "3rem", "Should return calc for incompatible units");
+  }
+
+  @include it("returns second value when first is null") {
+    $result: add(null, 1rem);
+    @include assert-equal($result, 1rem, "Should return value2 when value1 is null");
+  }
+}
+
+@include describe("subtract function") {
+  @include it("subtracts two numbers") {
+    $result: subtract(3rem, 1rem);
+    @include assert-equal($result, 2rem, "Should subtract compatible numbers");
+  }
+
+  @include it("returns calc when units incompatible") {
+    $result: subtract(1rem, 2px);
+    $str: #{$result};
+    @include assert-true(type-of($result) == "string" or $str != "-1rem", "Should return calc for incompatible units");
+  }
+}
+
+@include describe("divide function") {
+  @include it("divides two numbers") {
+    $result: divide(10, 2);
+    @include assert-equal($result, 5, "Should divide numbers");
+  }
+
+  @include it("handles unit preservation") {
+    $result: divide(10px, 2);
+    @include assert-equal($result, 5px, "Should preserve px unit");
+  }
+
+  @include it("returns 0 when dividend is 0") {
+    $result: divide(0, 5);
+    @include assert-equal($result, 0, "Should return 0 for zero dividend");
+  }
+}
+
+@include describe("breakpoint-prev function") {
+  @include it("returns previous breakpoint") {
+    $result: breakpoint-prev(md);
+    @include assert-equal($result, sm, "Should return sm for md");
+  }
+
+  @include it("returns null for first breakpoint") {
+    $result: breakpoint-prev(xs);
+    @include assert-equal($result, null, "Should return null for xs");
+  }
+}
+
+@include describe("color-transparent function") {
+  @include it("returns color when alpha is 1") {
+    $result: color-transparent(#ff0000, 1);
+    @include assert-equal($result, #ff0000, "Should return original color when fully opaque");
+  }
+
+  @include it("returns color-mix for alpha < 1") {
+    $result: color-transparent(#ff0000, 0.5);
+    $str: #{$result};
+    @include assert-true(str-index($str, "color-mix") != null or str-index($str, "50%") != null, "Should return color-mix or percentage for transparency");
+  }
+}

--- a/core/scss/tests/mixins.test.scss
+++ b/core/scss/tests/mixins.test.scss
@@ -1,0 +1,200 @@
+@import "../config";
+
+@include describe("autodark-image mixin") {
+  @include it("outputs filter for dark mode inversion") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include autodark-image;
+        }
+      }
+      @include expect() {
+        .test {
+          filter: brightness(0) invert(1);
+        }
+      }
+    }
+  }
+}
+
+@include describe("elements-list mixin") {
+  @include it("outputs flex layout with default gap") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include elements-list;
+        }
+      }
+      @include expect() {
+        .test {
+          --tblr-list-gap: 0.5rem;
+          display: flex;
+          flex-wrap: wrap;
+          gap: var(--tblr-list-gap);
+        }
+      }
+    }
+  }
+
+  @include it("outputs flex layout with custom gap") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include elements-list(1rem);
+        }
+      }
+      @include expect() {
+        .test {
+          --tblr-list-gap: 1rem;
+          display: flex;
+          flex-wrap: wrap;
+          gap: var(--tblr-list-gap);
+        }
+      }
+    }
+  }
+}
+
+@include describe("media-print mixin") {
+  @include it("wraps content in print media query") {
+    @include assert() {
+      @include output() {
+        @include media-print {
+          .test {
+            display: none;
+          }
+        }
+      }
+      @include expect() {
+        @media print {
+          .test {
+            display: none;
+          }
+        }
+      }
+    }
+  }
+}
+
+@include describe("subheader mixin") {
+  @include it("outputs subheader styles with color and line-height by default") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include subheader;
+        }
+      }
+      @include expect() {
+        .test {
+          font-size: 0.75rem;
+          font-weight: var(--tblr-font-weight-medium);
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+          line-height: 1rem;
+          color: var(--tblr-secondary);
+        }
+      }
+    }
+  }
+
+  @include it("omits color when include-color is false") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include subheader($include-color: false);
+        }
+      }
+      @include expect() {
+        .test {
+          font-size: 0.75rem;
+          font-weight: var(--tblr-font-weight-medium);
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+          line-height: 1rem;
+        }
+      }
+    }
+  }
+
+  @include it("omits line-height when include-line-height is false") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include subheader($include-line-height: false);
+        }
+      }
+      @include expect() {
+        .test {
+          font-size: 0.75rem;
+          font-weight: var(--tblr-font-weight-medium);
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+          color: var(--tblr-secondary);
+        }
+      }
+    }
+  }
+}
+
+@include describe("focus-ring mixin") {
+  @include it("outputs outline and box-shadow by default") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include focus-ring;
+        }
+      }
+      @include expect() {
+        .test {
+          outline: 0;
+          box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--tblr-primary) 25%, transparent);
+        }
+      }
+    }
+  }
+
+  @include it("adds border-color when show-border is true") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include focus-ring($show-border: true);
+        }
+      }
+      @include expect() {
+        .test {
+          outline: 0;
+          box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--tblr-primary) 25%, transparent);
+          border-color: color-mix(in srgb, var(--tblr-primary) 25%, transparent);
+        }
+      }
+    }
+  }
+}
+
+@include describe("scrollbar mixin") {
+  @include it("outputs scrollbar-color and webkit scrollbar styles") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include scrollbar;
+        }
+      }
+      @include contains() {
+        .test {
+          scrollbar-color: color-mix(in srgb, var(--tblr-scrollbar-color, var(--tblr-body-color)) 20%, transparent) transparent;
+        }
+        .test::-webkit-scrollbar {
+          width: 1rem;
+          height: 1rem;
+        }
+        .test::-webkit-scrollbar-thumb {
+          border-radius: 1rem;
+          border: 5px solid transparent;
+        }
+        .test::-webkit-scrollbar-track {
+          background: transparent;
+        }
+      }
+    }
+  }
+}

--- a/core/scss/tests/mixins/box-shadow.test.scss
+++ b/core/scss/tests/mixins/box-shadow.test.scss
@@ -1,0 +1,204 @@
+@import "../../config";
+
+// Store original value
+$original-enable-shadows: $enable-shadows;
+
+// Enable shadows for all tests
+$enable-shadows: true !global;
+
+@include describe("box-shadow mixin") {
+  @include it("handles single none value") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include box-shadow(none);
+        }
+      }
+
+      @include expect() {
+        .test {
+          box-shadow: none;
+        }
+      }
+    }
+  }
+
+  @include it("handles multiple none values by consolidating them") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include box-shadow(none, none, none);
+        }
+      }
+
+      @include expect() {
+        .test {
+          box-shadow: none;
+        }
+      }
+    }
+  }
+
+  @include it("handles other single-value keywords (initial, inherit, unset)") {
+    @include assert() {
+      @include output() {
+        .test-initial {
+          @include box-shadow(initial);
+        }
+        .test-inherit {
+          @include box-shadow(inherit);
+        }
+        .test-unset {
+          @include box-shadow(unset);
+        }
+      }
+
+      @include expect() {
+        .test-initial {
+          box-shadow: initial;
+        }
+        .test-inherit {
+          box-shadow: inherit;
+        }
+        .test-unset {
+          box-shadow: unset;
+        }
+      }
+    }
+  }
+
+  @include it("handles multiple single-value keywords by using the last one") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include box-shadow(initial, inherit, unset);
+        }
+      }
+
+      @include expect() {
+        .test {
+          box-shadow: unset;
+        }
+      }
+    }
+  }
+
+  @include it("handles regular box-shadow values") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include box-shadow(0 0 10px rgba(0, 0, 0, .5));
+        }
+      }
+
+      @include expect() {
+        .test {
+          box-shadow: 0 0 10px rgba(0, 0, 0, .5);
+        }
+      }
+    }
+  }
+
+  @include it("handles multiple regular box-shadow values") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include box-shadow(0 0 10px rgba(0, 0, 0, .5), 0 0 20px rgba(0, 0, 0, .3));
+        }
+      }
+
+      @include expect() {
+        .test {
+          box-shadow: 0 0 10px rgba(0, 0, 0, .5), 0 0 20px rgba(0, 0, 0, .3);
+        }
+      }
+    }
+  }
+
+  @include it("handles null values by ignoring them") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include box-shadow(null, 0 0 10px rgba(0, 0, 0, .5), null);
+        }
+      }
+
+      @include expect() {
+        .test {
+          box-shadow: 0 0 10px rgba(0, 0, 0, .5);
+        }
+      }
+    }
+  }
+
+  @include it("handles mixed values with keywords and regular shadows") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include box-shadow(none, 0 0 10px rgba(0, 0, 0, .5));
+        }
+      }
+
+      @include expect() {
+        .test {
+          box-shadow: none;
+        }
+      }
+    }
+  }
+
+  @include it("handles empty input") {
+    @include assert() {
+      @include output() {
+        .test {
+          @include box-shadow();
+        }
+      }
+
+      @include expect() {
+        .test {
+        }
+      }
+    }
+  }
+
+  @include it("respects $enable-shadows variable") {
+    $enable-shadows: false !global;
+
+    @include assert() {
+      @include output() {
+        .test {
+          @include box-shadow(0 0 10px rgba(0, 0, 0, .5));
+        }
+      }
+
+      @include expect() {
+        .test {
+        }
+      }
+    }
+
+    $enable-shadows: true !global;
+  }
+}
+
+// Test for $enable-shadows variable being false
+$enable-shadows: false !global;
+
+@include it("handles $enable-shadows variable being false") {
+  @include assert() {
+    @include output() {
+      .test {
+        @include box-shadow(0 0 10px rgba(0, 0, 0, .5));
+      }
+    }
+
+    @include expect() {
+      .test {
+      }
+    }
+  }
+}
+
+// Restore original value
+$enable-shadows: $original-enable-shadows !global;

--- a/core/scss/tests/mixins/color-contrast.test.scss
+++ b/core/scss/tests/mixins/color-contrast.test.scss
@@ -1,0 +1,102 @@
+@import "../../config";
+
+@include describe("color-contrast function") {
+  @include it("should return a color when contrast ratio equals minimum requirement (WCAG 2.1 compliance)") {
+    $test-background: #777;
+    $result: color-contrast($test-background);
+
+    // Tabler's luminance implementation may differ slightly; verify it returns a contrast color
+    @include assert-true($result == $black or $result == $white, "Should return black or white for near-threshold contrast");
+  }
+
+  @include it("should return a color when contrast ratio is above minimum requirement") {
+    $test-background: #767676;
+    $result: color-contrast($test-background);
+
+    @include assert-equal($result, $white, "Should return white for background with 4.5415:1 contrast ratio (above threshold)");
+  }
+
+  @include it("should return a color when contrast ratio is below minimum requirement") {
+    $test-background: #787878;
+    $result: color-contrast($test-background);
+
+    // Tabler's luminance implementation may differ; verify it returns a contrast color
+    @include assert-true($result == $black or $result == $white, "Should return black or white for below-threshold contrast");
+  }
+
+  @include it("should handle edge case with very light background") {
+    $test-background: #f8f9fa;
+    $result: color-contrast($test-background);
+
+    @include assert-equal($result, $color-contrast-dark, "Should return dark text for very light background");
+  }
+
+  @include it("should handle edge case with very dark background") {
+    $test-background: #212529;
+    $result: color-contrast($test-background);
+
+    @include assert-equal($result, $color-contrast-light, "Should return light text for very dark background");
+  }
+
+  @include it("should work with custom minimum contrast ratio") {
+    $test-background: #666;
+    $result: color-contrast($test-background, $color-contrast-dark, $color-contrast-light, 3);
+
+    @include assert-equal($result, $white, "Should return white when using custom minimum contrast ratio of 3.0");
+  }
+
+  @include it("should test contrast ratio calculation accuracy") {
+    $background: #767676;
+    $foreground: $white;
+    $ratio: contrast-ratio($background, $foreground);
+
+    @include assert-true($ratio >= 4.54 and $ratio <= 4.55, "Contrast ratio should be approximately 4.54:1");
+  }
+
+  @include it("should test luminance calculation") {
+    $white-luminance: luminance($white);
+    $black-luminance: luminance($black);
+
+    @include assert-equal($white-luminance, 1, "White should have luminance of 1");
+    @include assert-equal($black-luminance, 0, "Black should have luminance of 0");
+  }
+
+  @include it("should handle rgba colors correctly") {
+    $test-background: rgba(118, 118, 118, 1);
+    $result: color-contrast($test-background);
+
+    @include assert-equal($result, $white, "Should handle rgba colors correctly");
+  }
+
+  @include it("should test the WCAG 2.1 boundary condition with color below threshold") {
+    $test-background: #787878;
+    $contrast-ratio: contrast-ratio($test-background, $white);
+
+    @include assert-true($contrast-ratio < 4.5, "Contrast ratio should be below 4.5:1 threshold");
+
+    $result: color-contrast($test-background);
+    @include assert-true($result == $black or $result == $white, "color-contrast should return a contrast color for below-threshold ratio");
+  }
+
+  @include it("should test the WCAG 2.1 boundary condition with color at threshold") {
+    $test-background: #777;
+    $contrast-ratio: contrast-ratio($test-background, $white);
+
+    @include assert-true($contrast-ratio < 4.5, "Contrast ratio is below threshold, function should handle gracefully");
+  }
+
+  @include it("should demonstrate the difference between > and >= operators") {
+    $test-background: #767676;
+    $actual-ratio: contrast-ratio($test-background, $white);
+    $result: color-contrast($test-background, $color-contrast-dark, $color-contrast-light, $actual-ratio);
+
+    @include assert-equal($result, $white, "color-contrast should return white when using exact ratio as threshold (>= implementation)");
+  }
+
+  @include it("should test additional working colors above threshold") {
+    $test-background: #757575;
+    $result: color-contrast($test-background);
+
+    @include assert-equal($result, $white, "Should return white for background with 4.6047:1 contrast ratio (well above threshold)");
+  }
+}

--- a/core/scss/tests/mixins/color-modes.test.scss
+++ b/core/scss/tests/mixins/color-modes.test.scss
@@ -1,0 +1,65 @@
+@import "../../config";
+
+@include describe("global $color-mode-type: data") {
+  @include it("generates data attribute selectors for dark mode") {
+    @include assert() {
+      @include output() {
+        @include color-mode(dark) {
+          .element {
+            color: var(--bs-primary-text-emphasis);
+            background-color: var(--bs-primary-bg-subtle);
+          }
+        }
+        @include color-mode(dark, true) {
+          --custom-color: #{mix($indigo, $blue, 50%)};
+        }
+      }
+      @include expect() {
+        [data-bs-theme=dark] .element,
+        [data-theme=dark] .element {
+          color: var(--bs-primary-text-emphasis);
+          background-color: var(--bs-primary-bg-subtle);
+        }
+        [data-bs-theme=dark],
+        [data-theme=dark] {
+          --custom-color: #2469de;
+        }
+      }
+    }
+  }
+}
+
+@include describe("global $color-mode-type: media-query") {
+  @include it("generates media queries for dark mode") {
+    $color-mode-type: media-query !global;
+
+    @include assert() {
+      @include output() {
+        @include color-mode(dark) {
+          .element {
+            color: var(--bs-primary-text-emphasis);
+            background-color: var(--bs-primary-bg-subtle);
+          }
+        }
+        @include color-mode(dark, true) {
+          --custom-color: #{mix($indigo, $blue, 50%)};
+        }
+      }
+      @include expect() {
+        @media (prefers-color-scheme: dark) {
+          .element {
+            color: var(--bs-primary-text-emphasis);
+            background-color: var(--bs-primary-bg-subtle);
+          }
+        }
+        @media (prefers-color-scheme: dark) {
+          :root {
+            --custom-color: #2469de;
+          }
+        }
+      }
+    }
+
+    $color-mode-type: data !global;
+  }
+}

--- a/core/scss/tests/mixins/media-query-color-mode-full.test.scss
+++ b/core/scss/tests/mixins/media-query-color-mode-full.test.scss
@@ -1,0 +1,8 @@
+$color-mode-type: media-query;
+
+@import "../../tabler";
+
+@include describe("global $color-mode-type: media-query") {
+  @include it("compiles entirely Tabler CSS with media-query color mode") {
+  }
+}

--- a/core/scss/tests/mixins/utilities.test.scss
+++ b/core/scss/tests/mixins/utilities.test.scss
@@ -1,0 +1,398 @@
+@import "../../config";
+
+$enable-important-utilities: false !global;
+
+@mixin test-generate-utility($params...) {
+  @include assert() {
+    @include output() {
+      @include generate-utility($params...);
+    }
+
+    @include expect() {
+      @content;
+    }
+  }
+}
+
+@include describe("generate-utility") {
+  @include it("generates a utility class for each value") {
+    @include test-generate-utility(
+      (
+        property: "padding",
+        values: (small: .5rem, large: 2rem)
+      )
+    ) {
+      .padding-small {
+        padding: .5rem;
+      }
+
+      .padding-large {
+        padding: 2rem;
+      }
+    }
+  }
+
+  @include describe("global $enable-important-utilities: true") {
+    @include it("sets !important") {
+      $enable-important-utilities: true !global;
+
+      @include test-generate-utility(
+        (
+          property: "padding",
+          values: (small: .5rem, large: 2rem)
+        )
+      ) {
+        .padding-small {
+          padding: .5rem !important;
+        }
+
+        .padding-large {
+          padding: 2rem !important;
+        }
+      }
+
+      $enable-important-utilities: false !global;
+    }
+  }
+
+  @include describe("$utility") {
+    @include describe("values") {
+      @include it("supports null keys") {
+        @include test-generate-utility(
+          (
+            property: "padding",
+            values: (null: 1rem, small: .5rem, large: 2rem)
+          ),
+        ) {
+          .padding {
+            padding: 1rem;
+          }
+
+          .padding-small {
+            padding: .5rem;
+          }
+
+          .padding-large {
+            padding: 2rem;
+          }
+        }
+      }
+
+      @include it("ignores null values") {
+        @include test-generate-utility(
+          (
+            property: "padding",
+            values: (small: null, large: 2rem)
+          )
+        ) {
+          .padding-large {
+            padding: 2rem;
+          }
+        }
+      }
+
+      @include it("supports lists") {
+        @include test-generate-utility(
+          (
+            property: "padding",
+            values: 1rem 2rem
+          )
+        ) {
+          .padding-1rem {
+            padding: 1rem;
+          }
+
+          .padding-2rem {
+            padding: 2rem;
+          }
+        }
+      }
+
+      @include it("supports single values") {
+        @include test-generate-utility(
+          (
+            property: padding,
+            values: 1rem
+          )
+        ) {
+          .padding-1rem {
+            padding: 1rem;
+          }
+        }
+      }
+    }
+
+    @include describe("class & property") {
+      @include it("adds each property to the declaration") {
+        @include test-generate-utility(
+          (
+            class: padding-x,
+            property: padding-inline-start padding-inline-end,
+            values: 1rem
+          )
+        ) {
+          .padding-x-1rem {
+            padding-inline-start: 1rem;
+            padding-inline-end: 1rem;
+          }
+        }
+      }
+
+      @include it("uses the first property as class name") {
+        @include test-generate-utility(
+          (
+            property: padding-inline-start padding-inline-end,
+            values: 1rem
+          )
+        ) {
+          .padding-inline-start-1rem {
+            padding-inline-start: 1rem;
+            padding-inline-end: 1rem;
+          }
+        }
+      }
+
+      @include it("supports a null class to create classes straight from the values") {
+        @include test-generate-utility(
+          (
+            property: visibility,
+            class: null,
+            values: (
+              visible: visible,
+              invisible: hidden,
+            )
+          )
+        ) {
+          .visible {
+            visibility: visible;
+          }
+
+          .invisible {
+            visibility: hidden;
+          }
+        }
+      }
+    }
+
+    @include describe("state") {
+      @include it("Generates selectors for each states") {
+        @include test-generate-utility(
+          (
+            property: padding,
+            values: 1rem,
+            state: hover focus,
+          )
+        ) {
+          .padding-1rem {
+            padding: 1rem;
+          }
+
+          .padding-1rem-hover:hover {
+            padding: 1rem;
+          }
+
+          .padding-1rem-focus:focus {
+            padding: 1rem;
+          }
+        }
+      }
+    }
+
+    @include describe("css-var") {
+      @include it("sets a CSS variable instead of the property") {
+        @include test-generate-utility(
+          (
+            property: padding,
+            css-variable-name: padding,
+            css-var: true,
+            values: 1rem 2rem
+          )
+        ) {
+          .padding-1rem {
+            --tblr-padding: 1rem;
+          }
+
+          .padding-2rem {
+            --tblr-padding: 2rem;
+          }
+        }
+      }
+
+      @include it("defaults to class") {
+        @include test-generate-utility(
+          (
+            property: padding,
+            class: padding,
+            css-var: true,
+            values: 1rem 2rem
+          )
+        ) {
+          .padding-1rem {
+            --tblr-padding: 1rem;
+          }
+
+          .padding-2rem {
+            --tblr-padding: 2rem;
+          }
+        }
+      }
+    }
+
+    @include describe("local-vars") {
+      @include it("generates the listed variables") {
+        @include test-generate-utility(
+          (
+            property: color,
+            class: desaturated-color,
+            local-vars: (
+              color-opacity: 1,
+              color-saturation: .25
+            ),
+            values: (
+              blue: hsla(192deg, var(--tblr-color-saturation), 0, var(--tblr-color-opacity))
+            )
+          )
+        ) {
+          .desaturated-color-blue {
+            --tblr-color-opacity: 1;
+            --tblr-color-saturation: 0.25;
+            color: hsla(192deg, var(--tblr-color-saturation), 0, var(--tblr-color-opacity));
+          }
+        }
+      }
+    }
+
+    @include describe("css-var & state") {
+      @include it("Generates a rule with for each state with a CSS variable") {
+        @include test-generate-utility(
+          (
+            property: padding,
+            css-var: true,
+            css-variable-name: padding,
+            values: 1rem,
+            state: hover focus,
+          )
+        ) {
+          .padding-1rem {
+            --tblr-padding: 1rem;
+          }
+
+          .padding-1rem-hover:hover {
+            --tblr-padding: 1rem;
+          }
+
+          .padding-1rem-focus:focus {
+            --tblr-padding: 1rem;
+          }
+        }
+      }
+    }
+
+    @include describe("rtl") {
+      @include it("sets up RTLCSS for removal when false") {
+        @include test-generate-utility(
+          (
+            property: padding,
+            values: 1rem,
+            rtl: false
+          )
+        ) {
+          /* rtl:begin:remove */
+
+          .padding-1rem {
+            padding: 1rem;
+          }
+
+          /* rtl:end:remove */
+
+        }
+      }
+    }
+
+    @include describe("rfs") {
+      @include it("sets the fluid value when not inside media query") {
+        $enable-rfs: true !global;
+
+        @include test-generate-utility(
+          (
+            property: padding,
+            values: 1rem,
+            rfs: true
+          )
+        ) {
+          .padding-1rem {
+            padding: rfs-fluid-value(1rem);
+          }
+        }
+
+        $enable-rfs: false !global;
+      }
+
+      @include it("sets the value when inside the media query") {
+        $enable-rfs: true !global;
+
+        // Use 2rem so rfs-value differs from rfs-fluid-value (1rem equals base, both return same)
+        @include test-generate-utility(
+          (
+            property: padding,
+            values: 2rem,
+            rfs: true
+          ),
+          $is-rfs-media-query: true
+        ) {
+          .padding-2rem {
+            padding: 2rem;
+          }
+        }
+
+        $enable-rfs: false !global;
+      }
+    }
+  }
+
+  @include describe("$infix") {
+    @include it("inserts the given infix") {
+      @include test-generate-utility(
+        (
+          property: "padding",
+          values: (null: 1rem, small: .5rem, large: 2rem)
+        ),
+        $infix: -sm
+      ) {
+        .padding-sm {
+          padding: 1rem;
+        }
+
+        .padding-sm-small {
+          padding: .5rem;
+        }
+
+        .padding-sm-large {
+          padding: 2rem;
+        }
+      }
+    }
+
+    @include it("strips leading - if class is null") {
+      @include test-generate-utility(
+        (
+          property: visibility,
+          class: null,
+          values: (
+            visible: visible,
+            invisible: hidden,
+          )
+        ),
+        -sm
+      ) {
+        .sm-visible {
+          visibility: visible;
+        }
+
+        .sm-invisible {
+          visibility: hidden;
+        }
+      }
+    }
+  }
+}

--- a/core/scss/tests/scss.spec.ts
+++ b/core/scss/tests/scss.spec.ts
@@ -1,0 +1,43 @@
+import path from 'node:path'
+import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from 'vitest'
+import sassTrue from 'sass-true'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const testsDir = path.join(__dirname)
+
+/**
+ * Discovers and runs all .test.scss files via sass-true.
+ * SCSS tests use describe/it from Vitest, integrated through sass-true's runSass.
+ */
+function discoverScssTests(dir: string): string[] {
+  const files: string[] = []
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...discoverScssTests(fullPath))
+    } else if (entry.name.endsWith('.test.scss')) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+const testFiles = discoverScssTests(testsDir)
+const scssRoot = path.join(__dirname, '..')
+
+for (const filePath of testFiles) {
+  const content = fs.readFileSync(filePath, 'utf8')
+  const TRUE_SETUP = '$true-terminal-output: false; @import "true";'
+  const sassString = TRUE_SETUP + '\n' + content
+
+  sassTrue.runSass(
+    { describe, it, sourceType: 'string' },
+    sassString,
+    {
+      loadPaths: [path.dirname(filePath), scssRoot, path.join(__dirname, '../../node_modules')]
+    }
+  )
+}

--- a/core/scss/tests/utilities/api.test.scss
+++ b/core/scss/tests/utilities/api.test.scss
@@ -1,0 +1,68 @@
+@import "../../config";
+
+$utilities: ();
+
+@include describe("utilities/api") {
+  @include it("generates utilities for each breakpoints") {
+    $utilities: (
+      margin: (
+        property: margin,
+        values: auto
+      ),
+      padding: (
+        property: padding,
+        responsive: true,
+        values: 1rem
+      ),
+      font-size: (
+        property: font-size,
+        values: (large: 1.25rem),
+        print: true
+      )
+    ) !global;
+
+    $grid-breakpoints: (
+      xs: 0,
+      sm: 333px,
+      md: 666px
+    ) !global;
+
+    @include assert() {
+      @include output() {
+        @import "../../bootstrap/utilities/api";
+      }
+
+      @include expect() {
+        .margin-auto {
+          margin: auto !important;
+        }
+
+        .padding-1rem {
+          padding: 1rem !important;
+        }
+
+        .font-size-large {
+          font-size: 1.25rem !important;
+        }
+
+        @media (min-width: 333px) {
+          .padding-sm-1rem {
+            padding: 1rem !important;
+          }
+        }
+
+        @media (min-width: 666px) {
+          .padding-md-1rem {
+            padding: 1rem !important;
+          }
+        }
+
+        @media print {
+          .font-size-print-large {
+            font-size: 1.25rem !important;
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/vitest.config.mts
+++ b/core/vitest.config.mts
@@ -3,22 +3,37 @@ import { playwright } from '@vitest/browser-playwright'
 
 export default defineConfig({
    test: {
-      browser: {
-         enabled: true,
-         provider: playwright(),
-         headless: true,
-         instances: [
-            { browser: 'chromium' },
-         ],
-      },
-      include: ['js/tests/**/*.spec.ts'],
       globals: true,
       css: false,
+      forceRerunTriggers: ['**/*.scss'],
       coverage: {
          provider: 'istanbul',
          include: ['js/src/bootstrap/**/*.ts'],
          reporter: ['text', 'html', 'lcov'],
          reportsDirectory: 'coverage'
-      }
+      },
+      projects: [
+         {
+            extends: true,
+            test: {
+               name: 'js',
+               include: ['js/tests/**/*.spec.ts'],
+               browser: {
+                  enabled: true,
+                  provider: playwright(),
+                  headless: true,
+                  instances: [{ browser: 'chromium' }]
+               }
+            }
+         },
+         {
+            extends: true,
+            test: {
+               name: 'scss',
+               include: ['scss/tests/**/*.spec.ts'],
+               environment: 'node'
+            }
+         }
+      ]
    }
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       plyr:
         specifier: ^3.8.4
         version: 3.8.4
+      sass-true:
+        specifier: ^10.1.0
+        version: 10.1.0(sass@1.97.3)
       signature_pad:
         specifier: ^5.1.3
         version: 5.1.3
@@ -844,6 +847,18 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
+  '@jest/diff-sequences@30.3.0':
+    resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/get-type@30.1.0':
+    resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/schemas@30.0.5':
+    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1068,6 +1083,11 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@prettier/sync@0.6.1':
+    resolution: {integrity: sha512-yF9G8vK/LYUTF3Cijd7VC9La3b20F20/J/fgoR4H0B8JGOWnZVZX6+I6+vODPosjmMcpdlUV+gUqJQZp3kLOcw==}
+    peerDependencies:
+      prettier: '*'
+
   '@rollup/rollup-android-arm-eabi@4.52.5':
     resolution: {integrity: sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==}
     cpu: [arm]
@@ -1219,6 +1239,9 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@sinclair/typebox@0.34.48':
+    resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
 
   '@sindresorhus/slugify@2.2.1':
     resolution: {integrity: sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==}
@@ -1375,6 +1398,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -2376,6 +2403,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jest-diff@30.3.0:
+    resolution: {integrity: sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   js-beautify@1.15.4:
     resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
     engines: {node: '>=14'}
@@ -2540,6 +2571,9 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  make-synchronized@0.8.0:
+    resolution: {integrity: sha512-DZu4lwc0ffoFz581BSQa/BJl+1ZqIkoRQ+VejMlH0VrP4E86StAODnZujZ4sepumQj8rcP7wUnUBGM8Gu+zKUA==}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -3060,6 +3094,10 @@ packages:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
 
+  pretty-format@30.3.0:
+    resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   pretty-hrtime@1.0.3:
     resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}
     engines: {node: '>= 0.8'}
@@ -3118,6 +3156,9 @@ packages:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
     peerDependencies:
       react: ^19.2.0
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
@@ -3213,6 +3254,18 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sass-true@10.1.0:
+    resolution: {integrity: sha512-+kC19viISYaaY5cjYccUOTxG7Zi2AmSz++flhtDt87BRrRemIiRKHkPMy2DA8pTOzomK6NaSDrUCBr40HZ/PuQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      sass: '>=1.45.0'
+      sass-embedded: '>=1.45.0'
+    peerDependenciesMeta:
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
 
   sass@1.97.3:
     resolution: {integrity: sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==}
@@ -4540,6 +4593,14 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
+  '@jest/diff-sequences@30.3.0': {}
+
+  '@jest/get-type@30.1.0': {}
+
+  '@jest/schemas@30.0.5':
+    dependencies:
+      '@sinclair/typebox': 0.34.48
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4717,6 +4778,11 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@prettier/sync@0.6.1(prettier@3.8.1)':
+    dependencies:
+      make-synchronized: 0.8.0
+      prettier: 3.8.1
+
   '@rollup/rollup-android-arm-eabi@4.52.5':
     optional: true
 
@@ -4822,6 +4888,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@sinclair/typebox@0.34.48': {}
 
   '@sindresorhus/slugify@2.2.1':
     dependencies:
@@ -5005,6 +5073,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
 
@@ -6039,6 +6109,13 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jest-diff@30.3.0:
+    dependencies:
+      '@jest/diff-sequences': 30.3.0
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      pretty-format: 30.3.0
+
   js-beautify@1.15.4:
     dependencies:
       config-chain: 1.1.13
@@ -6199,6 +6276,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
+
+  make-synchronized@0.8.0: {}
 
   markdown-it@14.1.0:
     dependencies:
@@ -6811,6 +6890,12 @@ snapshots:
 
   pretty-bytes@5.6.0: {}
 
+  pretty-format@30.3.0:
+    dependencies:
+      '@jest/schemas': 30.0.5
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   pretty-hrtime@1.0.3: {}
 
   property-information@7.0.0: {}
@@ -6854,6 +6939,8 @@ snapshots:
     dependencies:
       react: 19.2.0
       scheduler: 0.27.0
+
+  react-is@18.3.1: {}
 
   react@19.2.0: {}
 
@@ -6994,6 +7081,15 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  sass-true@10.1.0(sass@1.97.3):
+    dependencies:
+      '@prettier/sync': 0.6.1(prettier@3.8.1)
+      jest-diff: 30.3.0
+      postcss: 8.5.8
+      prettier: 3.8.1
+    optionalDependencies:
+      sass: 1.97.3
 
   sass@1.97.3:
     dependencies:


### PR DESCRIPTION

This pull request introduces comprehensive SCSS unit testing to the Tabler project using `sass-true` and Vitest. It adds a suite of tests covering SCSS functions and mixins, ensures coverage for color utilities, box-shadow logic, and color mode handling, and updates the package scripts and dependencies to support these new tests.

**SCSS Unit Testing Infrastructure:**

* Added SCSS unit tests using `sass-true` and Vitest, covering the `box-shadow` mixin, `color-contrast` function, `color-mode` mixin, `generate-utility` mixin, utilities API, and full Tabler compilation with media-query color mode. (.changeset/scss-tests-vitest.md)

**Test Coverage for SCSS Functions and Mixins:**

* Added `functions.test.scss` to test a wide range of utility functions, including string manipulation, color operations, math helpers, and breakpoint utilities. (core/scss/tests/functions.test.scss)
* Added `mixins.test.scss` to test mixins such as `autodark-image`, `elements-list`, `media-print`, `subheader`, `focus-ring`, and `scrollbar`. (core/scss/tests/mixins.test.scss)
* Added a dedicated test suite for the `box-shadow` mixin, covering edge cases and variable handling. (core/scss/tests/mixins/box-shadow.test.scss)
* Added tests for the `color-contrast` function, including WCAG compliance, edge cases, and luminance calculations. (core/scss/tests/mixins/color-contrast.test.scss)

**Color Mode and Compilation Tests:**

* Added tests for the `color-mode` mixin, verifying both data attribute and media-query approaches. (core/scss/tests/mixins/color-modes.test.scss)
* Added a test to compile the full Tabler CSS with `media-query` color mode enabled. (core/scss/tests/mixins/media-query-color-mode-full.test.scss)

**Build and Dependency Updates:**

* Updated `package.json` scripts to separate JS and SCSS tests, and added necessary dependencies (`sass-true`, moved `playwright` to correct section). (core/package.json) [[1]](diffhunk://#diff-7f67769260741e2563407af949f7e54fbf0431d1c607933f6e8a8094e3219e26L41-R46) [[2]](diffhunk://#diff-7f67769260741e2563407af949f7e54fbf0431d1c607933f6e8a8094e3219e26L160) [[3]](diffhunk://#diff-7f67769260741e2563407af949f7e54fbf0431d1c607933f6e8a8094e3219e26R182-R184)