### PR TITLE
Add framework integration guides to Getting Started

### DIFF
--- a/.changeset/frameworks-getting-started-guides.md
+++ b/.changeset/frameworks-getting-started-guides.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": minor
+---
+
+Added a new `Frameworks` docs section at `/ui/getting-started/frameworks` with initial framework guides and updated docs layout support for `hide_pagination`.

--- a/docs/content/ui/getting-started/frameworks/angular.md
+++ b/docs/content/ui/getting-started/frameworks/angular.md
@@ -1,0 +1,119 @@
+---
+title: Angular
+order: 5
+summary: Set up Tabler in Angular and build a first working page.
+description: Install `@tabler/core`, register CSS and JS in `angular.json`, and render a minimal Angular page with a Tabler card.
+---
+
+Use this guide to integrate Tabler in an Angular app.
+
+<div class="steps steps-vertical">
+
+### Install Tabler package
+
+Install `@tabler/core` with your preferred package manager:
+
+{% include "docs/tabs-package.html" name="@tabler/core" %}
+
+You can also use CDN files when you need a quick setup:
+
+```html
+<link rel="stylesheet" href="{{ cdnUrl }}/dist/css/tabler.min.css" />
+<script src="{{ cdnUrl }}/dist/js/tabler.min.js"></script>
+```
+
+### Import styles
+
+Register Tabler CSS in the Angular build config (`angular.json`) under `projects.<app>.architect.build.options.styles`:
+
+```json
+{
+  "styles": [
+    "src/styles.scss",
+    "node_modules/@tabler/core/dist/css/tabler.min.css"
+  ]
+}
+```
+
+For full theme customization, import SCSS sources in `src/styles.scss`:
+
+```scss
+@import "@tabler/core/scss/tabler";
+```
+
+`@tabler/core` does not define `exports`, so deep imports work in Angular CLI builds.
+
+### Import and initialize JavaScript
+
+Tabler JavaScript is required for interactive components such as dropdowns, modals, and tooltips.
+Register it in `angular.json` under `projects.<app>.architect.build.options.scripts`:
+
+```json
+{
+  "scripts": [
+    "node_modules/@tabler/core/dist/js/tabler.min.js"
+  ]
+}
+```
+
+Angular-specific note: use `angular.json` for global CSS and JS registration so assets are included
+in both development and production builds.
+
+### Minimal working example
+
+Use a simple root component template in `src/app/app.component.html`:
+
+```html
+<div class="page">
+  <div class="page-wrapper">
+    <div class="container-xl py-4">
+      <div class="card">
+        <div class="card-body">
+          <h3 class="card-title">Angular + Tabler</h3>
+          <p class="text-secondary mb-0">Your Tabler setup is working.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+A minimal `angular.json` example (relevant part):
+
+```json
+{
+  "projects": {
+    "my-app": {
+      "architect": {
+        "build": {
+          "options": {
+            "styles": [
+              "src/styles.scss",
+              "node_modules/@tabler/core/dist/css/tabler.min.css"
+            ],
+            "scripts": [
+              "node_modules/@tabler/core/dist/js/tabler.min.js"
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Run the app:
+
+```shell
+npm run start
+```
+
+Open the local Angular URL and confirm the card is styled with Tabler.
+
+### Next steps
+
+- Continue with [Customize](/ui/getting-started/customize) to adjust styles and build setup.
+- Explore [Layout](/ui/layout) to choose page structures.
+- Browse [Components](/ui/components) to add UI building blocks.
+
+</div>

--- a/docs/content/ui/getting-started/frameworks/angular.md
+++ b/docs/content/ui/getting-started/frameworks/angular.md
@@ -7,6 +7,8 @@ description: Install `@tabler/core`, register CSS and JS in `angular.json`, and 
 
 Use this guide to integrate Tabler in an Angular app.
 
+Tabler works with any framework as markup + CSS; JS is only needed for interactive components.
+
 <div class="steps steps-vertical">
 
 ### Install Tabler package

--- a/docs/content/ui/getting-started/frameworks/django.md
+++ b/docs/content/ui/getting-started/frameworks/django.md
@@ -1,0 +1,127 @@
+---
+title: Django
+order: 8
+summary: Set up Tabler in Django and build a first working page.
+description: Install `@tabler/core`, load CSS and optional JS in Django templates, and render a minimal page layout with a Tabler card.
+---
+
+Use this guide to integrate Tabler in a Django app.
+
+Tabler works with any framework as markup + CSS; JS is only needed for interactive components.
+
+<div class="steps steps-vertical">
+
+### Install Tabler package
+
+Install `@tabler/core` with your preferred package manager:
+
+{% include "docs/tabs-package.html" name="@tabler/core" %}
+
+You can also use CDN files when you need a quick setup:
+
+```html
+<link rel="stylesheet" href="{{ cdnUrl }}/dist/css/tabler.min.css" />
+<script src="{{ cdnUrl }}/dist/js/tabler.min.js"></script>
+```
+
+### Import styles
+
+Django can use Tabler in two common ways:
+
+- Build frontend assets with npm and serve compiled files.
+- Copy static CSS/JS files into your Django static directory.
+
+If you use static files directly, add Tabler CSS to your base template:
+
+{% raw %}
+```html
+{% load static %}
+<link rel="stylesheet" href="{% static 'css/tabler.min.css' %}" />
+```
+{% endraw %}
+
+For full theme customization, build from SCSS sources:
+
+```scss
+@import "@tabler/core/scss/tabler";
+```
+
+`@tabler/core` does not define `exports`, so deep imports work in common build setups.
+
+### Import and initialize JavaScript
+
+Tabler JavaScript is required for interactive components such as dropdowns, modals, and tooltips.
+
+If you use static files, include Tabler JS in your base template:
+
+{% raw %}
+```html
+{% load static %}
+<script src="{% static 'js/tabler.min.js' %}"></script>
+```
+{% endraw %}
+
+Django-specific note: when serving local static assets in production, run `collectstatic` so
+Tabler files are included in your final static output.
+
+### Minimal working example
+
+Create a minimal base template in `templates/base.html`:
+
+{% raw %}
+```html
+{% load static %}
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="{% static 'css/tabler.min.css' %}" />
+  </head>
+  <body>
+    {% block content %}{% endblock %}
+    <script src="{% static 'js/tabler.min.js' %}"></script>
+  </body>
+</html>
+```
+{% endraw %}
+
+Then add a simple page in `templates/home.html`:
+
+{% raw %}
+```html
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page">
+  <div class="page-wrapper">
+    <div class="container-xl py-4">
+      <div class="card">
+        <div class="card-body">
+          <h3 class="card-title">Django + Tabler</h3>
+          <p class="text-secondary mb-0">Your Tabler setup is working.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+```
+{% endraw %}
+
+Run the app:
+
+```shell
+python manage.py runserver
+python manage.py collectstatic
+```
+
+Open the local Django URL and confirm the card is styled with Tabler.
+
+### Next steps
+
+- Continue with [Customize](/ui/getting-started/customize) to adjust styles and build setup.
+- Explore [Layout](/ui/layout) to choose page structures.
+- Browse [Components](/ui/components) to add UI building blocks.
+
+</div>

--- a/docs/content/ui/getting-started/frameworks/index.md
+++ b/docs/content/ui/getting-started/frameworks/index.md
@@ -19,7 +19,7 @@ This subsection contains framework-related setup and starter guidance.
 
 {% card "Vue", "vue" %} Integrate Tabler with Vue. {% endcard %}
 
-{% card "Angular", "" %} Integrate Tabler with Angular. {% endcard %}
+{% card "Angular", "angular" %} Integrate Tabler with Angular. {% endcard %}
 
 {% card "Nuxt", "" %} Integrate Tabler with Nuxt. {% endcard %}
 

--- a/docs/content/ui/getting-started/frameworks/index.md
+++ b/docs/content/ui/getting-started/frameworks/index.md
@@ -21,7 +21,7 @@ This subsection contains framework-related setup and starter guidance.
 
 {% card "Angular", "/ui/getting-started/frameworks/angular" %} Integrate Tabler with Angular. {% endcard %}
 
-{% card "Nuxt", "" %} Integrate Tabler with Nuxt. {% endcard %}
+{% card "Nuxt", "/ui/getting-started/frameworks/nuxt" %} Integrate Tabler with Nuxt. {% endcard %}
 
 {% card "Symfony", "" %} Integrate Tabler with Symfony. {% endcard %}
 

--- a/docs/content/ui/getting-started/frameworks/index.md
+++ b/docs/content/ui/getting-started/frameworks/index.md
@@ -23,7 +23,7 @@ This subsection contains framework-related setup and starter guidance.
 
 {% card "Nuxt", "/ui/getting-started/frameworks/nuxt" %} Integrate Tabler with Nuxt. {% endcard %}
 
-{% card "Symfony", "" %} Integrate Tabler with Symfony. {% endcard %}
+{% card "Symfony", "/ui/getting-started/frameworks/symfony" %} Integrate Tabler with Symfony. {% endcard %}
 
 {% card "Django", "" %} Integrate Tabler with Django. {% endcard %}
 

--- a/docs/content/ui/getting-started/frameworks/index.md
+++ b/docs/content/ui/getting-started/frameworks/index.md
@@ -29,6 +29,6 @@ This subsection contains framework-related setup and starter guidance.
 
 {% card "Rails", "/ui/getting-started/frameworks/rails" %} Integrate Tabler with Rails. {% endcard %}
 
-{% card "SvelteKit", "" %} Integrate Tabler with SvelteKit. {% endcard %}
+{% card "SvelteKit", "/ui/getting-started/frameworks/sveltekit" %} Integrate Tabler with SvelteKit. {% endcard %}
 
 {% endcards %}

--- a/docs/content/ui/getting-started/frameworks/index.md
+++ b/docs/content/ui/getting-started/frameworks/index.md
@@ -15,7 +15,7 @@ This subsection contains framework-related setup and starter guidance.
 
 {% card "React", "react" %} Integrate Tabler with React. {% endcard %}
 
-{% card "Next.js", "" %} Integrate Tabler with Next.js. {% endcard %}
+{% card "Next.js", "nextjs" %} Integrate Tabler with Next.js. {% endcard %}
 
 {% card "Vue", "" %} Integrate Tabler with Vue. {% endcard %}
 

--- a/docs/content/ui/getting-started/frameworks/index.md
+++ b/docs/content/ui/getting-started/frameworks/index.md
@@ -27,7 +27,7 @@ This subsection contains framework-related setup and starter guidance.
 
 {% card "Django", "/ui/getting-started/frameworks/django" %} Integrate Tabler with Django. {% endcard %}
 
-{% card "Rails", "" %} Integrate Tabler with Rails. {% endcard %}
+{% card "Rails", "/ui/getting-started/frameworks/rails" %} Integrate Tabler with Rails. {% endcard %}
 
 {% card "SvelteKit", "" %} Integrate Tabler with SvelteKit. {% endcard %}
 

--- a/docs/content/ui/getting-started/frameworks/index.md
+++ b/docs/content/ui/getting-started/frameworks/index.md
@@ -25,7 +25,7 @@ This subsection contains framework-related setup and starter guidance.
 
 {% card "Symfony", "/ui/getting-started/frameworks/symfony" %} Integrate Tabler with Symfony. {% endcard %}
 
-{% card "Django", "" %} Integrate Tabler with Django. {% endcard %}
+{% card "Django", "/ui/getting-started/frameworks/django" %} Integrate Tabler with Django. {% endcard %}
 
 {% card "Rails", "" %} Integrate Tabler with Rails. {% endcard %}
 

--- a/docs/content/ui/getting-started/frameworks/index.md
+++ b/docs/content/ui/getting-started/frameworks/index.md
@@ -17,7 +17,7 @@ This subsection contains framework-related setup and starter guidance.
 
 {% card "Next.js", "nextjs" %} Integrate Tabler with Next.js. {% endcard %}
 
-{% card "Vue", "" %} Integrate Tabler with Vue. {% endcard %}
+{% card "Vue", "vue" %} Integrate Tabler with Vue. {% endcard %}
 
 {% card "Angular", "" %} Integrate Tabler with Angular. {% endcard %}
 

--- a/docs/content/ui/getting-started/frameworks/index.md
+++ b/docs/content/ui/getting-started/frameworks/index.md
@@ -1,0 +1,34 @@
+---
+title: Frameworks
+description: Framework-specific integration guides in the Getting Started section.
+summary: Use this subsection to browse Tabler setup guides for specific frameworks.
+hide_pagination: true
+---
+
+## Overview
+
+This subsection contains framework-related setup and starter guidance.
+
+{% cards %}
+
+{% card "Laravel", "laravel" %} Integrate Tabler with Laravel. {% endcard %}
+
+{% card "React", "react" %} Integrate Tabler with React. {% endcard %}
+
+{% card "Next.js", "" %} Integrate Tabler with Next.js. {% endcard %}
+
+{% card "Vue", "" %} Integrate Tabler with Vue. {% endcard %}
+
+{% card "Angular", "" %} Integrate Tabler with Angular. {% endcard %}
+
+{% card "Nuxt", "" %} Integrate Tabler with Nuxt. {% endcard %}
+
+{% card "Symfony", "" %} Integrate Tabler with Symfony. {% endcard %}
+
+{% card "Django", "" %} Integrate Tabler with Django. {% endcard %}
+
+{% card "Rails", "" %} Integrate Tabler with Rails. {% endcard %}
+
+{% card "SvelteKit", "" %} Integrate Tabler with SvelteKit. {% endcard %}
+
+{% endcards %}

--- a/docs/content/ui/getting-started/frameworks/index.md
+++ b/docs/content/ui/getting-started/frameworks/index.md
@@ -11,15 +11,15 @@ This subsection contains framework-related setup and starter guidance.
 
 {% cards %}
 
-{% card "Laravel", "laravel" %} Integrate Tabler with Laravel. {% endcard %}
+{% card "Laravel", "/ui/getting-started/frameworks/laravel" %} Integrate Tabler with Laravel. {% endcard %}
 
-{% card "React", "react" %} Integrate Tabler with React. {% endcard %}
+{% card "React", "/ui/getting-started/frameworks/react" %} Integrate Tabler with React. {% endcard %}
 
-{% card "Next.js", "nextjs" %} Integrate Tabler with Next.js. {% endcard %}
+{% card "Next.js", "/ui/getting-started/frameworks/nextjs" %} Integrate Tabler with Next.js. {% endcard %}
 
-{% card "Vue", "vue" %} Integrate Tabler with Vue. {% endcard %}
+{% card "Vue", "/ui/getting-started/frameworks/vue" %} Integrate Tabler with Vue. {% endcard %}
 
-{% card "Angular", "angular" %} Integrate Tabler with Angular. {% endcard %}
+{% card "Angular", "/ui/getting-started/frameworks/angular" %} Integrate Tabler with Angular. {% endcard %}
 
 {% card "Nuxt", "" %} Integrate Tabler with Nuxt. {% endcard %}
 

--- a/docs/content/ui/getting-started/frameworks/index.md
+++ b/docs/content/ui/getting-started/frameworks/index.md
@@ -31,4 +31,12 @@ This subsection contains framework-related setup and starter guidance.
 
 {% card "SvelteKit", "/ui/getting-started/frameworks/sveltekit" %} Integrate Tabler with SvelteKit. {% endcard %}
 
+{% card "Astro", "" %} Integrate Tabler with Astro {% endcard %}
+
+{% card "ASP.NET Core", "" %} Integrate Tabler with ASP.NET Core {% endcard %}
+
+{% card "Flask", "" %} Integrate Tabler with Flask {% endcard %}
+
+{% card "HTMX", "" %} Integrate Tabler with HTMX {% endcard %}
+
 {% endcards %}

--- a/docs/content/ui/getting-started/frameworks/laravel.md
+++ b/docs/content/ui/getting-started/frameworks/laravel.md
@@ -1,0 +1,119 @@
+---
+title: Laravel
+order: 1
+summary: Set up Tabler in Laravel with Vite and build a first working page.
+description: Install `@tabler/core`, import CSS and JS with Vite, and render a minimal Laravel view with Tabler styles.
+---
+
+Use this guide to integrate Tabler in a Laravel app with the default Vite setup.
+
+<div class="steps steps-vertical">
+
+### Install Tabler package
+
+Install `@tabler/core` with your preferred package manager:
+
+{% include "docs/tabs-package.html" name="@tabler/core" %}
+
+You can also use CDN files when you do not want a Node-based build step:
+
+```blade
+<link rel="stylesheet" href="{{ cdnUrl }}/dist/css/tabler.min.css" />
+<script src="{{ cdnUrl }}/dist/js/tabler.min.js"></script>
+```
+
+### Import styles
+
+In a standard Laravel setup, import Tabler CSS in `resources/css/app.css`:
+
+```scss
+@import "@tabler/core/dist/css/tabler.min.css";
+```
+
+For full theme customization, you can import SCSS sources from the package:
+
+```scss
+@import "@tabler/core/scss/tabler";
+```
+
+`@tabler/core` does not define `exports`, so deep imports work in Vite.
+
+### Import and initialize JavaScript
+
+Tabler JavaScript is required for interactive components such as dropdowns, modals, and tooltips.
+Import it in `resources/js/app.js`:
+
+```js
+import "@tabler/core/dist/js/tabler.min.js";
+```
+
+Laravel-specific note: keep Tabler imports in Vite entry files (`resources/css/app.css` and `resources/js/app.js`)
+so they are compiled into your application bundles.
+
+### Minimal working example
+
+First, load compiled assets in your base Blade layout (for example `resources/views/layouts/app.blade.php`):
+
+```blade
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    @vite(["resources/css/app.css", "resources/js/app.js"])
+  </head>
+  <body>
+    @yield("content")
+  </body>
+</html>
+```
+
+Then create a simple page route in `routes/web.php`:
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get("/", function () {
+    return view("welcome");
+});
+```
+
+Then add a small Tabler layout with one card in `resources/views/welcome.blade.php`:
+
+```blade
+@extends("layouts.app")
+
+@section("content")
+<div class="page">
+  <div class="page-wrapper">
+    <div class="container-xl py-4">
+      <div class="card">
+        <div class="card-body">
+          <h3 class="card-title">Laravel + Tabler</h3>
+          <p class="text-secondary mb-0">Your Tabler setup is working.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+```
+
+Run the dev server and Vite:
+
+```shell
+php artisan serve
+npm run dev
+```
+
+Open the local URL from `php artisan serve` and confirm the card is styled with Tabler.
+
+### Next steps
+
+- Continue with [Customize](/ui/getting-started/customize) to adjust styles and build setup.
+- Explore [Layout](/ui/layout) to choose page structures.
+- Browse [Components](/ui/components) to add UI building blocks.
+
+</div>

--- a/docs/content/ui/getting-started/frameworks/laravel.md
+++ b/docs/content/ui/getting-started/frameworks/laravel.md
@@ -7,6 +7,8 @@ description: Install `@tabler/core`, import CSS and JS with Vite, and render a m
 
 Use this guide to integrate Tabler in a Laravel app with the default Vite setup.
 
+Tabler works with any framework as markup + CSS; JS is only needed for interactive components.
+
 <div class="steps steps-vertical">
 
 ### Install Tabler package

--- a/docs/content/ui/getting-started/frameworks/nextjs.md
+++ b/docs/content/ui/getting-started/frameworks/nextjs.md
@@ -44,6 +44,8 @@ For full theme customization, import SCSS sources:
 
 Tabler JavaScript is required for interactive components such as dropdowns, modals, and tooltips.
 
+Next.js-specific note: `tabler.min.js` accesses `document`, so load it only on the client. If you import it during SSR, Next.js throws `document is not defined`.
+
 Use a client component and dynamic import:
 
 ```jsx
@@ -59,8 +61,6 @@ export function TablerScripts() {
   return null
 }
 ```
-
-Next.js-specific note: `tabler.min.js` accesses `document`, so load it only on the client. If you import it during SSR, Next.js throws `document is not defined`.
 
 ### Minimal working example
 

--- a/docs/content/ui/getting-started/frameworks/nextjs.md
+++ b/docs/content/ui/getting-started/frameworks/nextjs.md
@@ -7,6 +7,8 @@ description: Install `@tabler/core`, import CSS and JS in Next.js, and render a 
 
 Use this guide to integrate Tabler in a Next.js app.
 
+Tabler works with any framework as markup + CSS; JS is only needed for interactive components.
+
 <div class="steps steps-vertical">
 
 ### Install Tabler package

--- a/docs/content/ui/getting-started/frameworks/nextjs.md
+++ b/docs/content/ui/getting-started/frameworks/nextjs.md
@@ -1,0 +1,120 @@
+---
+title: Next.js
+order: 3
+summary: Set up Tabler in Next.js and build a first working page.
+description: Install `@tabler/core`, import CSS and JS in Next.js, and render a minimal page layout with a Tabler card.
+---
+
+Use this guide to integrate Tabler in a Next.js app.
+
+<div class="steps steps-vertical">
+
+### Install Tabler package
+
+Install `@tabler/core` with your preferred package manager:
+
+{% include "docs/tabs-package.html" name="@tabler/core" %}
+
+You can also use CDN files when you need a quick setup:
+
+```html
+<link rel="stylesheet" href="{{ cdnUrl }}/dist/css/tabler.min.css" />
+<script src="{{ cdnUrl }}/dist/js/tabler.min.js"></script>
+```
+
+### Import styles
+
+Import Tabler CSS once in your global stylesheet (`app/globals.css`):
+
+```scss
+@import '@tabler/core/dist/css/tabler.min.css';
+```
+
+For full theme customization, import SCSS sources:
+
+```scss
+@import '@tabler/core/scss/tabler';
+```
+
+`@tabler/core` does not define `exports`, so deep imports work in common Next.js setups.
+
+### Import and initialize JavaScript
+
+Tabler JavaScript is required for interactive components such as dropdowns, modals, and tooltips.
+
+Use a client component and dynamic import:
+
+```jsx
+'use client'
+
+import { useEffect } from 'react'
+
+export function TablerScripts() {
+  useEffect(() => {
+    import('@tabler/core/dist/js/tabler.min.js')
+  }, [])
+
+  return null
+}
+```
+
+Next.js-specific note: `tabler.min.js` accesses `document`, so load it only on the client. If you import it during SSR, Next.js throws `document is not defined`.
+
+### Minimal working example
+
+Load styles globally and mount client-only scripts in the app layout.
+
+`app/layout.jsx`:
+
+```jsx
+import './globals.css'
+import { TablerScripts } from './tabler-scripts'
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        <TablerScripts />
+        {children}
+      </body>
+    </html>
+  )
+}
+```
+
+`app/page.jsx`:
+
+```jsx
+export default function Page() {
+  return (
+    <div className="page">
+      <div className="page-wrapper">
+        <div className="container-xl py-4">
+          <div className="card">
+            <div className="card-body">
+              <h3 className="card-title">Next.js + Tabler</h3>
+              <p className="text-secondary mb-0">Your Tabler setup is working.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+Run the app:
+
+```shell
+npm run dev
+```
+
+Open the local Next.js URL and confirm the card is styled with Tabler.
+
+### Next steps
+
+- Continue with [Customize](/ui/getting-started/customize) to adjust styles and build setup.
+- Explore [Layout](/ui/layout) to choose page structures.
+- Browse [Components](/ui/components) to add UI building blocks.
+
+</div>

--- a/docs/content/ui/getting-started/frameworks/nuxt.md
+++ b/docs/content/ui/getting-started/frameworks/nuxt.md
@@ -1,0 +1,95 @@
+---
+title: Nuxt
+order: 6
+summary: Set up Tabler in Nuxt and build a first working page.
+description: Install `@tabler/core`, import CSS and client-only JS in Nuxt, and render a minimal page layout with a Tabler card.
+---
+
+Use this guide to integrate Tabler in a Nuxt app.
+
+Tabler works with any framework as markup + CSS; JS is only needed for interactive components.
+
+<div class="steps steps-vertical">
+
+### Install Tabler package
+
+Install `@tabler/core` with your preferred package manager:
+
+{% include "docs/tabs-package.html" name="@tabler/core" %}
+
+You can also use CDN files when you need a quick setup:
+
+```html
+<link rel="stylesheet" href="{{ cdnUrl }}/dist/css/tabler.min.css" />
+<script src="{{ cdnUrl }}/dist/js/tabler.min.js"></script>
+```
+
+### Import styles
+
+Register Tabler CSS in `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  css: ["@tabler/core/dist/css/tabler.min.css"],
+});
+```
+
+For full theme customization, import SCSS sources in your app stylesheet:
+
+```scss
+@import "@tabler/core/scss/tabler";
+```
+
+`@tabler/core` does not define `exports`, so deep imports work in common Nuxt setups.
+
+### Import and initialize JavaScript
+
+Tabler JavaScript is required for interactive components such as dropdowns, modals, and tooltips.
+
+Nuxt-specific note: `tabler.min.js` accesses `document`, so load it only on the client.
+If you import it during SSR, Nuxt throws `document is not defined`.
+
+Create a client-only plugin in `plugins/tabler.client.ts`:
+
+```ts
+export default defineNuxtPlugin(async () => {
+  await import("@tabler/core/dist/js/tabler.min.js");
+});
+```
+
+### Minimal working example
+
+Create a minimal `pages/index.vue` page:
+
+```vue
+<template>
+  <div class="page">
+    <div class="page-wrapper">
+      <div class="container-xl py-4">
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title">Nuxt + Tabler</h3>
+            <p class="text-secondary mb-0">Your Tabler setup is working.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+Run the app:
+
+```shell
+npm run dev
+```
+
+Open the local Nuxt URL and confirm the card is styled with Tabler.
+
+### Next steps
+
+- Continue with [Customize](/ui/getting-started/customize) to adjust styles and build setup.
+- Explore [Layout](/ui/layout) to choose page structures.
+- Browse [Components](/ui/components) to add UI building blocks.
+
+</div>

--- a/docs/content/ui/getting-started/frameworks/rails.md
+++ b/docs/content/ui/getting-started/frameworks/rails.md
@@ -1,0 +1,108 @@
+---
+title: Rails
+order: 9
+summary: Set up Tabler in Rails and build a first working page.
+description: Install `@tabler/core`, load CSS and optional JS in Rails, and render a minimal page layout with a Tabler card.
+---
+
+Use this guide to integrate Tabler in a Ruby on Rails app.
+
+Tabler works with any framework as markup + CSS; JS is only needed for interactive components.
+
+<div class="steps steps-vertical">
+
+### Install Tabler package
+
+Install `@tabler/core` with your preferred package manager:
+
+{% include "docs/tabs-package.html" name="@tabler/core" %}
+
+You can also use CDN files when you need a quick setup:
+
+```html
+<link rel="stylesheet" href="{{ cdnUrl }}/dist/css/tabler.min.css" />
+<script src="{{ cdnUrl }}/dist/js/tabler.min.js"></script>
+```
+
+### Import styles
+
+For Rails with `cssbundling-rails`, import Tabler CSS in `app/assets/stylesheets/application.scss`:
+
+```scss
+@import "@tabler/core/dist/css/tabler.min.css";
+```
+
+For full theme customization, import SCSS sources instead:
+
+```scss
+@import "@tabler/core/scss/tabler";
+```
+
+`@tabler/core` does not define `exports`, so deep imports work in common Rails bundling setups.
+
+### Import and initialize JavaScript
+
+Tabler JavaScript is required for interactive components such as dropdowns, modals, and tooltips.
+
+If you use `jsbundling-rails`, import Tabler JS in `app/javascript/application.js`:
+
+```js
+import "@tabler/core/dist/js/tabler.min.js";
+```
+
+Rails-specific note: if you use `importmap-rails` without npm bundling, prefer CDN for Tabler JS
+or add compiled files to your asset pipeline and include them from your layout.
+
+### Minimal working example
+
+Create a simple layout in `app/views/layouts/application.html.erb`:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>
+```
+
+Then add a simple page in `app/views/home/index.html.erb`:
+
+```html
+<div class="page">
+  <div class="page-wrapper">
+    <div class="container-xl py-4">
+      <div class="card">
+        <div class="card-body">
+          <h3 class="card-title">Rails + Tabler</h3>
+          <p class="text-secondary mb-0">Your Tabler setup is working.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+Run the app:
+
+```shell
+bin/rails server
+```
+
+Open the local Rails URL and confirm the card is styled with Tabler.
+
+### Next steps
+
+- Continue with [Customize](/ui/getting-started/customize) to adjust styles and build setup.
+- Explore [Layout](/ui/layout) to choose page structures.
+- Browse [Components](/ui/components) to add UI building blocks.
+
+</div>

--- a/docs/content/ui/getting-started/frameworks/react.md
+++ b/docs/content/ui/getting-started/frameworks/react.md
@@ -1,0 +1,119 @@
+---
+title: React
+order: 2
+summary: Set up Tabler in React and build a first working page.
+description: Install `@tabler/core`, import CSS and JS in React, and render a minimal page layout with a Tabler card.
+---
+
+Use this guide to integrate Tabler in a React app with a standard Vite-based setup.
+
+<div class="steps steps-vertical">
+
+### Install Tabler package
+
+Install `@tabler/core` with your preferred package manager:
+
+{% include "docs/tabs-package.html" name="@tabler/core" %}
+
+You can also use CDN files when you want a quick no-build setup:
+
+```html
+<link rel="stylesheet" href="{{ cdnUrl }}/dist/css/tabler.min.css" />
+<script src="{{ cdnUrl }}/dist/js/tabler.min.js"></script>
+```
+
+### Import styles
+
+Import Tabler CSS once in your React entry file (`src/main.jsx`):
+
+```jsx
+import "@tabler/core/dist/css/tabler.min.css";
+```
+
+For full theme customization, import SCSS sources instead:
+
+```scss
+@import "@tabler/core/scss/tabler";
+```
+
+`@tabler/core` does not define `exports`, so deep imports work in common React build setups.
+
+### Import and initialize JavaScript
+
+Tabler JavaScript is required for interactive components such as dropdowns, modals, and tooltips.
+Import it once in `src/main.jsx`:
+
+```jsx
+import "@tabler/core/dist/js/tabler.min.js";
+```
+
+React-specific note: do not initialize DOM-based behavior during render. Use `useEffect`:
+
+```jsx
+import { useEffect } from "react";
+
+export function TooltipExample() {
+  useEffect(() => {
+    // Run DOM initialization only after the component is mounted.
+    const elements = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+    elements.forEach((element) => new window.bootstrap.Tooltip(element));
+  }, []);
+
+  return <button data-bs-toggle="tooltip" title="Example">Hover me</button>;
+}
+```
+
+### Minimal working example
+
+Create a simple `src/main.jsx` that loads Tabler assets and renders the app:
+
+```jsx
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "@tabler/core/dist/css/tabler.min.css";
+import "@tabler/core/dist/js/tabler.min.js";
+import App from "./App.jsx";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+```
+
+Then create `src/App.jsx` with a minimal Tabler layout and one card:
+
+```jsx
+export default function App() {
+  return (
+    <div className="page">
+      <div className="page-wrapper">
+        <div className="container-xl py-4">
+          <div className="card">
+            <div className="card-body">
+              <h3 className="card-title">React + Tabler</h3>
+              <p className="text-secondary mb-0">Your Tabler setup is working.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+Run the app:
+
+```shell
+npm run dev
+```
+
+Open the local Vite URL and confirm the card is styled with Tabler.
+
+### Next steps
+
+- Continue with [Customize](/ui/getting-started/customize) to adjust styles and build setup.
+- Explore [Layout](/ui/layout) to choose page structures.
+- Browse [Components](/ui/components) to add UI building blocks.
+
+</div>

--- a/docs/content/ui/getting-started/frameworks/react.md
+++ b/docs/content/ui/getting-started/frameworks/react.md
@@ -7,6 +7,8 @@ description: Install `@tabler/core`, import CSS and JS in React, and render a mi
 
 Use this guide to integrate Tabler in a React app with a standard Vite-based setup.
 
+Tabler works with any framework as markup + CSS; JS is only needed for interactive components.
+
 <div class="steps steps-vertical">
 
 ### Install Tabler package

--- a/docs/content/ui/getting-started/frameworks/sveltekit.md
+++ b/docs/content/ui/getting-started/frameworks/sveltekit.md
@@ -1,0 +1,111 @@
+---
+title: SvelteKit
+order: 10
+summary: Set up Tabler in SvelteKit and build a first working page.
+description: Install `@tabler/core`, import CSS and optional JS in SvelteKit, and render a minimal page layout with a Tabler card.
+---
+
+Use this guide to integrate Tabler in a SvelteKit app.
+
+Tabler works with any framework as markup + CSS; JS is only needed for interactive components.
+
+<div class="steps steps-vertical">
+
+### Install Tabler package
+
+Install `@tabler/core` with your preferred package manager:
+
+{% include "docs/tabs-package.html" name="@tabler/core" %}
+
+You can also use CDN files when you need a quick setup:
+
+```html
+<link rel="stylesheet" href="{{ cdnUrl }}/dist/css/tabler.min.css" />
+<script src="{{ cdnUrl }}/dist/js/tabler.min.js"></script>
+```
+
+### Import styles
+
+Import Tabler CSS once in your global stylesheet (`src/app.css`):
+
+```scss
+@import "@tabler/core/dist/css/tabler.min.css";
+```
+
+For full theme customization, import SCSS sources instead:
+
+```scss
+@import "@tabler/core/scss/tabler";
+```
+
+`@tabler/core` does not define `exports`, so deep imports work in common SvelteKit setups.
+
+### Import and initialize JavaScript
+
+Tabler JavaScript is required for interactive components such as dropdowns, modals, and tooltips.
+
+In SvelteKit, load `tabler.min.js` only on the client:
+
+```js
+import { browser } from "$app/environment";
+
+if (browser) {
+  await import("@tabler/core/dist/js/tabler.min.js");
+}
+```
+
+SvelteKit-specific note: `tabler.min.js` accesses `document`, so importing it during SSR can cause
+`document is not defined`.
+
+### Minimal working example
+
+Create a simple `src/routes/+layout.svelte` that loads global styles:
+
+```html
+<script>
+  import "../app.css";
+</script>
+
+<slot />
+```
+
+Then add a minimal page in `src/routes/+page.svelte`:
+
+```html
+<script>
+  import { browser } from "$app/environment";
+
+  if (browser) {
+    import("@tabler/core/dist/js/tabler.min.js");
+  }
+</script>
+
+<div class="page">
+  <div class="page-wrapper">
+    <div class="container-xl py-4">
+      <div class="card">
+        <div class="card-body">
+          <h3 class="card-title">SvelteKit + Tabler</h3>
+          <p class="text-secondary mb-0">Your Tabler setup is working.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+Run the app:
+
+```shell
+npm run dev
+```
+
+Open the local SvelteKit URL and confirm the card is styled with Tabler.
+
+### Next steps
+
+- Continue with [Customize](/ui/getting-started/customize) to adjust styles and build setup.
+- Explore [Layout](/ui/layout) to choose page structures.
+- Browse [Components](/ui/components) to add UI building blocks.
+
+</div>

--- a/docs/content/ui/getting-started/frameworks/symfony.md
+++ b/docs/content/ui/getting-started/frameworks/symfony.md
@@ -1,0 +1,117 @@
+---
+title: Symfony
+order: 7
+summary: Set up Tabler in Symfony and build a first working page.
+description: Install `@tabler/core`, import CSS and JS with Symfony asset tooling, and render a minimal page layout with a Tabler card.
+---
+
+Use this guide to integrate Tabler in a Symfony app.
+
+Tabler works with any framework as markup + CSS; JS is only needed for interactive components.
+
+<div class="steps steps-vertical">
+
+### Install Tabler package
+
+Install `@tabler/core` with your preferred package manager:
+
+{% include "docs/tabs-package.html" name="@tabler/core" %}
+
+You can also use CDN files when you need a quick setup:
+
+```html
+<link rel="stylesheet" href="{{ cdnUrl }}/dist/css/tabler.min.css" />
+<script src="{{ cdnUrl }}/dist/js/tabler.min.js"></script>
+```
+
+### Import styles
+
+If you use Webpack Encore, import Tabler CSS in `assets/styles/app.scss`:
+
+```scss
+@import "@tabler/core/dist/css/tabler.min.css";
+```
+
+For full theme customization, import SCSS sources instead:
+
+```scss
+@import "@tabler/core/scss/tabler";
+```
+
+`@tabler/core` does not define `exports`, so deep imports work in common Symfony build setups.
+
+### Import and initialize JavaScript
+
+Tabler JavaScript is required for interactive components such as dropdowns, modals, and tooltips.
+
+If you use Webpack Encore, import Tabler JS in `assets/app.js`:
+
+```js
+import "@tabler/core/dist/js/tabler.min.js";
+```
+
+Symfony-specific note: include generated Encore assets in your base Twig template:
+`{% raw %}{{ encore_entry_link_tags("app") }}{% endraw %}` and `{% raw %}{{ encore_entry_script_tags("app") }}{% endraw %}`.
+
+If you use AssetMapper instead of Encore, use CDN links or copy built Tabler files to your public assets.
+
+### Minimal working example
+
+Create a minimal Twig layout in `templates/base.html.twig`:
+
+{% raw %}
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {{ encore_entry_link_tags("app") }}
+  </head>
+  <body>
+    {% block body %}{% endblock %}
+    {{ encore_entry_script_tags("app") }}
+  </body>
+</html>
+```
+{% endraw %}
+
+Then add a simple page in `templates/home/index.html.twig`:
+
+{% raw %}
+```html
+{% extends "base.html.twig" %}
+
+{% block body %}
+<div class="page">
+  <div class="page-wrapper">
+    <div class="container-xl py-4">
+      <div class="card">
+        <div class="card-body">
+          <h3 class="card-title">Symfony + Tabler</h3>
+          <p class="text-secondary mb-0">Your Tabler setup is working.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+```
+{% endraw %}
+
+Run the app and asset build:
+
+```shell
+symfony server:start
+npm run dev
+```
+
+Open the local Symfony URL and confirm the card is styled with Tabler.
+
+### Next steps
+
+- Continue with [Customize](/ui/getting-started/customize) to adjust styles and build setup.
+- Explore [Layout](/ui/layout) to choose page structures.
+- Browse [Components](/ui/components) to add UI building blocks.
+
+</div>

--- a/docs/content/ui/getting-started/frameworks/vue.md
+++ b/docs/content/ui/getting-started/frameworks/vue.md
@@ -1,0 +1,108 @@
+---
+title: Vue
+order: 4
+summary: Set up Tabler in Vue and build a first working page.
+description: Install `@tabler/core`, import CSS and JS in Vue, and render a minimal page layout with a Tabler card.
+---
+
+Use this guide to integrate Tabler in a Vue app with a standard Vite-based setup.
+
+<div class="steps steps-vertical">
+
+### Install Tabler package
+
+Install `@tabler/core` with your preferred package manager:
+
+{% include "docs/tabs-package.html" name="@tabler/core" %}
+
+You can also use CDN files when you need a quick setup:
+
+```html
+<link rel="stylesheet" href="{{ cdnUrl }}/dist/css/tabler.min.css" />
+<script src="{{ cdnUrl }}/dist/js/tabler.min.js"></script>
+```
+
+### Import styles
+
+Import Tabler CSS once in your Vue entry file (`src/main.js`):
+
+```js
+import "@tabler/core/dist/css/tabler.min.css";
+```
+
+For full theme customization, import SCSS sources instead:
+
+```scss
+@import "@tabler/core/scss/tabler";
+```
+
+`@tabler/core` does not define `exports`, so deep imports work in common Vue build setups.
+
+### Import and initialize JavaScript
+
+Tabler JavaScript is required for interactive components such as dropdowns, modals, and tooltips.
+Import it once in `src/main.js`:
+
+```js
+import "@tabler/core/dist/js/tabler.min.js";
+```
+
+Vue-specific note: initialize DOM-based behavior after mount, not during render.
+Use `onMounted` in components that need manual initialization:
+
+```js
+import { onMounted } from "vue";
+
+onMounted(() => {
+  const elements = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+  elements.forEach((element) => new window.bootstrap.Tooltip(element));
+});
+```
+
+### Minimal working example
+
+Create a simple `src/main.js` that loads Tabler assets and mounts the app:
+
+```js
+import { createApp } from "vue";
+import App from "./App.vue";
+import "@tabler/core/dist/css/tabler.min.css";
+import "@tabler/core/dist/js/tabler.min.js";
+
+createApp(App).mount("#app");
+```
+
+Then create `src/App.vue` with a minimal Tabler layout and one card:
+
+```vue
+<template>
+  <div class="page">
+    <div class="page-wrapper">
+      <div class="container-xl py-4">
+        <div class="card">
+          <div class="card-body">
+            <h3 class="card-title">Vue + Tabler</h3>
+            <p class="text-secondary mb-0">Your Tabler setup is working.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+Run the app:
+
+```shell
+npm run dev
+```
+
+Open the local Vite URL and confirm the card is styled with Tabler.
+
+### Next steps
+
+- Continue with [Customize](/ui/getting-started/customize) to adjust styles and build setup.
+- Explore [Layout](/ui/layout) to choose page structures.
+- Browse [Components](/ui/components) to add UI building blocks.
+
+</div>

--- a/docs/content/ui/getting-started/frameworks/vue.md
+++ b/docs/content/ui/getting-started/frameworks/vue.md
@@ -7,6 +7,8 @@ description: Install `@tabler/core`, import CSS and JS in Vue, and render a mini
 
 Use this guide to integrate Tabler in a Vue app with a standard Vite-based setup.
 
+Tabler works with any framework as markup + CSS; JS is only needed for interactive components.
+
 <div class="steps steps-vertical">
 
 ### Install Tabler package

--- a/docs/content/ui/getting-started/installation.md
+++ b/docs/content/ui/getting-started/installation.md
@@ -2,8 +2,10 @@
 title: Installation
 order: 1
 summary: Learn how to set up Tabler in your project by creating a basic HTML file, adding Tabler’s CSS and JavaScript, and exploring its powerful components to build responsive and visually stunning web applications.
-description: "Set up Tabler: HTML, CSS, JS, and build stunning UIs."
+description: 'Set up Tabler: HTML, CSS, JS, and build stunning UIs.'
 ---
+
+Using a framework? See [Tabler framework integration guides](/ui/getting-started/frameworks).
 
 This guide will take you through the essential steps to set up Tabler in your project, from creating a basic HTML file to incorporating Tabler’s styles and scripts. Let’s dive in!
 

--- a/shared/layouts/docs/default.html
+++ b/shared/layouts/docs/default.html
@@ -130,7 +130,9 @@
 
 								{{ content | headings-id }}
 
+								{% unless hide_pagination %}
 								{% include "docs/pagination.html" %}
+								{% endunless %}
 
 								<div class="mt-7">
 									<div>


### PR DESCRIPTION
## Summary

- Add a new `/ui/getting-started/frameworks` section with card navigation for framework guides.
- Add full setup pages for Laravel, React, Next.js, Vue, and Angular using the same short step format.
- Add a clear note in each guide that Tabler works as markup + CSS, and JS is only for interactive components.
- Add a framework link in the main Installation page and support `hide_pagination` in docs layout for custom landing pages.

## Preview

- **How to test:** Open the frameworks page and verify that Laravel, React, Next.js, Vue, and Angular cards open real guides, while the remaining cards show as "Coming soon". Open each guide and confirm the same 5-step flow (install, styles, JS, minimal example, next steps). Open `/ui/getting-started/installation` and verify the new framework link near the top.