### PR TITLE
Fix card tab corners and update status strip size

### DIFF
--- a/.changeset/fix-card-tab-border-radius.md
+++ b/.changeset/fix-card-tab-border-radius.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed card corner radius in tab layouts when tabs sit above or below tab content.

--- a/.changeset/update-card-status-size.md
+++ b/.changeset/update-card-status-size.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Updated `$card-status-size` default from `$border-width-wide` to `3px`.

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -1257,7 +1257,7 @@ $card-bg-hover: $white !default;
 $card-img-overlay-padding: $spacer !default;
 $card-group-margin: 1.5rem !default;
 
-$card-status-size: $border-width-wide !default;
+$card-status-size: 3px !default;
 
 $card-stamp-opacity: 0.2 !default;
 

--- a/core/scss/mixins/bootstrap/_border-radius.scss
+++ b/core/scss/mixins/bootstrap/_border-radius.scss
@@ -34,12 +34,12 @@
   @if $enable-rounded {
     border-radius: valid-radius($radius);
 
-    @if $radius != 0 {
-      @supports (corner-shape: squircle) {
-        corner-shape: squircle;
-        border-radius: squircle-radius($radius) !important;
-      }
-    }
+    // @if $radius != 0 {
+    //   @supports (corner-shape: squircle) {
+    //     corner-shape: squircle;
+    //     border-radius: squircle-radius($radius) !important;
+    //   }
+    // }
   } @else if $fallback-border-radius != false {
     border-radius: $fallback-border-radius;
   }

--- a/core/scss/ui/_cards.scss
+++ b/core/scss/ui/_cards.scss
@@ -652,7 +652,12 @@ Card list group
 
   .nav-tabs + .tab-content .card {
     border-end-start-radius: var(--#{$prefix}card-border-radius);
-    border-start-start-radius: 0;
+    border-start-start-radius: 0 !important;
+  }
+  
+  .tab-content:has(+ .nav-tabs) .card {
+    border-start-start-radius: var(--#{$prefix}card-border-radius);
+    border-end-start-radius: 0 !important;
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixed card corner radius when tabs are above or below tab content in `.card-tabs` layouts.
- Set `$card-status-size` default to `3px` (was `$border-width-wide`, `2px`) for card status strips.
- Temporarily disabled squircle `corner-shape` override in `border-radius()` (commented out; no changeset).
- Added `@tabler/core` patch changesets for the tab radius and status size updates.

## Preview

- **URL:** [Cards preview](https://tabler-git-dev-fix-radiuses-tabler-io.vercel.app/cards.html)
- **How to test:** Open the Cards page. Check **Card tabs** demos (tabs on top and bottom): card corners should match the tab layout without wrong rounding on the start edge. Check stacked cards with **card status** strips at the top: the colored strip should be slightly thicker (`3px` vs `2px` before). If you use a squircle-capable browser, corners should follow standard `border-radius` (squircle override is off in this branch).

## Notes / rollout

- Squircle support is commented out in `_border-radius.scss` but not covered by a changeset. Confirm whether that is intentional before merge.
- `$card-status-size` is a Sass default; projects that override it are unchanged.