### PR TITLE
Improve form control border contrast to meet WCAG 1.4.11

### DIFF
--- a/.changeset/form-control-border-contrast.md
+++ b/.changeset/form-control-border-contrast.md
@@ -1,0 +1,7 @@
+---
+"@tabler/core": patch
+---
+
+Derived form control and checkbox/radio borders from the text color token so the
+control boundary reaches the 3:1 non-text contrast required by WCAG 1.4.11. The
+previous `gray-200` border sat at ~1.2:1 on light surfaces.

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -1791,7 +1791,10 @@ $list-group-action-active-bg: var(--#{$prefix}secondary-bg) !default;
 
 // Forms
 $input-disabled-bg: $disabled-bg !default;
-$input-border-color: var(--#{$prefix}border-color) !default;
+// Derived from the text color so the control boundary keeps >=3:1 (WCAG 1.4.11);
+// var(--#{$prefix}border-color) (gray-200) was ~1.2:1 on light surfaces.
+$form-control-border-color: color-mix(in srgb, var(--#{$prefix}body-color), transparent 40%) !default;
+$input-border-color: $form-control-border-color !default;
 $input-border-color-translucent: var(--#{$prefix}border-color-translucent) !default;
 
 $input-placeholder-color: var(--#{$prefix}tertiary) !default;
@@ -1817,7 +1820,7 @@ $form-check-input-width: 1.25rem !default;
 $form-check-min-height: $font-size-base * $line-height-base !default;
 $form-check-input-active-filter: brightness(90%) !default;
 $form-check-input-bg: var(--#{$prefix}bg-forms) !default;
-$form-check-input-border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $input-border-color-translucent !default;
+$form-check-input-border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $form-control-border-color !default;
 $form-check-input-border-radius: var(--#{$prefix}border-radius) !default;
 $form-check-radio-border-radius: 50% !default;
 $form-check-input-focus-border: $input-focus-border-color !default;
@@ -1830,7 +1833,7 @@ $form-check-input-checked-color: var(--#{$prefix}bg-forms) !default;
 $form-check-input-checked-bg-repeat: repeat !default;
 $form-check-input-checked-bg-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'><path fill='none' stroke='#{$white}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8.5l2.5 2.5l5.5 -5.5'/></svg>") !default;
 $form-check-input-checked-bg-image-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'><path fill='none' stroke='#{$body-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8.5l2.5 2.5l5.5 -5.5'/></svg>") !default;
-$form-check-input-checked-border-color: $input-border-color-translucent !default;
+$form-check-input-checked-border-color: $form-control-border-color !default;
 $form-check-input-indeterminate-color: $component-active-color !default;
 $form-check-input-indeterminate-bg-color: var(--#{$prefix}primary) !default;
 $form-check-input-indeterminate-border-color: $form-check-input-indeterminate-bg-color !default;


### PR DESCRIPTION
While checking form accessibility and making a compliance work on https://github.com/glpi-project/glpi , 

I noticed the default field borders are really hard to see on a light background. The input and select border uses `--tblr-border-color` (`gray-200`, `#e5e7eb`) and the checkbox/radio border uses `--tblr-border-color-translucent`, and both sit at roughly 1.2:1 against white. That's well under the 3:1 that WCAG 2.1 SC 1.4.11 asks for, so an empty field or an unchecked control can be tricky to make out.

The fix derives those borders from the text color rather than from gray-200, through a new token:

```scss
$form-control-border-color: color-mix(in srgb, var(--#{$prefix}body-color), transparent 40%) !default;
```

Because `body-color` flips with the theme, this lands around 3.3:1 on the default light palette and around 6:1 on dark, without anything hardcoded per theme. `$input-border-color` (so selects and input-group addons follow along) and the `form-check` border tokens now point at it.

A few notes on scope:

* It targets the controls whose border is actually drawn in the default theme: inputs, selects, checkboxes and radios.
* The checked checkbox/radio is identified by its primary fill and has no border in the default light theme, so there's no contrast regression there. I still repointed the checked-border token so themes that do render that border stay consistent.
* I left `$border-color` alone on purpose, so cards, tables and dividers are untouched.

Quick before/after: on `main` an empty input border measures about 1.2:1 against the surface; with this change the same border comes out around 3.3:1, so the box is clearly visible.

Live repro: https://jsfiddle.net/xvq5zbkj/

A changeset is included.
