### PR TITLE
fix: inverted-plus accordion not working with SVG sprite icons

### DIFF
--- a/core/scss/ui/_accordion.scss
+++ b/core/scss/ui/_accordion.scss
@@ -96,9 +96,15 @@
 }
 
 .accordion-button-toggle-plus {
+  .icon,
+  svg {
+    transition: transform 0.2s ease;
+  }
+
   .accordion-button:not(.collapsed) & {
-    path:first-child {
-      opacity: 0;
+    .icon,
+    svg {
+      transform: rotate(45deg);
     }
   }
 }


### PR DESCRIPTION
The inverted-plus accordion toggle relies on targeting internal SVG <path> elements,
which does not work when using SVG sprites (<use>).

This fix replaces path-based manipulation with transform-based rotation,
ensuring compatibility with both inline SVG and sprite icons.