### PR TITLE
Fix CountUp, dropdown viewport boundary, and input mask lazy option

### DIFF
--- a/.changeset/fix-countup-formatted-values.md
+++ b/.changeset/fix-countup-formatted-values.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed CountUp to parse formatted number targets and avoid double-start when `enableScrollSpy` is enabled.

--- a/.changeset/fix-dropdown-viewport-boundary.md
+++ b/.changeset/fix-dropdown-viewport-boundary.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed dropdown `data-bs-boundary="viewport"` to use `document.documentElement` instead of the first `.btn` element.

--- a/.changeset/fix-input-mask-lazy-option.md
+++ b/.changeset/fix-input-mask-lazy-option.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed input mask `lazy` option to read `data-mask-visible` via `dataset.maskVisible`.

--- a/core/js/src/countup.ts
+++ b/core/js/src/countup.ts
@@ -15,11 +15,15 @@ if (countupElements.length) {
       // ignore invalid JSON
     }
 
-    const value = parseInt(element.innerHTML, 10)
+    // Strip thousands separators, currency symbols and other non-numeric characters
+    // so formatted targets like "1,234", "1 234" or "$99.5" parse correctly.
+    const value = parseFloat((element.textContent ?? '').replace(/[^0-9.-]/g, ''))
 
-    if (window.countUp && window.countUp.CountUp) {
+    if (!Number.isNaN(value) && window.countUp && window.countUp.CountUp) {
       const countUp = new window.countUp.CountUp(element, value, options)
-      if (!countUp.error) {
+      // When scrollSpy is enabled CountUp starts the animation itself once the
+      // element scrolls into view, so only start manually when it's disabled.
+      if (!countUp.error && !options.enableScrollSpy) {
         countUp.start()
       }
     }

--- a/core/js/src/dropdown.ts
+++ b/core/js/src/dropdown.ts
@@ -6,7 +6,7 @@ Core dropdowns
 const dropdownTriggerList: HTMLElement[] = [].slice.call(document.querySelectorAll<HTMLElement>('[data-bs-toggle="dropdown"]'))
 dropdownTriggerList.map(function (dropdownTriggerEl: HTMLElement) {
   const options = {
-    boundary: dropdownTriggerEl.getAttribute('data-bs-boundary') === 'viewport' ? document.querySelector('.btn') : 'clippingParents',
+    boundary: dropdownTriggerEl.getAttribute('data-bs-boundary') === 'viewport' ? document.documentElement : 'clippingParents',
   }
   return new Dropdown(dropdownTriggerEl, options)
 })

--- a/core/js/src/input-mask.ts
+++ b/core/js/src/input-mask.ts
@@ -5,6 +5,6 @@ maskElementList.map(function (maskEl: HTMLElement) {
   window.IMask &&
     new window.IMask(maskEl, {
       mask: maskEl.dataset.mask,
-      lazy: maskEl.dataset['mask-visible'] === 'true',
+      lazy: maskEl.dataset.maskVisible !== 'true',
     })
 })


### PR DESCRIPTION
## Summary

- CountUp now parses formatted targets like `1,234` or `$99.5` and skips manual `start()` when `enableScrollSpy` is on.
- Dropdowns with `data-bs-boundary="viewport"` now use `document.documentElement` instead of the first `.btn` on the page.
- Input masks with `data-mask-visible="true"` now set `lazy: false` correctly via `dataset.maskVisible`.
- Added three `@tabler/core` patch changesets for the release notes.

## Preview

- **URL:** [Form elements](https://tabler-git-dev-js-fixes-tabler-io.vercel.app/form-elements.html) · [Dropdowns](https://tabler-git-dev-js-fixes-tabler-io.vercel.app/dropdowns.html) · [Tables](https://tabler-git-dev-js-fixes-tabler-io.vercel.app/tables.html)
- **How to test:**
  - **Input mask:** On Form elements, focus masked fields with visible placeholders — the mask should show immediately (`lazy: false`).
  - **Dropdown:** On Tables, open the **Actions** dropdown in the Invoices card (`data-bs-boundary="viewport"`) — the menu should not clip incorrectly because of a random `.btn` boundary.
  - **CountUp:** Use any page with `[data-countup]` and formatted numbers, or the [CountUp docs demo](https://tabler-git-dev-js-fixes-tabler-io.vercel.app/docs/countup.html) — the animation should read the correct target value and not double-start with scroll spy enabled.

## Notes / rollout

- All changes are in `core/js/src/` and ship with `@tabler/core` JS bundle.
- No breaking API changes; behavior fixes only.