### PR TITLE
Add drag and drop to the Tasks board

### DIFF
--- a/core/scss/_core.scss
+++ b/core/scss/_core.scss
@@ -96,6 +96,7 @@
 @import 'ui/chat';
 @import 'ui/signature';
 @import 'ui/patterns';
+@import 'ui/sortable';
 
 @import 'helpers/index';
 

--- a/core/scss/ui/_sortable.scss
+++ b/core/scss/ui/_sortable.scss
@@ -1,0 +1,13 @@
+// Sortable
+// Cursor affordances for elements made draggable via [data-sortable]
+
+[data-sortable] > * {
+  cursor: grab;
+}
+
+[data-sortable] > *:active,
+.sortable-chosen,
+.sortable-drag,
+.sortable-fallback {
+  cursor: grabbing;
+}

--- a/preview/pages/tasks.html
+++ b/preview/pages/tasks.html
@@ -2,6 +2,7 @@
 title: Tasks
 page-header: Tabler Inc. Tasks
 page-header-actions: add-board
+page-libs: [sortablejs]
 page-menu: extra.tasks.kanban
 layout: default
 permalink: tasks.html

--- a/shared/includes/parts/tasks.html
+++ b/shared/includes/parts/tasks.html
@@ -6,7 +6,7 @@
 		<h2 class="mb-3">{{ column.name }}</h2>
 
 		<div class="mb-4">
-			<div class="row row-cards">
+			<div class="row row-cards" data-sortable='{"group":"tasks","animation":150}'>
 				{% for task in column.tasks %}
 				<div class="col-12">
 					<div class="card card-sm">


### PR DESCRIPTION
Added a feature where you can now drag task cards around the kanban board and move them between columns. Used SortableJS (already vendored in the project), so it just needed wiring up.

Modified Page: https://preview.tabler.io/tasks.html