### PR TITLE
[BUG] Alerts with icons (in docs) spacing issue #2307

### DIFF
--- a/docs/content/ui/components/alert.md
+++ b/docs/content/ui/components/alert.md
@@ -51,33 +51,32 @@ Use the `alert-icon` class on an `<svg>` (or on an `<i>` when using the webfont)
 
 {% capture html -%}
 <div class="alert alert-success" role="alert">
-  <div class="d-flex">
-    <div>
+   <div class="alert-icon">
+      <!-- Download SVG icon from http://tabler.io/icons/icon/check -->
       <svg
-        xmlns="http://www.w3.org/2000/svg"
-        class="icon alert-icon"
-        width="24"
-        height="24"
-        viewBox="0 0 24 24"
-        stroke-width="2"
-        stroke="currentColor"
-        fill="none"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-        <path d="M5 12l5 5l10 -10" />
+         xmlns="http://www.w3.org/2000/svg"
+         class="icon alert-icon"
+         width="24"
+         height="24"
+         viewBox="0 0 24 24"
+         stroke-width="2"
+         stroke="currentColor"
+         fill="none"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         >
+         <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+         <path d="M5 12l5 5l10 -10" />
       </svg>
-    </div>
-    <div>
+   </div>
+   <div>
       <h4 class="alert-title">Wow! Everything worked!</h4>
       <div class="text-secondary">Your account has been saved!</div>
-    </div>
-  </div>
+   </div>
 </div>
 <div class="alert alert-info" role="alert">
-  <div class="d-flex">
-    <div>
+  <div class="alert-icon">
+      <!-- Download SVG icon from http://tabler.io/icons/icon/info-circle -->
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="icon alert-icon"
@@ -100,11 +99,10 @@ Use the `alert-icon` class on an `<svg>` (or on an `<i>` when using the webfont)
       <h4 class="alert-title">Did you know?</h4>
       <div class="text-secondary">Here is something that you might like to know.</div>
     </div>
-  </div>
 </div>
 <div class="alert alert-warning" role="alert">
-  <div class="d-flex">
-    <div>
+  <div class="alert-icon">
+      <!-- Download SVG icon from http://tabler.io/icons/icon/alert-triangle -->
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="icon alert-icon"
@@ -128,11 +126,10 @@ Use the `alert-icon` class on an `<svg>` (or on an `<i>` when using the webfont)
       <h4 class="alert-title">Uh oh, something went wrong</h4>
       <div class="text-secondary">Sorry! There was a problem with your request.</div>
     </div>
-  </div>
 </div>
 <div class="alert alert-danger" role="alert">
-  <div class="d-flex">
-    <div>
+  <div class="alert-icon">
+      <!-- Download SVG icon from http://tabler.io/icons/icon/alert-circle -->
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="icon alert-icon"
@@ -155,7 +152,6 @@ Use the `alert-icon` class on an `<svg>` (or on an `<i>` when using the webfont)
       <h4 class="alert-title">I'm so sorry&hellip;</h4>
       <div class="text-secondary">Your account has been deleted and can't be restored.</div>
     </div>
-  </div>
 </div>
 {%- endcapture %}
 {% include "docs/example.html" html=html %}


### PR DESCRIPTION
**This pull request makes the following changes:**

*Fixes issue #2307 

The alert examples in the "Alerts with icons" section were missing the intended visual spacing (gap) between the icon and the content.

Changes:

- Restructured Alert HTML: Removed the redundant d-flex wrapper inside the alert components.
- Renamed Classes: Renamed the wrapper from d-flex to alert-icon to align with Tabler's standard markup.
- Flattened DOM Hierarchy: By removing the extra nesting level, the icon and text content are now direct children of the alert container.

Why this approach?

Tabler alerts use Flexbox on the parent container to manage spacing via the gap property. The previous nesting prevented this gap from affecting the icons. Instead of introducing utility classes to fix the symptoms, this change restores the originally intended structure. This ensures the design is consistent with the "Default markup" and maintains long-term maintainability.