### PR TITLE
Fix Astro photo source paths

### DIFF
--- a/shared/astro/components/ui/Avatar.astro
+++ b/shared/astro/components/ui/Avatar.astro
@@ -49,7 +49,7 @@ const {
 	statusIcon,
 	brand,
 	icon,
-	base = '.',
+	base = '',
 } = Astro.props;
 
 // equivalent of the first_letters filter

--- a/shared/astro/components/ui/Timeline.astro
+++ b/shared/astro/components/ui/Timeline.astro
@@ -81,15 +81,15 @@ const timelinePhotos = photos as { file: string; title: string }[];
 					<div class="row g-2">
 						<div class="col-4">
 							<!-- Photo -->
-							<img src={`./static/photos/${timelinePhotos[6].file}`} class="rounded" alt={timelinePhotos[6].title} />
+							<img src={`/static/photos/${timelinePhotos[6].file}`} class="rounded" alt={timelinePhotos[6].title} />
 						</div>
 						<div class="col-4">
 							<!-- Photo -->
-							<img src={`./static/photos/${timelinePhotos[7].file}`} class="rounded" alt={timelinePhotos[7].title} />
+							<img src={`/static/photos/${timelinePhotos[7].file}`} class="rounded" alt={timelinePhotos[7].title} />
 						</div>
 						<div class="col-4">
 							<!-- Photo -->
-							<img src={`./static/photos/${timelinePhotos[8].file}`} class="rounded" alt={timelinePhotos[8].title} />
+							<img src={`/static/photos/${timelinePhotos[8].file}`} class="rounded" alt={timelinePhotos[8].title} />
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

- Fix the default image base path in the Astro Avatar component.
- Use root-relative paths for Timeline photos so they load on nested pages.

## Preview

- **How to test:** Open the timeline page and confirm all avatars and attached photos load correctly.