### PR TITLE
Add Star Rating docs with static and interactive examples

### DIFF
--- a/.changeset/star-rating-docs-page.md
+++ b/.changeset/star-rating-docs-page.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": minor
+---
+
+Added `Star Rating` documentation page with static and interactive rating examples based on existing classes.

--- a/docs/content/ui/components/star-rating.md
+++ b/docs/content/ui/components/star-rating.md
@@ -1,0 +1,114 @@
+---
+title: Star Rating
+summary: Use star rating to show score values with static stars or interactive star states.
+description: Build star rating UI with stars classes and data-star-rating state selectors.
+---
+
+## Overview
+
+Use `.stars` as the container and `.star` for each icon.
+This creates an inline star row with spacing and base color.
+
+{% capture html -%}
+<div class="stars">
+  <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+  <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+  <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+  <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+  <span class="star">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+</div>
+{%- endcapture %}
+{% include "docs/example.html" html=html centered %}
+
+## Variants
+
+### Static value rows
+
+Use `.stars` for read-only values in lists and cards.
+Color only the active stars and keep the rest in default color.
+
+{% capture html -%}
+<div class="space-y">
+  <div class="d-flex justify-content-between align-items-center">
+    <span>Product quality</span>
+    <div class="stars">
+      <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+      <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+      <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+      <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+      <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+    </div>
+  </div>
+  <div class="d-flex justify-content-between align-items-center">
+    <span>Delivery speed</span>
+    <div class="stars">
+      <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+      <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+      <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+      <span class="star">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+      <span class="star">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+    </div>
+  </div>
+</div>
+{%- endcapture %}
+{% include "docs/example.html" html=html %}
+
+### Data-star-rating states
+
+The vendor styles also target `[data-star-rating]`.
+Use `.gl-active` and `.gl-star-full` to control active and inactive star color.
+
+{% capture html -%}
+<div data-star-rating class="d-flex gap-1" style="--tblr-icon-size: 1.25rem;">
+  <span class="gl-active">{% include "ui/icon.html" icon="star" type="filled" class="gl-star-full" %}</span>
+  <span class="gl-active">{% include "ui/icon.html" icon="star" type="filled" class="gl-star-full" %}</span>
+  <span class="gl-active">{% include "ui/icon.html" icon="star" type="filled" class="gl-star-full" %}</span>
+  <span>{% include "ui/icon.html" icon="star" type="filled" class="gl-star-full" %}</span>
+  <span>{% include "ui/icon.html" icon="star" type="filled" class="gl-star-full" %}</span>
+</div>
+{%- endcapture %}
+{% include "docs/example.html" html=html centered %}
+
+### Custom rating colors
+
+Use CSS custom properties from vendor styles to change star colors.
+You can set active and inactive colors per instance.
+
+{% capture html -%}
+<div data-star-rating class="d-flex gap-1" style="--gl-star-color: var(--tblr-red); --gl-star-color-inactive: var(--tblr-border-color); --tblr-icon-size: 1.25rem;">
+  <span class="gl-active">{% include "ui/icon.html" icon="heart" type="filled" class="gl-star-full" %}</span>
+  <span class="gl-active">{% include "ui/icon.html" icon="heart" type="filled" class="gl-star-full" %}</span>
+  <span class="gl-active">{% include "ui/icon.html" icon="heart" type="filled" class="gl-star-full" %}</span>
+  <span>{% include "ui/icon.html" icon="heart" type="filled" class="gl-star-full" %}</span>
+  <span>{% include "ui/icon.html" icon="heart" type="filled" class="gl-star-full" %}</span>
+</div>
+{%- endcapture %}
+{% include "docs/example.html" html=html centered %}
+
+## Examples
+
+### Summary rating block
+
+Combine stars with text to show score and vote count.
+This pattern works for cards, reviews, and product lists.
+
+{% capture html -%}
+<div class="d-flex align-items-center gap-2">
+  <div class="stars">
+    <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+    <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+    <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+    <span class="star text-yellow">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+    <span class="star">{% include "ui/icon.html" icon="star" type="filled" %}</span>
+  </div>
+  <span class="text-secondary">4.0 (128 reviews)</span>
+</div>
+{%- endcapture %}
+{% include "docs/example.html" html=html centered %}
+
+## Accessibility
+
+- Add a text label near stars, for example `4.0 out of 5`.
+- For read-only stars, keep the value visible in text.
+- For interactive ratings, ensure keyboard focus and clear selected state.
+- Do not rely on color alone; pair color with a numeric value.


### PR DESCRIPTION
## Summary

- Add a new `Star Rating` documentation page at `docs/content/ui/components/star-rating.md`.
- Document both static `.stars`/`.star` usage and interactive `[data-star-rating]` state usage with `.gl-active` and `.gl-star-full`.
- Include practical examples for value rows, custom color states, and a summary rating block.
- Add a changeset at `.changeset/star-rating-docs-page.md` for `@tabler/docs` with a `minor` bump.

## Preview

- **How to test:** Open the preview URL, verify static rows render correctly in `.stars`, confirm interactive state examples show active vs inactive icons under `[data-star-rating]`, check custom color example with heart icons, and verify accessibility text guidance matches visible rating values.