### PR TITLE
Add `sitemap.xml` and `robots.txt` for docs

### DIFF
--- a/.changeset/docs-sitemap-robots.md
+++ b/.changeset/docs-sitemap-robots.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Added `sitemap.xml` and `robots.txt` for the docs site, with a `sitemap` Eleventy collection and fixed docs layout title rendering outside production.

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ dist/
 packages-zip/
 .env
 sri.json
+preview-astro
 
 # TypeScript
 *.tsbuildinfo

--- a/docs/content/robots.liquid
+++ b/docs/content/robots.liquid
@@ -1,0 +1,14 @@
+---
+layout: null
+permalink: robots.txt
+eleventyExcludeFromCollections: true
+---
+Sitemap: {% if environment != 'development' %}{{ site.docsUrl }}{% endif %}/sitemap.xml
+
+{% if environment == 'development' %}
+User-agent: *
+Disallow: /
+{% else %}
+User-agent: *
+Disallow:
+{% endif %}

--- a/docs/content/sitemap.liquid
+++ b/docs/content/sitemap.liquid
@@ -1,0 +1,19 @@
+---
+layout: null
+permalink: sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+{% for entry in collections.sitemap %}
+{% assign path = entry.url | replace: 'index.html', '' %}
+{% if path == '/' %}
+{% assign path = '' %}
+{% endif %}
+<url>
+	<loc>{% if environment != 'development' %}{{ site.docsUrl }}{% endif %}{{ path | xml_escape }}</loc>
+	<lastmod>{{ entry.last_modified_at | default: 'now' | date_to_xmlschema }}</lastmod>
+</url>
+{% endfor %}
+</urlset>

--- a/docs/eleventy.config.mjs
+++ b/docs/eleventy.config.mjs
@@ -27,6 +27,17 @@ export default function (eleventyConfig) {
 		});
 	});
 
+	eleventyConfig.addCollection('sitemap', collection => {
+		return [...collection.getFilteredByGlob('./content/**/*.md')].sort((a, b) => {
+			const isHome = (page) => page.url === '/' || page.url === '/index.html';
+
+			if (isHome(a)) return -1;
+			if (isHome(b)) return 1;
+
+			return (a.url || '').localeCompare(b.url || '');
+		});
+	});
+
 	eleventyConfig.setInputDirectory("content");
 
 	eleventyConfig.amendLibrary('md', () => { });

--- a/shared/layouts/docs/default.html
+++ b/shared/layouts/docs/default.html
@@ -5,8 +5,6 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	{% if environment == 'production' %}
-	
 	{% assign pageSection = "" %}
 	{% if page.url contains "/ui/" %}
 	{% assign pageSection = "UI" %}
@@ -34,6 +32,7 @@
 	{% endif %}
 
 	<title>{{ metaTitle }} | {{ siteName }}</title>
+	{% if environment == 'production' %}
 	{% if metaDescription %}<meta name="description" content="{{ metaDescription }}">{% endif %}
 	<link rel="canonical" href="{{ page.url | absolute_url }}">
 


### PR DESCRIPTION
## Summary

- Add `sitemap.xml` for the docs site so search engines can find all documentation pages.
- Add `robots.txt` that points to the docs sitemap and blocks crawlers only in development.
- Add a `sitemap` Eleventy collection that lists all `.md` pages, with the homepage first.
- Fix docs layout so page titles and section names work outside production (SEO meta tags stay production-only).
- Ignore `preview-astro` in `.gitignore`.

## Preview

- **URL:** [docs preview](https://tabler-git-dev-docs-seo-tabler-io.vercel.app/sitemap.xml)
- **How to test:**
  1. Open `/sitemap.xml` and check the first entry is `https://docs.tabler.io` (homepage).
  2. Confirm all doc pages are listed with `lastmod` dates.
  3. Open `/robots.txt` and check it links to `https://docs.tabler.io/sitemap.xml` and allows crawling (not `Disallow: /`).
  4. Open any docs page and check the `<title>` includes the section name (e.g. `Tabler UI Documentation`).
  5. In production build, check `canonical`, `description`, and Open Graph tags still render.