### PR TITLE
Migrate core SCSS from `@import` to `@use`/`@forward`

### DIFF
--- a/core/scss/_core.scss
+++ b/core/scss/_core.scss
@@ -1,4 +1,5 @@
 @import 'config';
+@import 'layers';
 
 // Bootstrap components — managed by Tabler (see core/scss/bootstrap/)
 @import 'bootstrap/root';

--- a/core/scss/_layers.scss
+++ b/core/scss/_layers.scss
@@ -1,0 +1,16 @@
+// Cascade layers
+//
+// Declares the cascade layer order up front, so it applies regardless of the
+// order in which the layers are used later in the stylesheet.
+//
+// Kept outside of any layer on purpose:
+// - design tokens (`:root` custom properties in `props`, `bootstrap/root`,
+//   `layout/root`, `tabler-themes`) — unlayered styles always win, so user
+//   overrides of tokens keep working without specificity hacks
+// - `@property` registrations and `@font-face` rules — global by nature
+// - dark-mode switches (`layout/dark`)
+//
+// The `custom` layer is intentionally left empty: it is reserved for user
+// code. Styles placed in `@layer custom` override Tabler components, but
+// still lose to helpers and utilities.
+@layer root, reboot, layout, content, forms, components, custom, helpers, utilities;

--- a/core/scss/bootstrap/_button-group.scss
+++ b/core/scss/bootstrap/_button-group.scss
@@ -1,147 +1,151 @@
 // Make the div behave like a button
-.btn-group,
-.btn-group-vertical {
-  position: relative;
-  display: inline-flex;
-  vertical-align: middle; // match .btn alignment given font-size hack above
 
-  > .btn {
+@layer components {
+  .btn-group,
+  .btn-group-vertical {
     position: relative;
-    flex: 1 1 auto;
+    display: inline-flex;
+    vertical-align: middle; // match .btn alignment given font-size hack above
+
+    > .btn {
+      position: relative;
+      flex: 1 1 auto;
+    }
+
+    // Bring the hover, focused, and "active" buttons to the front to overlay
+    // the borders properly
+    > .btn-check:checked + .btn,
+    > .btn-check:focus + .btn,
+    > .btn:hover,
+    > .btn:focus,
+    > .btn:active,
+    > .btn.active {
+      z-index: 1;
+    }
   }
 
-  // Bring the hover, focused, and "active" buttons to the front to overlay
-  // the borders properly
-  > .btn-check:checked + .btn,
-  > .btn-check:focus + .btn,
-  > .btn:hover,
-  > .btn:focus,
-  > .btn:active,
-  > .btn.active {
-    z-index: 1;
-  }
-}
+  // Optional: Group multiple button groups together for a toolbar
+  .btn-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
 
-// Optional: Group multiple button groups together for a toolbar
-.btn-toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-
-  .input-group {
-    width: auto;
-  }
-}
-
-.btn-group {
-  @include border-radius($btn-border-radius);
-
-  // Prevent double borders when buttons are next to each other
-  > :not(.btn-check:first-child) + .btn,
-  > .btn-group:not(:first-child) {
-    margin-left: calc(-1 * #{$btn-border-width}); // stylelint-disable-line function-disallowed-list
+    .input-group {
+      width: auto;
+    }
   }
 
-  // Reset rounded corners
-  > .btn:not(:last-child):not(.dropdown-toggle),
-  > .btn.dropdown-toggle-split:first-child,
-  > .btn-group:not(:last-child) > .btn {
-    @include border-end-radius(0);
+  .btn-group {
+    @include border-radius($btn-border-radius);
+
+    // Prevent double borders when buttons are next to each other
+    > :not(.btn-check:first-child) + .btn,
+    > .btn-group:not(:first-child) {
+      margin-left: calc(-1 * #{$btn-border-width}); // stylelint-disable-line function-disallowed-list
+    }
+
+    // Reset rounded corners
+    > .btn:not(:last-child):not(.dropdown-toggle),
+    > .btn.dropdown-toggle-split:first-child,
+    > .btn-group:not(:last-child) > .btn {
+      @include border-end-radius(0);
+    }
+
+    // The left radius should be 0 if the button is:
+    // - the "third or more" child
+    // - the second child and the previous element isn't `.btn-check` (making it the first child visually)
+    // - part of a btn-group which isn't the first child
+    > .btn:nth-child(n + 3),
+    > :not(.btn-check) + .btn,
+    > .btn-group:not(:first-child) > .btn {
+      @include border-start-radius(0);
+    }
   }
 
-  // The left radius should be 0 if the button is:
-  // - the "third or more" child
-  // - the second child and the previous element isn't `.btn-check` (making it the first child visually)
-  // - part of a btn-group which isn't the first child
-  > .btn:nth-child(n + 3),
-  > :not(.btn-check) + .btn,
-  > .btn-group:not(:first-child) > .btn {
-    @include border-start-radius(0);
+  // Sizing
+  //
+  // Remix the default button sizing classes into new ones for easier manipulation.
+
+  .btn-group-sm > .btn {
+    @extend .btn-sm;
   }
-}
-
-// Sizing
-//
-// Remix the default button sizing classes into new ones for easier manipulation.
-
-.btn-group-sm > .btn { @extend .btn-sm; }
-.btn-group-lg > .btn { @extend .btn-lg; }
-
-
-//
-// Split button dropdowns
-//
-
-.dropdown-toggle-split {
-  padding-right: $btn-padding-x * .75;
-  padding-left: $btn-padding-x * .75;
-
-  &::after,
-  .dropup &::after,
-  .dropend &::after {
-    margin-left: 0;
+  .btn-group-lg > .btn {
+    @extend .btn-lg;
   }
 
-  .dropstart &::before {
-    margin-right: 0;
-  }
-}
+  //
+  // Split button dropdowns
+  //
 
-.btn-sm + .dropdown-toggle-split {
-  padding-right: $btn-padding-x-sm * .75;
-  padding-left: $btn-padding-x-sm * .75;
-}
+  .dropdown-toggle-split {
+    padding-right: $btn-padding-x * 0.75;
+    padding-left: $btn-padding-x * 0.75;
 
-.btn-lg + .dropdown-toggle-split {
-  padding-right: $btn-padding-x-lg * .75;
-  padding-left: $btn-padding-x-lg * .75;
-}
+    &::after,
+    .dropup &::after,
+    .dropend &::after {
+      margin-left: 0;
+    }
 
-
-// The clickable button for toggling the menu
-// Set the same inset shadow as the :active state
-.btn-group.show .dropdown-toggle {
-  @include box-shadow($btn-active-box-shadow);
-
-  // Show no shadow for `.btn-link` since it has no other button styles.
-  &.btn-link {
-    @include box-shadow(none);
-  }
-}
-
-
-//
-// Vertical button groups
-//
-
-.btn-group-vertical {
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
-
-  > .btn,
-  > .btn-group {
-    width: 100%;
+    .dropstart &::before {
+      margin-right: 0;
+    }
   }
 
-  > .btn:not(:first-child),
-  > .btn-group:not(:first-child) {
-    margin-top: calc(-1 * #{$btn-border-width}); // stylelint-disable-line function-disallowed-list
+  .btn-sm + .dropdown-toggle-split {
+    padding-right: $btn-padding-x-sm * 0.75;
+    padding-left: $btn-padding-x-sm * 0.75;
   }
 
-  // Reset rounded corners
-  > .btn:not(:last-child):not(.dropdown-toggle),
-  > .btn-group:not(:last-child) > .btn {
-    @include border-bottom-radius(0);
+  .btn-lg + .dropdown-toggle-split {
+    padding-right: $btn-padding-x-lg * 0.75;
+    padding-left: $btn-padding-x-lg * 0.75;
   }
 
-  // The top radius should be 0 if the button is:
-  // - the "third or more" child
-  // - the second child and the previous element isn't `.btn-check` (making it the first child visually)
-  // - part of a btn-group which isn't the first child
-  > .btn:nth-child(n + 3),
-  > :not(.btn-check) + .btn,
-  > .btn-group:not(:first-child) > .btn {
-    @include border-top-radius(0);
+  // The clickable button for toggling the menu
+  // Set the same inset shadow as the :active state
+  .btn-group.show .dropdown-toggle {
+    @include box-shadow($btn-active-box-shadow);
+
+    // Show no shadow for `.btn-link` since it has no other button styles.
+    &.btn-link {
+      @include box-shadow(none);
+    }
+  }
+
+  //
+  // Vertical button groups
+  //
+
+  .btn-group-vertical {
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+
+    > .btn,
+    > .btn-group {
+      width: 100%;
+    }
+
+    > .btn:not(:first-child),
+    > .btn-group:not(:first-child) {
+      margin-top: calc(-1 * #{$btn-border-width}); // stylelint-disable-line function-disallowed-list
+    }
+
+    // Reset rounded corners
+    > .btn:not(:last-child):not(.dropdown-toggle),
+    > .btn-group:not(:last-child) > .btn {
+      @include border-bottom-radius(0);
+    }
+
+    // The top radius should be 0 if the button is:
+    // - the "third or more" child
+    // - the second child and the previous element isn't `.btn-check` (making it the first child visually)
+    // - part of a btn-group which isn't the first child
+    > .btn:nth-child(n + 3),
+    > :not(.btn-check) + .btn,
+    > .btn-group:not(:first-child) > .btn {
+      @include border-top-radius(0);
+    }
   }
 }

--- a/core/scss/bootstrap/_buttons.scss
+++ b/core/scss/bootstrap/_buttons.scss
@@ -2,95 +2,106 @@
 // Base styles
 //
 
-.btn {
-  // scss-docs-start btn-css-vars
-  --#{$prefix}btn-padding-x: #{$btn-padding-x};
-  --#{$prefix}btn-padding-y: #{$btn-padding-y};
-  --#{$prefix}btn-font-family: #{$btn-font-family};
-  @include rfs($btn-font-size, --#{$prefix}btn-font-size);
-  --#{$prefix}btn-font-weight: #{$btn-font-weight};
-  --#{$prefix}btn-line-height: #{$btn-line-height};
-  --#{$prefix}btn-color: #{$btn-color};
-  --#{$prefix}btn-bg: transparent;
-  --#{$prefix}btn-border-width: #{$btn-border-width};
-  --#{$prefix}btn-border-color: transparent;
-  --#{$prefix}btn-border-radius: #{$btn-border-radius};
-  --#{$prefix}btn-hover-border-color: transparent;
-  --#{$prefix}btn-box-shadow: #{$btn-box-shadow};
-  --#{$prefix}btn-disabled-opacity: #{$btn-disabled-opacity};
-  --#{$prefix}btn-focus-box-shadow: 0 0 0 #{$btn-focus-width} rgba(var(--#{$prefix}btn-focus-shadow-rgb), .5);
-  // scss-docs-end btn-css-vars
+@layer components {
+  .btn {
+    // scss-docs-start btn-css-vars
+    --#{$prefix}btn-padding-x: #{$btn-padding-x};
+    --#{$prefix}btn-padding-y: #{$btn-padding-y};
+    --#{$prefix}btn-font-family: #{$btn-font-family};
+    @include rfs($btn-font-size, --#{$prefix}btn-font-size);
+    --#{$prefix}btn-font-weight: #{$btn-font-weight};
+    --#{$prefix}btn-line-height: #{$btn-line-height};
+    --#{$prefix}btn-color: #{$btn-color};
+    --#{$prefix}btn-bg: transparent;
+    --#{$prefix}btn-border-width: #{$btn-border-width};
+    --#{$prefix}btn-border-color: transparent;
+    --#{$prefix}btn-border-radius: #{$btn-border-radius};
+    --#{$prefix}btn-hover-border-color: transparent;
+    --#{$prefix}btn-box-shadow: #{$btn-box-shadow};
+    --#{$prefix}btn-disabled-opacity: #{$btn-disabled-opacity};
+    --#{$prefix}btn-focus-box-shadow: 0 0 0 #{$btn-focus-width} rgba(var(--#{$prefix}btn-focus-shadow-rgb), 0.5);
+    // scss-docs-end btn-css-vars
 
-  display: inline-block;
-  padding: var(--#{$prefix}btn-padding-y) var(--#{$prefix}btn-padding-x);
-  font-family: var(--#{$prefix}btn-font-family);
-  @include font-size(var(--#{$prefix}btn-font-size));
-  font-weight: var(--#{$prefix}btn-font-weight);
-  line-height: var(--#{$prefix}btn-line-height);
-  color: var(--#{$prefix}btn-color);
-  text-align: center;
-  text-decoration: if(sass($link-decoration == none): null; else: none);
-  white-space: $btn-white-space;
-  vertical-align: middle;
-  cursor: if(sass($enable-button-pointers): pointer; else: null);
-  user-select: none;
-  border: var(--#{$prefix}btn-border-width) solid var(--#{$prefix}btn-border-color);
-  @include border-radius(var(--#{$prefix}btn-border-radius));
-  @include gradient-bg(var(--#{$prefix}btn-bg));
-  @include box-shadow(var(--#{$prefix}btn-box-shadow));
-  @include transition($btn-transition);
-
-  &:hover {
-    color: var(--#{$prefix}btn-hover-color);
-    text-decoration: if(sass($link-hover-decoration == underline): none; else: null);
-    background-color: var(--#{$prefix}btn-hover-bg);
-    border-color: var(--#{$prefix}btn-hover-border-color);
-  }
-
-  .btn-check + &:hover {
-    // override for the checkbox/radio buttons
+    display: inline-block;
+    padding: var(--#{$prefix}btn-padding-y) var(--#{$prefix}btn-padding-x);
+    font-family: var(--#{$prefix}btn-font-family);
+    @include font-size(var(--#{$prefix}btn-font-size));
+    font-weight: var(--#{$prefix}btn-font-weight);
+    line-height: var(--#{$prefix}btn-line-height);
     color: var(--#{$prefix}btn-color);
-    background-color: var(--#{$prefix}btn-bg);
-    border-color: var(--#{$prefix}btn-border-color);
-  }
+    text-align: center;
+    text-decoration: if(sass($link-decoration == none): null; else: none);
+    white-space: $btn-white-space;
+    vertical-align: middle;
+    cursor: if(sass($enable-button-pointers): pointer; else: null);
+    user-select: none;
+    border: var(--#{$prefix}btn-border-width) solid var(--#{$prefix}btn-border-color);
+    @include border-radius(var(--#{$prefix}btn-border-radius));
+    @include gradient-bg(var(--#{$prefix}btn-bg));
+    @include box-shadow(var(--#{$prefix}btn-box-shadow));
+    @include transition($btn-transition);
 
-  &:focus-visible {
-    color: var(--#{$prefix}btn-hover-color);
-    @include gradient-bg(var(--#{$prefix}btn-hover-bg));
-    border-color: var(--#{$prefix}btn-hover-border-color);
-    outline: 0;
-    // Avoid using mixin so we can pass custom focus shadow properly
-    @if $enable-shadows {
-      box-shadow: var(--#{$prefix}btn-box-shadow), var(--#{$prefix}btn-focus-box-shadow);
-    } @else {
-      box-shadow: var(--#{$prefix}btn-focus-box-shadow);
+    &:hover {
+      color: var(--#{$prefix}btn-hover-color);
+      text-decoration: if(sass($link-hover-decoration == underline): none; else: null);
+      background-color: var(--#{$prefix}btn-hover-bg);
+      border-color: var(--#{$prefix}btn-hover-border-color);
     }
-  }
 
-  .btn-check:focus-visible + & {
-    border-color: var(--#{$prefix}btn-hover-border-color);
-    outline: 0;
-    // Avoid using mixin so we can pass custom focus shadow properly
-    @if $enable-shadows {
-      box-shadow: var(--#{$prefix}btn-box-shadow), var(--#{$prefix}btn-focus-box-shadow);
-    } @else {
-      box-shadow: var(--#{$prefix}btn-focus-box-shadow);
+    .btn-check + &:hover {
+      // override for the checkbox/radio buttons
+      color: var(--#{$prefix}btn-color);
+      background-color: var(--#{$prefix}btn-bg);
+      border-color: var(--#{$prefix}btn-border-color);
     }
-  }
-
-  .btn-check:checked + &,
-  :not(.btn-check) + &:active,
-  &:first-child:active,
-  &.active,
-  &.show {
-    color: var(--#{$prefix}btn-active-color);
-    background-color: var(--#{$prefix}btn-active-bg);
-    // Remove CSS gradients if they're enabled
-    background-image: if(sass($enable-gradients): none; else: null);
-    border-color: var(--#{$prefix}btn-active-border-color);
-    @include box-shadow(var(--#{$prefix}btn-active-shadow));
 
     &:focus-visible {
+      color: var(--#{$prefix}btn-hover-color);
+      @include gradient-bg(var(--#{$prefix}btn-hover-bg));
+      border-color: var(--#{$prefix}btn-hover-border-color);
+      outline: 0;
+      // Avoid using mixin so we can pass custom focus shadow properly
+      @if $enable-shadows {
+        box-shadow: var(--#{$prefix}btn-box-shadow), var(--#{$prefix}btn-focus-box-shadow);
+      } @else {
+        box-shadow: var(--#{$prefix}btn-focus-box-shadow);
+      }
+    }
+
+    .btn-check:focus-visible + & {
+      border-color: var(--#{$prefix}btn-hover-border-color);
+      outline: 0;
+      // Avoid using mixin so we can pass custom focus shadow properly
+      @if $enable-shadows {
+        box-shadow: var(--#{$prefix}btn-box-shadow), var(--#{$prefix}btn-focus-box-shadow);
+      } @else {
+        box-shadow: var(--#{$prefix}btn-focus-box-shadow);
+      }
+    }
+
+    .btn-check:checked + &,
+    :not(.btn-check) + &:active,
+    &:first-child:active,
+    &.active,
+    &.show {
+      color: var(--#{$prefix}btn-active-color);
+      background-color: var(--#{$prefix}btn-active-bg);
+      // Remove CSS gradients if they're enabled
+      background-image: if(sass($enable-gradients): none; else: null);
+      border-color: var(--#{$prefix}btn-active-border-color);
+      @include box-shadow(var(--#{$prefix}btn-active-shadow));
+
+      &:focus-visible {
+        // Avoid using mixin so we can pass custom focus shadow properly
+        @if $enable-shadows {
+          box-shadow: var(--#{$prefix}btn-active-shadow), var(--#{$prefix}btn-focus-box-shadow);
+        } @else {
+          box-shadow: var(--#{$prefix}btn-focus-box-shadow);
+        }
+      }
+    }
+
+    .btn-check:checked:focus-visible + & {
       // Avoid using mixin so we can pass custom focus shadow properly
       @if $enable-shadows {
         box-shadow: var(--#{$prefix}btn-active-shadow), var(--#{$prefix}btn-focus-box-shadow);
@@ -98,119 +109,100 @@
         box-shadow: var(--#{$prefix}btn-focus-box-shadow);
       }
     }
-  }
 
-  .btn-check:checked:focus-visible + & {
-    // Avoid using mixin so we can pass custom focus shadow properly
-    @if $enable-shadows {
-      box-shadow: var(--#{$prefix}btn-active-shadow), var(--#{$prefix}btn-focus-box-shadow);
-    } @else {
-      box-shadow: var(--#{$prefix}btn-focus-box-shadow);
+    &:disabled,
+    &.disabled,
+    fieldset:disabled & {
+      color: var(--#{$prefix}btn-disabled-color);
+      pointer-events: none;
+      background-color: var(--#{$prefix}btn-disabled-bg);
+      background-image: if(sass($enable-gradients): none; else: null);
+      border-color: var(--#{$prefix}btn-disabled-border-color);
+      opacity: var(--#{$prefix}btn-disabled-opacity);
+      @include box-shadow(none);
     }
   }
 
-  &:disabled,
-  &.disabled,
-  fieldset:disabled & {
-    color: var(--#{$prefix}btn-disabled-color);
-    pointer-events: none;
-    background-color: var(--#{$prefix}btn-disabled-bg);
-    background-image: if(sass($enable-gradients): none; else: null);
-    border-color: var(--#{$prefix}btn-disabled-border-color);
-    opacity: var(--#{$prefix}btn-disabled-opacity);
-    @include box-shadow(none);
-  }
-}
+  //
+  // Alternate buttons
+  //
 
-
-//
-// Alternate buttons
-//
-
-// scss-docs-start btn-variant-loops
-@each $color, $value in $theme-colors {
-  .btn-#{$color} {
-    @if $color == "light" {
-      @include button-variant(
-        $value,
-        $value,
-        $hover-background: shade-color($value, $btn-hover-bg-shade-amount),
-        $hover-border: shade-color($value, $btn-hover-border-shade-amount),
-        $active-background: shade-color($value, $btn-active-bg-shade-amount),
-        $active-border: shade-color($value, $btn-active-border-shade-amount)
-      );
-    } @else if $color == "dark" {
-      @include button-variant(
-        $value,
-        $value,
-        $hover-background: tint-color($value, $btn-hover-bg-tint-amount),
-        $hover-border: tint-color($value, $btn-hover-border-tint-amount),
-        $active-background: tint-color($value, $btn-active-bg-tint-amount),
-        $active-border: tint-color($value, $btn-active-border-tint-amount)
-      );
-    } @else {
-      @include button-variant($value, $value);
+  // scss-docs-start btn-variant-loops
+  @each $color, $value in $theme-colors {
+    .btn-#{$color} {
+      @if $color == 'light' {
+        @include button-variant(
+          $value,
+          $value,
+          $hover-background: shade-color($value, $btn-hover-bg-shade-amount),
+          $hover-border: shade-color($value, $btn-hover-border-shade-amount),
+          $active-background: shade-color($value, $btn-active-bg-shade-amount),
+          $active-border: shade-color($value, $btn-active-border-shade-amount)
+        );
+      } @else if $color == 'dark' {
+        @include button-variant($value, $value, $hover-background: tint-color($value, $btn-hover-bg-tint-amount), $hover-border: tint-color($value, $btn-hover-border-tint-amount), $active-background: tint-color($value, $btn-active-bg-tint-amount), $active-border: tint-color($value, $btn-active-border-tint-amount));
+      } @else {
+        @include button-variant($value, $value);
+      }
     }
   }
-}
 
-@each $color, $value in $theme-colors {
-  .btn-outline-#{$color} {
-    @include button-outline-variant($value);
+  @each $color, $value in $theme-colors {
+    .btn-outline-#{$color} {
+      @include button-outline-variant($value);
+    }
   }
-}
-// scss-docs-end btn-variant-loops
+  // scss-docs-end btn-variant-loops
 
+  //
+  // Link buttons
+  //
 
-//
-// Link buttons
-//
+  // Make a button look and behave like a link
+  .btn-link {
+    --#{$prefix}btn-font-weight: #{$font-weight-normal};
+    --#{$prefix}btn-color: #{$btn-link-color};
+    --#{$prefix}btn-bg: transparent;
+    --#{$prefix}btn-border-color: transparent;
+    --#{$prefix}btn-hover-color: #{$btn-link-hover-color};
+    --#{$prefix}btn-hover-border-color: transparent;
+    --#{$prefix}btn-active-color: #{$btn-link-hover-color};
+    --#{$prefix}btn-active-border-color: transparent;
+    --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color};
+    --#{$prefix}btn-disabled-border-color: transparent;
+    --#{$prefix}btn-box-shadow: 0 0 0 #000; // Can't use `none` as keyword negates all values when used with multiple shadows
+    --#{$prefix}btn-focus-shadow-rgb: #{$btn-link-focus-shadow-rgb};
 
-// Make a button look and behave like a link
-.btn-link {
-  --#{$prefix}btn-font-weight: #{$font-weight-normal};
-  --#{$prefix}btn-color: #{$btn-link-color};
-  --#{$prefix}btn-bg: transparent;
-  --#{$prefix}btn-border-color: transparent;
-  --#{$prefix}btn-hover-color: #{$btn-link-hover-color};
-  --#{$prefix}btn-hover-border-color: transparent;
-  --#{$prefix}btn-active-color: #{$btn-link-hover-color};
-  --#{$prefix}btn-active-border-color: transparent;
-  --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color};
-  --#{$prefix}btn-disabled-border-color: transparent;
-  --#{$prefix}btn-box-shadow: 0 0 0 #000; // Can't use `none` as keyword negates all values when used with multiple shadows
-  --#{$prefix}btn-focus-shadow-rgb: #{$btn-link-focus-shadow-rgb};
+    text-decoration: $link-decoration;
+    @if $enable-gradients {
+      background-image: none;
+    }
 
-  text-decoration: $link-decoration;
-  @if $enable-gradients {
-    background-image: none;
+    &:hover,
+    &:focus-visible {
+      text-decoration: $link-hover-decoration;
+    }
+
+    &:focus-visible {
+      color: var(--#{$prefix}btn-color);
+    }
+
+    &:hover {
+      color: var(--#{$prefix}btn-hover-color);
+    }
+
+    // No need for an active state here
   }
 
-  &:hover,
-  &:focus-visible {
-    text-decoration: $link-hover-decoration;
+  //
+  // Button Sizes
+  //
+
+  .btn-lg {
+    @include button-size($btn-padding-y-lg, $btn-padding-x-lg, $btn-font-size-lg, $btn-border-radius-lg);
   }
 
-  &:focus-visible {
-    color: var(--#{$prefix}btn-color);
+  .btn-sm {
+    @include button-size($btn-padding-y-sm, $btn-padding-x-sm, $btn-font-size-sm, $btn-border-radius-sm);
   }
-
-  &:hover {
-    color: var(--#{$prefix}btn-hover-color);
-  }
-
-  // No need for an active state here
-}
-
-
-//
-// Button Sizes
-//
-
-.btn-lg {
-  @include button-size($btn-padding-y-lg, $btn-padding-x-lg, $btn-font-size-lg, $btn-border-radius-lg);
-}
-
-.btn-sm {
-  @include button-size($btn-padding-y-sm, $btn-padding-x-sm, $btn-font-size-sm, $btn-border-radius-sm);
 }

--- a/core/scss/bootstrap/_card.scss
+++ b/core/scss/bootstrap/_card.scss
@@ -2,234 +2,234 @@
 // Base styles
 //
 
-.card {
-  // scss-docs-start card-css-vars
-  --#{$prefix}card-spacer-y: #{$card-spacer-y};
-  --#{$prefix}card-spacer-x: #{$card-spacer-x};
-  --#{$prefix}card-title-spacer-y: #{$card-title-spacer-y};
-  --#{$prefix}card-title-color: #{$card-title-color};
-  --#{$prefix}card-subtitle-color: #{$card-subtitle-color};
-  --#{$prefix}card-border-width: #{$card-border-width};
-  --#{$prefix}card-border-color: #{$card-border-color};
-  --#{$prefix}card-border-radius: #{$card-border-radius};
-  --#{$prefix}card-box-shadow: #{$card-box-shadow};
-  --#{$prefix}card-inner-border-radius: #{$card-inner-border-radius};
-  --#{$prefix}card-cap-padding-y: #{$card-cap-padding-y};
-  --#{$prefix}card-cap-padding-x: #{$card-cap-padding-x};
-  --#{$prefix}card-cap-bg: #{$card-cap-bg};
-  --#{$prefix}card-cap-color: #{$card-cap-color};
-  --#{$prefix}card-height: #{$card-height};
-  --#{$prefix}card-color: #{$card-color};
-  --#{$prefix}card-bg: #{$card-bg};
-  --#{$prefix}card-img-overlay-padding: #{$card-img-overlay-padding};
-  --#{$prefix}card-group-margin: #{$card-group-margin};
-  // scss-docs-end card-css-vars
+@layer components {
+  .card {
+    // scss-docs-start card-css-vars
+    --#{$prefix}card-spacer-y: #{$card-spacer-y};
+    --#{$prefix}card-spacer-x: #{$card-spacer-x};
+    --#{$prefix}card-title-spacer-y: #{$card-title-spacer-y};
+    --#{$prefix}card-title-color: #{$card-title-color};
+    --#{$prefix}card-subtitle-color: #{$card-subtitle-color};
+    --#{$prefix}card-border-width: #{$card-border-width};
+    --#{$prefix}card-border-color: #{$card-border-color};
+    --#{$prefix}card-border-radius: #{$card-border-radius};
+    --#{$prefix}card-box-shadow: #{$card-box-shadow};
+    --#{$prefix}card-inner-border-radius: #{$card-inner-border-radius};
+    --#{$prefix}card-cap-padding-y: #{$card-cap-padding-y};
+    --#{$prefix}card-cap-padding-x: #{$card-cap-padding-x};
+    --#{$prefix}card-cap-bg: #{$card-cap-bg};
+    --#{$prefix}card-cap-color: #{$card-cap-color};
+    --#{$prefix}card-height: #{$card-height};
+    --#{$prefix}card-color: #{$card-color};
+    --#{$prefix}card-bg: #{$card-bg};
+    --#{$prefix}card-img-overlay-padding: #{$card-img-overlay-padding};
+    --#{$prefix}card-group-margin: #{$card-group-margin};
+    // scss-docs-end card-css-vars
 
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  min-width: 0; // See https://github.com/twbs/bootstrap/pull/22740#issuecomment-305868106
-  height: var(--#{$prefix}card-height);
-  color: var(--#{$prefix}body-color);
-  word-wrap: break-word;
-  background-color: var(--#{$prefix}card-bg);
-  background-clip: border-box;
-  border: var(--#{$prefix}card-border-width) solid var(--#{$prefix}card-border-color);
-  @include border-radius(var(--#{$prefix}card-border-radius));
-  @include box-shadow(var(--#{$prefix}card-box-shadow));
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    min-width: 0; // See https://github.com/twbs/bootstrap/pull/22740#issuecomment-305868106
+    height: var(--#{$prefix}card-height);
+    color: var(--#{$prefix}body-color);
+    word-wrap: break-word;
+    background-color: var(--#{$prefix}card-bg);
+    background-clip: border-box;
+    border: var(--#{$prefix}card-border-width) solid var(--#{$prefix}card-border-color);
+    @include border-radius(var(--#{$prefix}card-border-radius));
+    @include box-shadow(var(--#{$prefix}card-box-shadow));
 
-  > hr {
-    margin-right: 0;
-    margin-left: 0;
+    > hr {
+      margin-right: 0;
+      margin-left: 0;
+    }
+
+    > .list-group {
+      border-top: inherit;
+      border-bottom: inherit;
+
+      &:first-child {
+        border-top-width: 0;
+        @include border-top-radius(var(--#{$prefix}card-inner-border-radius));
+      }
+
+      &:last-child {
+        border-bottom-width: 0;
+        @include border-bottom-radius(var(--#{$prefix}card-inner-border-radius));
+      }
+    }
+
+    // Due to specificity of the above selector (`.card > .list-group`), we must
+    // use a child selector here to prevent double borders.
+    > .card-header + .list-group,
+    > .list-group + .card-footer {
+      border-top: 0;
+    }
   }
 
-  > .list-group {
-    border-top: inherit;
-    border-bottom: inherit;
+  .card-body {
+    // Enable `flex-grow: 1` for decks and groups so that card blocks take up
+    // as much space as possible, ensuring footers are aligned to the bottom.
+    flex: 1 1 auto;
+    padding: var(--#{$prefix}card-spacer-y) var(--#{$prefix}card-spacer-x);
+    color: var(--#{$prefix}card-color);
+  }
+
+  .card-title {
+    margin-bottom: var(--#{$prefix}card-title-spacer-y);
+    color: var(--#{$prefix}card-title-color);
+  }
+
+  .card-subtitle {
+    margin-top: calc(-0.5 * var(--#{$prefix}card-title-spacer-y)); // stylelint-disable-line function-disallowed-list
+    margin-bottom: 0;
+    color: var(--#{$prefix}card-subtitle-color);
+  }
+
+  .card-text:last-child {
+    margin-bottom: 0;
+  }
+
+  .card-link {
+    &:hover {
+      text-decoration: if(sass($link-hover-decoration == underline): none; else: null);
+    }
+
+    + .card-link {
+      margin-left: var(--#{$prefix}card-spacer-x);
+    }
+  }
+
+  //
+  // Optional textual caps
+  //
+
+  .card-header {
+    padding: var(--#{$prefix}card-cap-padding-y) var(--#{$prefix}card-cap-padding-x);
+    margin-bottom: 0; // Removes the default margin-bottom of <hN>
+    color: var(--#{$prefix}card-cap-color);
+    background-color: var(--#{$prefix}card-cap-bg);
+    border-bottom: var(--#{$prefix}card-border-width) solid var(--#{$prefix}card-border-color);
 
     &:first-child {
-      border-top-width: 0;
-      @include border-top-radius(var(--#{$prefix}card-inner-border-radius));
-    }
-
-    &:last-child  {
-      border-bottom-width: 0;
-      @include border-bottom-radius(var(--#{$prefix}card-inner-border-radius));
+      @include border-radius(var(--#{$prefix}card-inner-border-radius) var(--#{$prefix}card-inner-border-radius) 0 0);
     }
   }
 
-  // Due to specificity of the above selector (`.card > .list-group`), we must
-  // use a child selector here to prevent double borders.
-  > .card-header + .list-group,
-  > .list-group + .card-footer {
-    border-top: 0;
-  }
-}
+  .card-footer {
+    padding: var(--#{$prefix}card-cap-padding-y) var(--#{$prefix}card-cap-padding-x);
+    color: var(--#{$prefix}card-cap-color);
+    background-color: var(--#{$prefix}card-cap-bg);
+    border-top: var(--#{$prefix}card-border-width) solid var(--#{$prefix}card-border-color);
 
-.card-body {
-  // Enable `flex-grow: 1` for decks and groups so that card blocks take up
-  // as much space as possible, ensuring footers are aligned to the bottom.
-  flex: 1 1 auto;
-  padding: var(--#{$prefix}card-spacer-y) var(--#{$prefix}card-spacer-x);
-  color: var(--#{$prefix}card-color);
-}
-
-.card-title {
-  margin-bottom: var(--#{$prefix}card-title-spacer-y);
-  color: var(--#{$prefix}card-title-color);
-}
-
-.card-subtitle {
-  margin-top: calc(-.5 * var(--#{$prefix}card-title-spacer-y)); // stylelint-disable-line function-disallowed-list
-  margin-bottom: 0;
-  color: var(--#{$prefix}card-subtitle-color);
-}
-
-.card-text:last-child {
-  margin-bottom: 0;
-}
-
-.card-link {
-  &:hover {
-    text-decoration: if(sass($link-hover-decoration == underline): none; else: null);
+    &:last-child {
+      @include border-radius(0 0 var(--#{$prefix}card-inner-border-radius) var(--#{$prefix}card-inner-border-radius));
+    }
   }
 
-  + .card-link {
-    margin-left: var(--#{$prefix}card-spacer-x);
-  }
-}
+  //
+  // Header navs
+  //
 
-//
-// Optional textual caps
-//
+  .card-header-tabs {
+    margin-right: calc(-0.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
+    margin-bottom: calc(-1 * var(--#{$prefix}card-cap-padding-y)); // stylelint-disable-line function-disallowed-list
+    margin-left: calc(-0.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
+    border-bottom: 0;
 
-.card-header {
-  padding: var(--#{$prefix}card-cap-padding-y) var(--#{$prefix}card-cap-padding-x);
-  margin-bottom: 0; // Removes the default margin-bottom of <hN>
-  color: var(--#{$prefix}card-cap-color);
-  background-color: var(--#{$prefix}card-cap-bg);
-  border-bottom: var(--#{$prefix}card-border-width) solid var(--#{$prefix}card-border-color);
-
-  &:first-child {
-    @include border-radius(var(--#{$prefix}card-inner-border-radius) var(--#{$prefix}card-inner-border-radius) 0 0);
-  }
-}
-
-.card-footer {
-  padding: var(--#{$prefix}card-cap-padding-y) var(--#{$prefix}card-cap-padding-x);
-  color: var(--#{$prefix}card-cap-color);
-  background-color: var(--#{$prefix}card-cap-bg);
-  border-top: var(--#{$prefix}card-border-width) solid var(--#{$prefix}card-border-color);
-
-  &:last-child {
-    @include border-radius(0 0 var(--#{$prefix}card-inner-border-radius) var(--#{$prefix}card-inner-border-radius));
-  }
-}
-
-
-//
-// Header navs
-//
-
-.card-header-tabs {
-  margin-right: calc(-.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
-  margin-bottom: calc(-1 * var(--#{$prefix}card-cap-padding-y)); // stylelint-disable-line function-disallowed-list
-  margin-left: calc(-.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
-  border-bottom: 0;
-
-  .nav-link.active {
-    background-color: var(--#{$prefix}card-bg);
-    border-bottom-color: var(--#{$prefix}card-bg);
-  }
-}
-
-.card-header-pills {
-  margin-right: calc(-.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
-  margin-left: calc(-.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
-}
-
-// Card image
-.card-img-overlay {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  padding: var(--#{$prefix}card-img-overlay-padding);
-  @include border-radius(var(--#{$prefix}card-inner-border-radius));
-}
-
-.card-img,
-.card-img-top,
-.card-img-bottom {
-  width: 100%; // Required because we use flexbox and this inherently applies align-self: stretch
-}
-
-.card-img,
-.card-img-top {
-  @include border-top-radius(var(--#{$prefix}card-inner-border-radius));
-}
-
-.card-img,
-.card-img-bottom {
-  @include border-bottom-radius(var(--#{$prefix}card-inner-border-radius));
-}
-
-
-//
-// Card groups
-//
-
-.card-group {
-  // The child selector allows nested `.card` within `.card-group`
-  // to display properly.
-  > .card {
-    margin-bottom: var(--#{$prefix}card-group-margin);
+    .nav-link.active {
+      background-color: var(--#{$prefix}card-bg);
+      border-bottom-color: var(--#{$prefix}card-bg);
+    }
   }
 
-  @include media-breakpoint-up(sm) {
-    display: flex;
-    flex-flow: row wrap;
+  .card-header-pills {
+    margin-right: calc(-0.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
+    margin-left: calc(-0.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
+  }
+
+  // Card image
+  .card-img-overlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    padding: var(--#{$prefix}card-img-overlay-padding);
+    @include border-radius(var(--#{$prefix}card-inner-border-radius));
+  }
+
+  .card-img,
+  .card-img-top,
+  .card-img-bottom {
+    width: 100%; // Required because we use flexbox and this inherently applies align-self: stretch
+  }
+
+  .card-img,
+  .card-img-top {
+    @include border-top-radius(var(--#{$prefix}card-inner-border-radius));
+  }
+
+  .card-img,
+  .card-img-bottom {
+    @include border-bottom-radius(var(--#{$prefix}card-inner-border-radius));
+  }
+
+  //
+  // Card groups
+  //
+
+  .card-group {
     // The child selector allows nested `.card` within `.card-group`
     // to display properly.
     > .card {
-      flex: 1 0 0;
-      margin-bottom: 0;
+      margin-bottom: var(--#{$prefix}card-group-margin);
+    }
 
-      + .card {
-        margin-left: 0;
-        border-left: 0;
-      }
+    @include media-breakpoint-up(sm) {
+      display: flex;
+      flex-flow: row wrap;
+      // The child selector allows nested `.card` within `.card-group`
+      // to display properly.
+      > .card {
+        flex: 1 0 0;
+        margin-bottom: 0;
 
-      // Handle rounded corners
-      @if $enable-rounded {
-        &:not(:last-child) {
-          @include border-end-radius(0);
-
-          > .card-img-top,
-          > .card-header {
-            // stylelint-disable-next-line property-disallowed-list
-            border-top-right-radius: 0;
-          }
-          > .card-img-bottom,
-          > .card-footer {
-            // stylelint-disable-next-line property-disallowed-list
-            border-bottom-right-radius: 0;
-          }
+        + .card {
+          margin-left: 0;
+          border-left: 0;
         }
 
-        &:not(:first-child) {
-          @include border-start-radius(0);
+        // Handle rounded corners
+        @if $enable-rounded {
+          &:not(:last-child) {
+            @include border-end-radius(0);
 
-          > .card-img-top,
-          > .card-header {
-            // stylelint-disable-next-line property-disallowed-list
-            border-top-left-radius: 0;
+            > .card-img-top,
+            > .card-header {
+              // stylelint-disable-next-line property-disallowed-list
+              border-top-right-radius: 0;
+            }
+            > .card-img-bottom,
+            > .card-footer {
+              // stylelint-disable-next-line property-disallowed-list
+              border-bottom-right-radius: 0;
+            }
           }
-          > .card-img-bottom,
-          > .card-footer {
-            // stylelint-disable-next-line property-disallowed-list
-            border-bottom-left-radius: 0;
+
+          &:not(:first-child) {
+            @include border-start-radius(0);
+
+            > .card-img-top,
+            > .card-header {
+              // stylelint-disable-next-line property-disallowed-list
+              border-top-left-radius: 0;
+            }
+            > .card-img-bottom,
+            > .card-footer {
+              // stylelint-disable-next-line property-disallowed-list
+              border-bottom-left-radius: 0;
+            }
           }
         }
       }

--- a/core/scss/bootstrap/_carousel.scss
+++ b/core/scss/bootstrap/_carousel.scss
@@ -11,218 +11,217 @@
 // 5. .carousel-item-next.carousel-item-start and .carousel-item-prev.carousel-item-end
 //    is the upcoming slide in transition.
 
-.carousel {
-  position: relative;
-}
+@layer components {
+  .carousel {
+    position: relative;
+  }
 
-.carousel.pointer-event {
-  touch-action: pan-y;
-}
+  .carousel.pointer-event {
+    touch-action: pan-y;
+  }
 
-.carousel-inner {
-  position: relative;
-  width: 100%;
-  overflow: hidden;
-  @include clearfix();
-}
+  .carousel-inner {
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+    @include clearfix();
+  }
 
-.carousel-item {
-  position: relative;
-  display: none;
-  float: left;
-  width: 100%;
-  margin-right: -100%;
-  backface-visibility: hidden;
-  @include transition($carousel-transition);
-}
-
-.carousel-item.active,
-.carousel-item-next,
-.carousel-item-prev {
-  display: block;
-}
-
-.carousel-item-next:not(.carousel-item-start),
-.active.carousel-item-end {
-  transform: translateX(100%);
-}
-
-.carousel-item-prev:not(.carousel-item-end),
-.active.carousel-item-start {
-  transform: translateX(-100%);
-}
-
-
-//
-// Alternate transitions
-//
-
-.carousel-fade {
   .carousel-item {
-    opacity: 0;
-    transition-property: opacity;
-    transform: none;
+    position: relative;
+    display: none;
+    float: left;
+    width: 100%;
+    margin-right: -100%;
+    backface-visibility: hidden;
+    @include transition($carousel-transition);
   }
 
   .carousel-item.active,
-  .carousel-item-next.carousel-item-start,
-  .carousel-item-prev.carousel-item-end {
-    z-index: 1;
-    opacity: 1;
+  .carousel-item-next,
+  .carousel-item-prev {
+    display: block;
   }
 
-  .active.carousel-item-start,
+  .carousel-item-next:not(.carousel-item-start),
   .active.carousel-item-end {
-    z-index: 0;
-    opacity: 0;
-    @include transition(opacity 0s $carousel-transition-duration);
+    transform: translateX(100%);
   }
-}
 
-
-//
-// Left/right controls for nav
-//
-
-.carousel-control-prev,
-.carousel-control-next {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  z-index: 1;
-  // Use flex for alignment (1-3)
-  display: flex; // 1. allow flex styles
-  align-items: center; // 2. vertically center contents
-  justify-content: center; // 3. horizontally center contents
-  width: $carousel-control-width;
-  padding: 0;
-  color: $carousel-control-color;
-  text-align: center;
-  background: none;
-  filter: var(--#{$prefix}carousel-control-icon-filter);
-  border: 0;
-  opacity: $carousel-control-opacity;
-  @include transition($carousel-control-transition);
-
-  // Hover/focus state
-  &:hover,
-  &:focus {
-    color: $carousel-control-color;
-    text-decoration: none;
-    outline: 0;
-    opacity: $carousel-control-hover-opacity;
+  .carousel-item-prev:not(.carousel-item-end),
+  .active.carousel-item-start {
+    transform: translateX(-100%);
   }
-}
-.carousel-control-prev {
-  left: 0;
-  background-image: if(sass($enable-gradients): linear-gradient(90deg, rgba($black, .25), rgba($black, .001)); else: null);
-}
-.carousel-control-next {
-  right: 0;
-  background-image: if(sass($enable-gradients): linear-gradient(270deg, rgba($black, .25), rgba($black, .001)); else: null);
-}
 
-// Icons for within
-.carousel-control-prev-icon,
-.carousel-control-next-icon {
-  display: inline-block;
-  width: $carousel-control-icon-width;
-  height: $carousel-control-icon-width;
-  background-repeat: no-repeat;
-  background-position: 50%;
-  background-size: 100% 100%;
-}
+  //
+  // Alternate transitions
+  //
 
-.carousel-control-prev-icon {
-  background-image: escape-svg($carousel-control-prev-icon-bg) #{"/*rtl:" + escape-svg($carousel-control-next-icon-bg) + "*/"};
-}
-.carousel-control-next-icon {
-  background-image: escape-svg($carousel-control-next-icon-bg) #{"/*rtl:" + escape-svg($carousel-control-prev-icon-bg) + "*/"};
-}
+  .carousel-fade {
+    .carousel-item {
+      opacity: 0;
+      transition-property: opacity;
+      transform: none;
+    }
 
-// Optional indicator pips/controls
-//
-// Add a container (such as a list) with the following class and add an item (ideally a focusable control,
-// like a button) with data-bs-target for each slide your carousel holds.
+    .carousel-item.active,
+    .carousel-item-next.carousel-item-start,
+    .carousel-item-prev.carousel-item-end {
+      z-index: 1;
+      opacity: 1;
+    }
 
-.carousel-indicators {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 2;
-  display: flex;
-  justify-content: center;
-  padding: 0;
-  // Use the .carousel-control's width as margin so we don't overlay those
-  margin-right: $carousel-control-width;
-  margin-bottom: 1rem;
-  margin-left: $carousel-control-width;
+    .active.carousel-item-start,
+    .active.carousel-item-end {
+      z-index: 0;
+      opacity: 0;
+      @include transition(opacity 0s $carousel-transition-duration);
+    }
+  }
 
-  [data-bs-target],
-  [data-target] {
-    box-sizing: content-box;
-    flex: 0 1 auto;
-    width: $carousel-indicator-width;
-    height: $carousel-indicator-height;
+  //
+  // Left/right controls for nav
+  //
+
+  .carousel-control-prev,
+  .carousel-control-next {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 1;
+    // Use flex for alignment (1-3)
+    display: flex; // 1. allow flex styles
+    align-items: center; // 2. vertically center contents
+    justify-content: center; // 3. horizontally center contents
+    width: $carousel-control-width;
     padding: 0;
-    margin-right: $carousel-indicator-spacer;
-    margin-left: $carousel-indicator-spacer;
-    text-indent: -999px;
-    cursor: pointer;
-    background-color: var(--#{$prefix}carousel-indicator-active-bg);
-    background-clip: padding-box;
+    color: $carousel-control-color;
+    text-align: center;
+    background: none;
+    filter: var(--#{$prefix}carousel-control-icon-filter);
     border: 0;
-    // Use transparent borders to increase the hit area by 10px on top and bottom.
-    border-top: $carousel-indicator-hit-area-height solid transparent;
-    border-bottom: $carousel-indicator-hit-area-height solid transparent;
-    opacity: $carousel-indicator-opacity;
-    @include transition($carousel-indicator-transition);
+    opacity: $carousel-control-opacity;
+    @include transition($carousel-control-transition);
+
+    // Hover/focus state
+    &:hover,
+    &:focus {
+      color: $carousel-control-color;
+      text-decoration: none;
+      outline: 0;
+      opacity: $carousel-control-hover-opacity;
+    }
+  }
+  .carousel-control-prev {
+    left: 0;
+    background-image: if(sass($enable-gradients): linear-gradient(90deg, rgba($black, 0.25), rgba($black, 0.001)); else: null);
+  }
+  .carousel-control-next {
+    right: 0;
+    background-image: if(sass($enable-gradients): linear-gradient(270deg, rgba($black, 0.25), rgba($black, 0.001)); else: null);
   }
 
-  .active {
-    opacity: $carousel-indicator-active-opacity;
+  // Icons for within
+  .carousel-control-prev-icon,
+  .carousel-control-next-icon {
+    display: inline-block;
+    width: $carousel-control-icon-width;
+    height: $carousel-control-icon-width;
+    background-repeat: no-repeat;
+    background-position: 50%;
+    background-size: 100% 100%;
   }
-}
 
+  .carousel-control-prev-icon {
+    background-image: escape-svg($carousel-control-prev-icon-bg) #{'/*rtl:' + escape-svg($carousel-control-next-icon-bg) + '*/'};
+  }
+  .carousel-control-next-icon {
+    background-image: escape-svg($carousel-control-next-icon-bg) #{'/*rtl:' + escape-svg($carousel-control-prev-icon-bg) + '*/'};
+  }
 
-// Optional captions
-//
-//
+  // Optional indicator pips/controls
+  //
+  // Add a container (such as a list) with the following class and add an item (ideally a focusable control,
+  // like a button) with data-bs-target for each slide your carousel holds.
 
-.carousel-caption {
-  position: absolute;
-  right: (100% - $carousel-caption-width) * .5;
-  bottom: $carousel-caption-spacer;
-  left: (100% - $carousel-caption-width) * .5;
-  padding-top: $carousel-caption-padding-y;
-  padding-bottom: $carousel-caption-padding-y;
-  color: var(--#{$prefix}carousel-caption-color);
-  text-align: center;
-}
+  .carousel-indicators {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 2;
+    display: flex;
+    justify-content: center;
+    padding: 0;
+    // Use the .carousel-control's width as margin so we don't overlay those
+    margin-right: $carousel-control-width;
+    margin-bottom: 1rem;
+    margin-left: $carousel-control-width;
 
-// Dark mode carousel
+    [data-bs-target],
+    [data-target] {
+      box-sizing: content-box;
+      flex: 0 1 auto;
+      width: $carousel-indicator-width;
+      height: $carousel-indicator-height;
+      padding: 0;
+      margin-right: $carousel-indicator-spacer;
+      margin-left: $carousel-indicator-spacer;
+      text-indent: -999px;
+      cursor: pointer;
+      background-color: var(--#{$prefix}carousel-indicator-active-bg);
+      background-clip: padding-box;
+      border: 0;
+      // Use transparent borders to increase the hit area by 10px on top and bottom.
+      border-top: $carousel-indicator-hit-area-height solid transparent;
+      border-bottom: $carousel-indicator-hit-area-height solid transparent;
+      opacity: $carousel-indicator-opacity;
+      @include transition($carousel-indicator-transition);
+    }
 
-@mixin carousel-dark() {
-  --#{$prefix}carousel-indicator-active-bg: #{$carousel-indicator-active-bg-dark};
-  --#{$prefix}carousel-caption-color: #{$carousel-caption-color-dark};
-  --#{$prefix}carousel-control-icon-filter: #{$carousel-control-icon-filter-dark};
-}
+    .active {
+      opacity: $carousel-indicator-active-opacity;
+    }
+  }
 
-.carousel-dark {
-  @include carousel-dark();
-}
+  // Optional captions
+  //
+  //
 
-:root,
-[data-bs-theme="light"],
-[data-theme="light"] {
-  --#{$prefix}carousel-indicator-active-bg: #{$carousel-indicator-active-bg};
-  --#{$prefix}carousel-caption-color: #{$carousel-caption-color};
-  --#{$prefix}carousel-control-icon-filter: #{$carousel-control-icon-filter};
-}
+  .carousel-caption {
+    position: absolute;
+    right: (100% - $carousel-caption-width) * 0.5;
+    bottom: $carousel-caption-spacer;
+    left: (100% - $carousel-caption-width) * 0.5;
+    padding-top: $carousel-caption-padding-y;
+    padding-bottom: $carousel-caption-padding-y;
+    color: var(--#{$prefix}carousel-caption-color);
+    text-align: center;
+  }
 
-@if $enable-dark-mode {
-  @include color-mode(dark, true) {
+  // Dark mode carousel
+
+  @mixin carousel-dark() {
+    --#{$prefix}carousel-indicator-active-bg: #{$carousel-indicator-active-bg-dark};
+    --#{$prefix}carousel-caption-color: #{$carousel-caption-color-dark};
+    --#{$prefix}carousel-control-icon-filter: #{$carousel-control-icon-filter-dark};
+  }
+
+  .carousel-dark {
     @include carousel-dark();
+  }
+
+  :root,
+  [data-bs-theme='light'],
+  [data-theme='light'] {
+    --#{$prefix}carousel-indicator-active-bg: #{$carousel-indicator-active-bg};
+    --#{$prefix}carousel-caption-color: #{$carousel-caption-color};
+    --#{$prefix}carousel-control-icon-filter: #{$carousel-control-icon-filter};
+  }
+
+  @if $enable-dark-mode {
+    @include color-mode(dark, true) {
+      @include carousel-dark();
+    }
   }
 }

--- a/core/scss/bootstrap/_containers.scss
+++ b/core/scss/bootstrap/_containers.scss
@@ -2,37 +2,39 @@
 //
 // Set the container width, and override it for fixed navbars in media queries.
 
-@if $enable-container-classes {
-  // Single container class with breakpoint max-widths
-  .container,
-  // 100% wide container at all breakpoints
-  .container-fluid {
-    @include make-container();
-  }
-
-  // Responsive containers that are 100% wide until a breakpoint
-  @each $breakpoint, $container-max-width in $container-max-widths {
-    .container-#{$breakpoint} {
-      @extend .container-fluid;
+@layer layout {
+  @if $enable-container-classes {
+    // Single container class with breakpoint max-widths
+    .container,
+    // 100% wide container at all breakpoints
+    .container-fluid {
+      @include make-container();
     }
 
-    @include media-breakpoint-up($breakpoint, $grid-breakpoints) {
-      %responsive-container-#{$breakpoint} {
-        max-width: $container-max-width;
+    // Responsive containers that are 100% wide until a breakpoint
+    @each $breakpoint, $container-max-width in $container-max-widths {
+      .container-#{$breakpoint} {
+        @extend .container-fluid;
       }
 
-      // Extend each breakpoint which is smaller or equal to the current breakpoint
-      $extend-breakpoint: true;
+      @include media-breakpoint-up($breakpoint, $grid-breakpoints) {
+        %responsive-container-#{$breakpoint} {
+          max-width: $container-max-width;
+        }
 
-      @each $name, $width in $grid-breakpoints {
-        @if ($extend-breakpoint) {
-          .container#{breakpoint-infix($name, $grid-breakpoints)} {
-            @extend %responsive-container-#{$breakpoint};
-          }
+        // Extend each breakpoint which is smaller or equal to the current breakpoint
+        $extend-breakpoint: true;
 
-          // Once the current breakpoint is reached, stop extending
-          @if ($breakpoint == $name) {
-            $extend-breakpoint: false;
+        @each $name, $width in $grid-breakpoints {
+          @if ($extend-breakpoint) {
+            .container#{breakpoint-infix($name, $grid-breakpoints)} {
+              @extend %responsive-container-#{$breakpoint};
+            }
+
+            // Once the current breakpoint is reached, stop extending
+            @if ($breakpoint == $name) {
+              $extend-breakpoint: false;
+            }
           }
         }
       }

--- a/core/scss/bootstrap/_dropdown.scss
+++ b/core/scss/bootstrap/_dropdown.scss
@@ -1,258 +1,259 @@
-@use "sass:map";
+@use 'sass:map';
 
 // The dropdown wrapper (`<div>`)
-.dropup,
-.dropend,
-.dropdown,
-.dropstart,
-.dropup-center,
-.dropdown-center {
-  position: relative;
-}
 
-.dropdown-toggle {
-  white-space: nowrap;
-
-  // Generate the caret automatically
-  @include caret();
-}
-
-// The dropdown menu
-.dropdown-menu {
-  // scss-docs-start dropdown-css-vars
-  --#{$prefix}dropdown-zindex: #{$zindex-dropdown};
-  --#{$prefix}dropdown-min-width: #{$dropdown-min-width};
-  --#{$prefix}dropdown-padding-x: #{$dropdown-padding-x};
-  --#{$prefix}dropdown-padding-y: #{$dropdown-padding-y};
-  --#{$prefix}dropdown-spacer: #{$dropdown-spacer};
-  @include rfs($dropdown-font-size, --#{$prefix}dropdown-font-size);
-  --#{$prefix}dropdown-color: #{$dropdown-color};
-  --#{$prefix}dropdown-bg: #{$dropdown-bg};
-  --#{$prefix}dropdown-border-color: #{$dropdown-border-color};
-  --#{$prefix}dropdown-border-radius: #{$dropdown-border-radius};
-  --#{$prefix}dropdown-border-width: #{$dropdown-border-width};
-  --#{$prefix}dropdown-inner-border-radius: #{$dropdown-inner-border-radius};
-  --#{$prefix}dropdown-divider-bg: #{$dropdown-divider-bg};
-  --#{$prefix}dropdown-divider-margin-y: #{$dropdown-divider-margin-y};
-  --#{$prefix}dropdown-box-shadow: #{$dropdown-box-shadow};
-  --#{$prefix}dropdown-link-color: #{$dropdown-link-color};
-  --#{$prefix}dropdown-link-hover-color: #{$dropdown-link-hover-color};
-  --#{$prefix}dropdown-link-hover-bg: #{$dropdown-link-hover-bg};
-  --#{$prefix}dropdown-link-active-color: #{$dropdown-link-active-color};
-  --#{$prefix}dropdown-link-active-bg: #{$dropdown-link-active-bg};
-  --#{$prefix}dropdown-link-disabled-color: #{$dropdown-link-disabled-color};
-  --#{$prefix}dropdown-item-padding-x: #{$dropdown-item-padding-x};
-  --#{$prefix}dropdown-item-padding-y: #{$dropdown-item-padding-y};
-  --#{$prefix}dropdown-header-color: #{$dropdown-header-color};
-  --#{$prefix}dropdown-header-padding-x: #{$dropdown-header-padding-x};
-  --#{$prefix}dropdown-header-padding-y: #{$dropdown-header-padding-y};
-  // scss-docs-end dropdown-css-vars
-
-  position: absolute;
-  z-index: var(--#{$prefix}dropdown-zindex);
-  display: none; // none by default, but block on "open" of the menu
-  min-width: var(--#{$prefix}dropdown-min-width);
-  padding: var(--#{$prefix}dropdown-padding-y) var(--#{$prefix}dropdown-padding-x);
-  margin: 0; // Override default margin of ul
-  @include font-size(var(--#{$prefix}dropdown-font-size));
-  color: var(--#{$prefix}dropdown-color);
-  text-align: left; // Ensures proper alignment if parent has it changed (e.g., modal footer)
-  list-style: none;
-  background-color: var(--#{$prefix}dropdown-bg);
-  background-clip: padding-box;
-  border: var(--#{$prefix}dropdown-border-width) solid var(--#{$prefix}dropdown-border-color);
-  @include border-radius(var(--#{$prefix}dropdown-border-radius));
-  @include box-shadow(var(--#{$prefix}dropdown-box-shadow));
-
-  &[data-bs-popper],
-  &[data-tblr-popper] {
-    top: 100%;
-    left: 0;
-    margin-top: var(--#{$prefix}dropdown-spacer);
+@layer components {
+  .dropup,
+  .dropend,
+  .dropdown,
+  .dropstart,
+  .dropup-center,
+  .dropdown-center {
+    position: relative;
   }
 
-  @if $dropdown-padding-y == 0 {
-    > .dropdown-item:first-child,
-    > li:first-child .dropdown-item {
-      @include border-top-radius(var(--#{$prefix}dropdown-inner-border-radius));
-    }
-    > .dropdown-item:last-child,
-    > li:last-child .dropdown-item {
-      @include border-bottom-radius(var(--#{$prefix}dropdown-inner-border-radius));
-    }
+  .dropdown-toggle {
+    white-space: nowrap;
 
+    // Generate the caret automatically
+    @include caret();
   }
-}
 
-// scss-docs-start responsive-breakpoints
-// We deliberately hardcode the `bs-` prefix because we check
-// this custom property in JS to determine Popper's positioning
+  // The dropdown menu
+  .dropdown-menu {
+    // scss-docs-start dropdown-css-vars
+    --#{$prefix}dropdown-zindex: #{$zindex-dropdown};
+    --#{$prefix}dropdown-min-width: #{$dropdown-min-width};
+    --#{$prefix}dropdown-padding-x: #{$dropdown-padding-x};
+    --#{$prefix}dropdown-padding-y: #{$dropdown-padding-y};
+    --#{$prefix}dropdown-spacer: #{$dropdown-spacer};
+    @include rfs($dropdown-font-size, --#{$prefix}dropdown-font-size);
+    --#{$prefix}dropdown-color: #{$dropdown-color};
+    --#{$prefix}dropdown-bg: #{$dropdown-bg};
+    --#{$prefix}dropdown-border-color: #{$dropdown-border-color};
+    --#{$prefix}dropdown-border-radius: #{$dropdown-border-radius};
+    --#{$prefix}dropdown-border-width: #{$dropdown-border-width};
+    --#{$prefix}dropdown-inner-border-radius: #{$dropdown-inner-border-radius};
+    --#{$prefix}dropdown-divider-bg: #{$dropdown-divider-bg};
+    --#{$prefix}dropdown-divider-margin-y: #{$dropdown-divider-margin-y};
+    --#{$prefix}dropdown-box-shadow: #{$dropdown-box-shadow};
+    --#{$prefix}dropdown-link-color: #{$dropdown-link-color};
+    --#{$prefix}dropdown-link-hover-color: #{$dropdown-link-hover-color};
+    --#{$prefix}dropdown-link-hover-bg: #{$dropdown-link-hover-bg};
+    --#{$prefix}dropdown-link-active-color: #{$dropdown-link-active-color};
+    --#{$prefix}dropdown-link-active-bg: #{$dropdown-link-active-bg};
+    --#{$prefix}dropdown-link-disabled-color: #{$dropdown-link-disabled-color};
+    --#{$prefix}dropdown-item-padding-x: #{$dropdown-item-padding-x};
+    --#{$prefix}dropdown-item-padding-y: #{$dropdown-item-padding-y};
+    --#{$prefix}dropdown-header-color: #{$dropdown-header-color};
+    --#{$prefix}dropdown-header-padding-x: #{$dropdown-header-padding-x};
+    --#{$prefix}dropdown-header-padding-y: #{$dropdown-header-padding-y};
+    // scss-docs-end dropdown-css-vars
 
-@each $breakpoint in map.keys($grid-breakpoints) {
-  @include media-breakpoint-up($breakpoint) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    position: absolute;
+    z-index: var(--#{$prefix}dropdown-zindex);
+    display: none; // none by default, but block on "open" of the menu
+    min-width: var(--#{$prefix}dropdown-min-width);
+    padding: var(--#{$prefix}dropdown-padding-y) var(--#{$prefix}dropdown-padding-x);
+    margin: 0; // Override default margin of ul
+    @include font-size(var(--#{$prefix}dropdown-font-size));
+    color: var(--#{$prefix}dropdown-color);
+    text-align: left; // Ensures proper alignment if parent has it changed (e.g., modal footer)
+    list-style: none;
+    background-color: var(--#{$prefix}dropdown-bg);
+    background-clip: padding-box;
+    border: var(--#{$prefix}dropdown-border-width) solid var(--#{$prefix}dropdown-border-color);
+    @include border-radius(var(--#{$prefix}dropdown-border-radius));
+    @include box-shadow(var(--#{$prefix}dropdown-box-shadow));
 
-    .dropdown-menu#{$infix}-start {
-      --bs-position: start;
+    &[data-bs-popper],
+    &[data-tblr-popper] {
+      top: 100%;
+      left: 0;
+      margin-top: var(--#{$prefix}dropdown-spacer);
+    }
 
-      &[data-bs-popper],
-      &[data-tblr-popper] {
-        right: auto;
-        left: 0;
+    @if $dropdown-padding-y == 0 {
+      > .dropdown-item:first-child,
+      > li:first-child .dropdown-item {
+        @include border-top-radius(var(--#{$prefix}dropdown-inner-border-radius));
       }
-    }
-
-    .dropdown-menu#{$infix}-end {
-      --bs-position: end;
-
-      &[data-bs-popper],
-      &[data-tblr-popper] {
-        right: 0;
-        left: auto;
+      > .dropdown-item:last-child,
+      > li:last-child .dropdown-item {
+        @include border-bottom-radius(var(--#{$prefix}dropdown-inner-border-radius));
       }
     }
   }
-}
-// scss-docs-end responsive-breakpoints
 
-// Allow for dropdowns to go bottom up (aka, dropup-menu)
-// Just add .dropup after the standard .dropdown class and you're set.
-.dropup {
-  .dropdown-menu[data-bs-popper],
-  .dropdown-menu[data-tblr-popper] {
-    top: auto;
-    bottom: 100%;
-    margin-top: 0;
-    margin-bottom: var(--#{$prefix}dropdown-spacer);
-  }
+  // scss-docs-start responsive-breakpoints
+  // We deliberately hardcode the `bs-` prefix because we check
+  // this custom property in JS to determine Popper's positioning
 
-  .dropdown-toggle {
-    @include caret(up);
-  }
-}
+  @each $breakpoint in map.keys($grid-breakpoints) {
+    @include media-breakpoint-up($breakpoint) {
+      $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
-.dropend {
-  .dropdown-menu[data-bs-popper],
-  .dropdown-menu[data-tblr-popper] {
-    top: 0;
-    right: auto;
-    left: 100%;
-    margin-top: 0;
-    margin-left: var(--#{$prefix}dropdown-spacer);
-  }
+      .dropdown-menu#{$infix}-start {
+        --bs-position: start;
 
-  .dropdown-toggle {
-    @include caret(end);
-    &::after {
-      vertical-align: 0;
+        &[data-bs-popper],
+        &[data-tblr-popper] {
+          right: auto;
+          left: 0;
+        }
+      }
+
+      .dropdown-menu#{$infix}-end {
+        --bs-position: end;
+
+        &[data-bs-popper],
+        &[data-tblr-popper] {
+          right: 0;
+          left: auto;
+        }
+      }
     }
   }
-}
+  // scss-docs-end responsive-breakpoints
 
-.dropstart {
-  .dropdown-menu[data-bs-popper],
-  .dropdown-menu[data-tblr-popper] {
-    top: 0;
-    right: 100%;
-    left: auto;
-    margin-top: 0;
-    margin-right: var(--#{$prefix}dropdown-spacer);
-  }
+  // Allow for dropdowns to go bottom up (aka, dropup-menu)
+  // Just add .dropup after the standard .dropdown class and you're set.
+  .dropup {
+    .dropdown-menu[data-bs-popper],
+    .dropdown-menu[data-tblr-popper] {
+      top: auto;
+      bottom: 100%;
+      margin-top: 0;
+      margin-bottom: var(--#{$prefix}dropdown-spacer);
+    }
 
-  .dropdown-toggle {
-    @include caret(start);
-    &::before {
-      vertical-align: 0;
+    .dropdown-toggle {
+      @include caret(up);
     }
   }
-}
 
+  .dropend {
+    .dropdown-menu[data-bs-popper],
+    .dropdown-menu[data-tblr-popper] {
+      top: 0;
+      right: auto;
+      left: 100%;
+      margin-top: 0;
+      margin-left: var(--#{$prefix}dropdown-spacer);
+    }
 
-// Dividers (basically an `<hr>`) within the dropdown
-.dropdown-divider {
-  height: 0;
-  margin: var(--#{$prefix}dropdown-divider-margin-y) 0;
-  overflow: hidden;
-  border-top: 1px solid var(--#{$prefix}dropdown-divider-bg);
-  opacity: 1; // Revisit in v6 to de-dupe styles that conflict with <hr> element
-}
-
-// Links, buttons, and more within the dropdown menu
-//
-// `<button>`-specific styles are denoted with `// For <button>s`
-.dropdown-item {
-  display: block;
-  width: 100%; // For `<button>`s
-  padding: var(--#{$prefix}dropdown-item-padding-y) var(--#{$prefix}dropdown-item-padding-x);
-  clear: both;
-  font-weight: $font-weight-normal;
-  color: var(--#{$prefix}dropdown-link-color);
-  text-align: inherit; // For `<button>`s
-  text-decoration: if(sass($link-decoration == none): null; else: none);
-  white-space: nowrap; // prevent links from randomly breaking onto new lines
-  background-color: transparent; // For `<button>`s
-  border: 0; // For `<button>`s
-  @include border-radius(var(--#{$prefix}dropdown-item-border-radius, 0));
-
-  &:hover,
-  &:focus {
-    color: var(--#{$prefix}dropdown-link-hover-color);
-    text-decoration: if(sass($link-hover-decoration == underline): none; else: null);
-    @include gradient-bg(var(--#{$prefix}dropdown-link-hover-bg));
+    .dropdown-toggle {
+      @include caret(end);
+      &::after {
+        vertical-align: 0;
+      }
+    }
   }
 
-  &.active,
-  &:active {
-    color: var(--#{$prefix}dropdown-link-active-color);
-    text-decoration: none;
-    @include gradient-bg(var(--#{$prefix}dropdown-link-active-bg));
+  .dropstart {
+    .dropdown-menu[data-bs-popper],
+    .dropdown-menu[data-tblr-popper] {
+      top: 0;
+      right: 100%;
+      left: auto;
+      margin-top: 0;
+      margin-right: var(--#{$prefix}dropdown-spacer);
+    }
+
+    .dropdown-toggle {
+      @include caret(start);
+      &::before {
+        vertical-align: 0;
+      }
+    }
   }
 
-  &.disabled,
-  &:disabled {
-    color: var(--#{$prefix}dropdown-link-disabled-color);
-    pointer-events: none;
-    background-color: transparent;
-    // Remove CSS gradients if they're enabled
-    background-image: if(sass($enable-gradients): none; else: null);
+  // Dividers (basically an `<hr>`) within the dropdown
+  .dropdown-divider {
+    height: 0;
+    margin: var(--#{$prefix}dropdown-divider-margin-y) 0;
+    overflow: hidden;
+    border-top: 1px solid var(--#{$prefix}dropdown-divider-bg);
+    opacity: 1; // Revisit in v6 to de-dupe styles that conflict with <hr> element
   }
-}
 
-.dropdown-menu.show {
-  display: block;
-}
+  // Links, buttons, and more within the dropdown menu
+  //
+  // `<button>`-specific styles are denoted with `// For <button>s`
+  .dropdown-item {
+    display: block;
+    width: 100%; // For `<button>`s
+    padding: var(--#{$prefix}dropdown-item-padding-y) var(--#{$prefix}dropdown-item-padding-x);
+    clear: both;
+    font-weight: $font-weight-normal;
+    color: var(--#{$prefix}dropdown-link-color);
+    text-align: inherit; // For `<button>`s
+    text-decoration: if(sass($link-decoration == none): null; else: none);
+    white-space: nowrap; // prevent links from randomly breaking onto new lines
+    background-color: transparent; // For `<button>`s
+    border: 0; // For `<button>`s
+    @include border-radius(var(--#{$prefix}dropdown-item-border-radius, 0));
 
-// Dropdown section headers
-.dropdown-header {
-  display: block;
-  padding: var(--#{$prefix}dropdown-header-padding-y) var(--#{$prefix}dropdown-header-padding-x);
-  margin-bottom: 0; // for use with heading elements
-  @include font-size($font-size-sm);
-  color: var(--#{$prefix}dropdown-header-color);
-  white-space: nowrap; // as with > li > a
-}
+    &:hover,
+    &:focus {
+      color: var(--#{$prefix}dropdown-link-hover-color);
+      text-decoration: if(sass($link-hover-decoration == underline): none; else: null);
+      @include gradient-bg(var(--#{$prefix}dropdown-link-hover-bg));
+    }
 
-// Dropdown text
-.dropdown-item-text {
-  display: block;
-  padding: var(--#{$prefix}dropdown-item-padding-y) var(--#{$prefix}dropdown-item-padding-x);
-  color: var(--#{$prefix}dropdown-link-color);
-}
+    &.active,
+    &:active {
+      color: var(--#{$prefix}dropdown-link-active-color);
+      text-decoration: none;
+      @include gradient-bg(var(--#{$prefix}dropdown-link-active-bg));
+    }
 
-// Dark dropdowns
-.dropdown-menu-dark {
-  // scss-docs-start dropdown-dark-css-vars
-  --#{$prefix}dropdown-color: #{$dropdown-dark-color};
-  --#{$prefix}dropdown-bg: #{$dropdown-dark-bg};
-  --#{$prefix}dropdown-border-color: #{$dropdown-dark-border-color};
-  --#{$prefix}dropdown-box-shadow: #{$dropdown-dark-box-shadow};
-  --#{$prefix}dropdown-link-color: #{$dropdown-dark-link-color};
-  --#{$prefix}dropdown-link-hover-color: #{$dropdown-dark-link-hover-color};
-  --#{$prefix}dropdown-divider-bg: #{$dropdown-dark-divider-bg};
-  --#{$prefix}dropdown-link-hover-bg: #{$dropdown-dark-link-hover-bg};
-  --#{$prefix}dropdown-link-active-color: #{$dropdown-dark-link-active-color};
-  --#{$prefix}dropdown-link-active-bg: #{$dropdown-dark-link-active-bg};
-  --#{$prefix}dropdown-link-disabled-color: #{$dropdown-dark-link-disabled-color};
-  --#{$prefix}dropdown-header-color: #{$dropdown-dark-header-color};
-  // scss-docs-end dropdown-dark-css-vars
+    &.disabled,
+    &:disabled {
+      color: var(--#{$prefix}dropdown-link-disabled-color);
+      pointer-events: none;
+      background-color: transparent;
+      // Remove CSS gradients if they're enabled
+      background-image: if(sass($enable-gradients): none; else: null);
+    }
+  }
+
+  .dropdown-menu.show {
+    display: block;
+  }
+
+  // Dropdown section headers
+  .dropdown-header {
+    display: block;
+    padding: var(--#{$prefix}dropdown-header-padding-y) var(--#{$prefix}dropdown-header-padding-x);
+    margin-bottom: 0; // for use with heading elements
+    @include font-size($font-size-sm);
+    color: var(--#{$prefix}dropdown-header-color);
+    white-space: nowrap; // as with > li > a
+  }
+
+  // Dropdown text
+  .dropdown-item-text {
+    display: block;
+    padding: var(--#{$prefix}dropdown-item-padding-y) var(--#{$prefix}dropdown-item-padding-x);
+    color: var(--#{$prefix}dropdown-link-color);
+  }
+
+  // Dark dropdowns
+  .dropdown-menu-dark {
+    // scss-docs-start dropdown-dark-css-vars
+    --#{$prefix}dropdown-color: #{$dropdown-dark-color};
+    --#{$prefix}dropdown-bg: #{$dropdown-dark-bg};
+    --#{$prefix}dropdown-border-color: #{$dropdown-dark-border-color};
+    --#{$prefix}dropdown-box-shadow: #{$dropdown-dark-box-shadow};
+    --#{$prefix}dropdown-link-color: #{$dropdown-dark-link-color};
+    --#{$prefix}dropdown-link-hover-color: #{$dropdown-dark-link-hover-color};
+    --#{$prefix}dropdown-divider-bg: #{$dropdown-dark-divider-bg};
+    --#{$prefix}dropdown-link-hover-bg: #{$dropdown-dark-link-hover-bg};
+    --#{$prefix}dropdown-link-active-color: #{$dropdown-dark-link-active-color};
+    --#{$prefix}dropdown-link-active-bg: #{$dropdown-dark-link-active-bg};
+    --#{$prefix}dropdown-link-disabled-color: #{$dropdown-dark-link-disabled-color};
+    --#{$prefix}dropdown-header-color: #{$dropdown-dark-header-color};
+    // scss-docs-end dropdown-dark-css-vars
+  }
 }

--- a/core/scss/bootstrap/_grid.scss
+++ b/core/scss/bootstrap/_grid.scss
@@ -2,38 +2,39 @@
 //
 // Rows contain your columns.
 
-:root {
-  @each $name, $value in $grid-breakpoints {
-    --#{$prefix}breakpoint-#{$name}: #{$value};
-  }
-}
-
-@if $enable-grid-classes {
-  .row {
-    @include make-row();
-
-    > * {
-      @include make-col-ready();
+@layer layout {
+  :root {
+    @each $name, $value in $grid-breakpoints {
+      --#{$prefix}breakpoint-#{$name}: #{$value};
     }
   }
-}
 
-@if $enable-cssgrid {
-  .grid {
-    display: grid;
-    grid-template-rows: repeat(var(--#{$prefix}rows, 1), 1fr);
-    grid-template-columns: repeat(var(--#{$prefix}columns, #{$grid-columns}), 1fr);
-    gap: var(--#{$prefix}gap, #{$grid-gutter-width});
+  @if $enable-grid-classes {
+    .row {
+      @include make-row();
 
-    @include make-cssgrid();
+      > * {
+        @include make-col-ready();
+      }
+    }
   }
-}
 
+  @if $enable-cssgrid {
+    .grid {
+      display: grid;
+      grid-template-rows: repeat(var(--#{$prefix}rows, 1), 1fr);
+      grid-template-columns: repeat(var(--#{$prefix}columns, #{$grid-columns}), 1fr);
+      gap: var(--#{$prefix}gap, #{$grid-gutter-width});
 
-// Columns
-//
-// Common styles for small and large grid columns
+      @include make-cssgrid();
+    }
+  }
 
-@if $enable-grid-classes {
-  @include make-grid-columns();
+  // Columns
+  //
+  // Common styles for small and large grid columns
+
+  @if $enable-grid-classes {
+    @include make-grid-columns();
+  }
 }

--- a/core/scss/bootstrap/_images.scss
+++ b/core/scss/bootstrap/_images.scss
@@ -5,38 +5,40 @@
 // and abandoned it in Bootstrap v3 because it breaks lots of third-party widgets (including Google Maps)
 // which weren't expecting the images within themselves to be involuntarily resized.
 // See also https://github.com/twbs/bootstrap/issues/18178
-.img-fluid {
-  @include img-fluid();
-}
 
+@layer content {
+  .img-fluid {
+    @include img-fluid();
+  }
 
-// Image thumbnails
-.img-thumbnail {
-  padding: $thumbnail-padding;
-  background-color: $thumbnail-bg;
-  border: $thumbnail-border-width solid $thumbnail-border-color;
-  @include border-radius($thumbnail-border-radius);
-  @include box-shadow($thumbnail-box-shadow);
+  // Image thumbnails
+  .img-thumbnail {
+    padding: $thumbnail-padding;
+    background-color: $thumbnail-bg;
+    border: $thumbnail-border-width solid $thumbnail-border-color;
+    @include border-radius($thumbnail-border-radius);
+    @include box-shadow($thumbnail-box-shadow);
 
-  // Keep them at most 100% wide
-  @include img-fluid();
-}
+    // Keep them at most 100% wide
+    @include img-fluid();
+  }
 
-//
-// Figures
-//
+  //
+  // Figures
+  //
 
-.figure {
-  // Ensures the caption's text aligns with the image.
-  display: inline-block;
-}
+  .figure {
+    // Ensures the caption's text aligns with the image.
+    display: inline-block;
+  }
 
-.figure-img {
-  margin-bottom: $spacer * .5;
-  line-height: 1;
-}
+  .figure-img {
+    margin-bottom: $spacer * 0.5;
+    line-height: 1;
+  }
 
-.figure-caption {
-  @include font-size($figure-caption-font-size);
-  color: $figure-caption-color;
+  .figure-caption {
+    @include font-size($figure-caption-font-size);
+    color: $figure-caption-color;
+  }
 }

--- a/core/scss/bootstrap/_list-group.scss
+++ b/core/scss/bootstrap/_list-group.scss
@@ -1,201 +1,201 @@
-@use "sass:map";
+@use 'sass:map';
 
 // Base class
 //
 // Easily usable on <ul>, <ol>, or <div>.
 
-.list-group {
-  // scss-docs-start list-group-css-vars
-  --#{$prefix}list-group-color: #{$list-group-color};
-  --#{$prefix}list-group-bg: #{$list-group-bg};
-  --#{$prefix}list-group-border-color: #{$list-group-border-color};
-  --#{$prefix}list-group-border-width: #{$list-group-border-width};
-  --#{$prefix}list-group-border-radius: #{$list-group-border-radius};
-  --#{$prefix}list-group-item-padding-x: #{$list-group-item-padding-x};
-  --#{$prefix}list-group-item-padding-y: #{$list-group-item-padding-y};
-  --#{$prefix}list-group-action-color: #{$list-group-action-color};
-  --#{$prefix}list-group-action-hover-color: #{$list-group-action-hover-color};
-  --#{$prefix}list-group-action-hover-bg: #{$list-group-hover-bg};
-  --#{$prefix}list-group-action-active-color: #{$list-group-action-active-color};
-  --#{$prefix}list-group-action-active-bg: #{$list-group-action-active-bg};
-  --#{$prefix}list-group-disabled-color: #{$list-group-disabled-color};
-  --#{$prefix}list-group-disabled-bg: #{$list-group-disabled-bg};
-  --#{$prefix}list-group-active-color: #{$list-group-active-color};
-  --#{$prefix}list-group-active-bg: #{$list-group-active-bg};
-  --#{$prefix}list-group-active-border-color: #{$list-group-active-border-color};
-  // scss-docs-end list-group-css-vars
+@layer components {
+  .list-group {
+    // scss-docs-start list-group-css-vars
+    --#{$prefix}list-group-color: #{$list-group-color};
+    --#{$prefix}list-group-bg: #{$list-group-bg};
+    --#{$prefix}list-group-border-color: #{$list-group-border-color};
+    --#{$prefix}list-group-border-width: #{$list-group-border-width};
+    --#{$prefix}list-group-border-radius: #{$list-group-border-radius};
+    --#{$prefix}list-group-item-padding-x: #{$list-group-item-padding-x};
+    --#{$prefix}list-group-item-padding-y: #{$list-group-item-padding-y};
+    --#{$prefix}list-group-action-color: #{$list-group-action-color};
+    --#{$prefix}list-group-action-hover-color: #{$list-group-action-hover-color};
+    --#{$prefix}list-group-action-hover-bg: #{$list-group-hover-bg};
+    --#{$prefix}list-group-action-active-color: #{$list-group-action-active-color};
+    --#{$prefix}list-group-action-active-bg: #{$list-group-action-active-bg};
+    --#{$prefix}list-group-disabled-color: #{$list-group-disabled-color};
+    --#{$prefix}list-group-disabled-bg: #{$list-group-disabled-bg};
+    --#{$prefix}list-group-active-color: #{$list-group-active-color};
+    --#{$prefix}list-group-active-bg: #{$list-group-active-bg};
+    --#{$prefix}list-group-active-border-color: #{$list-group-active-border-color};
+    // scss-docs-end list-group-css-vars
 
-  display: flex;
-  flex-direction: column;
+    display: flex;
+    flex-direction: column;
 
-  // No need to set list-style: none; since .list-group-item is block level
-  padding-left: 0; // reset padding because ul and ol
-  margin-bottom: 0;
-  @include border-radius(var(--#{$prefix}list-group-border-radius));
-}
-
-.list-group-numbered {
-  list-style-type: none;
-  counter-reset: section;
-
-  > .list-group-item::before {
-    // Increments only this instance of the section counter
-    content: counters(section, ".") ". ";
-    counter-increment: section;
-  }
-}
-
-// Individual list items
-//
-// Use on `li`s or `div`s within the `.list-group` parent.
-
-.list-group-item {
-  position: relative;
-  display: block;
-  padding: var(--#{$prefix}list-group-item-padding-y) var(--#{$prefix}list-group-item-padding-x);
-  color: var(--#{$prefix}list-group-color);
-  text-decoration: if(sass($link-decoration == none): null; else: none);
-  background-color: var(--#{$prefix}list-group-bg);
-  border: var(--#{$prefix}list-group-border-width) solid var(--#{$prefix}list-group-border-color);
-
-  &:first-child {
-    @include border-top-radius(inherit);
+    // No need to set list-style: none; since .list-group-item is block level
+    padding-left: 0; // reset padding because ul and ol
+    margin-bottom: 0;
+    @include border-radius(var(--#{$prefix}list-group-border-radius));
   }
 
-  &:last-child {
-    @include border-bottom-radius(inherit);
+  .list-group-numbered {
+    list-style-type: none;
+    counter-reset: section;
+
+    > .list-group-item::before {
+      // Increments only this instance of the section counter
+      content: counters(section, '.') '. ';
+      counter-increment: section;
+    }
   }
 
-  &.disabled,
-  &:disabled {
-    color: var(--#{$prefix}list-group-disabled-color);
-    pointer-events: none;
-    background-color: var(--#{$prefix}list-group-disabled-bg);
-  }
+  // Individual list items
+  //
+  // Use on `li`s or `div`s within the `.list-group` parent.
 
-  // Include both here for `<a>`s and `<button>`s
-  &.active {
-    z-index: 2; // Place active items above their siblings for proper border styling
-    color: var(--#{$prefix}list-group-active-color);
-    background-color: var(--#{$prefix}list-group-active-bg);
-    border-color: var(--#{$prefix}list-group-active-border-color);
-  }
+  .list-group-item {
+    position: relative;
+    display: block;
+    padding: var(--#{$prefix}list-group-item-padding-y) var(--#{$prefix}list-group-item-padding-x);
+    color: var(--#{$prefix}list-group-color);
+    text-decoration: if(sass($link-decoration == none): null; else: none);
+    background-color: var(--#{$prefix}list-group-bg);
+    border: var(--#{$prefix}list-group-border-width) solid var(--#{$prefix}list-group-border-color);
 
-  // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
-  & + .list-group-item {
-    border-top-width: 0;
+    &:first-child {
+      @include border-top-radius(inherit);
+    }
 
+    &:last-child {
+      @include border-bottom-radius(inherit);
+    }
+
+    &.disabled,
+    &:disabled {
+      color: var(--#{$prefix}list-group-disabled-color);
+      pointer-events: none;
+      background-color: var(--#{$prefix}list-group-disabled-bg);
+    }
+
+    // Include both here for `<a>`s and `<button>`s
     &.active {
-      margin-top: calc(-1 * var(--#{$prefix}list-group-border-width)); // stylelint-disable-line function-disallowed-list
-      border-top-width: var(--#{$prefix}list-group-border-width);
+      z-index: 2; // Place active items above their siblings for proper border styling
+      color: var(--#{$prefix}list-group-active-color);
+      background-color: var(--#{$prefix}list-group-active-bg);
+      border-color: var(--#{$prefix}list-group-active-border-color);
+    }
+
+    // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
+    & + .list-group-item {
+      border-top-width: 0;
+
+      &.active {
+        margin-top: calc(-1 * var(--#{$prefix}list-group-border-width)); // stylelint-disable-line function-disallowed-list
+        border-top-width: var(--#{$prefix}list-group-border-width);
+      }
     }
   }
-}
 
-// Interactive list items
-//
-// Use anchor or button elements instead of `li`s or `div`s to create interactive
-// list items. Includes an extra `.active` modifier class for selected items.
+  // Interactive list items
+  //
+  // Use anchor or button elements instead of `li`s or `div`s to create interactive
+  // list items. Includes an extra `.active` modifier class for selected items.
 
-.list-group-item-action {
-  width: 100%; // For `<button>`s (anchors become 100% by default though)
-  color: var(--#{$prefix}list-group-action-color);
-  text-align: inherit; // For `<button>`s (anchors inherit)
+  .list-group-item-action {
+    width: 100%; // For `<button>`s (anchors become 100% by default though)
+    color: var(--#{$prefix}list-group-action-color);
+    text-align: inherit; // For `<button>`s (anchors inherit)
 
-  &:not(.active) {
-    // Hover state
-    &:hover,
-    &:focus {
-      z-index: 1; // Place hover/focus items above their siblings for proper border styling
-      color: var(--#{$prefix}list-group-action-hover-color);
-      text-decoration: none;
-      background-color: var(--#{$prefix}list-group-action-hover-bg);
-    }
+    &:not(.active) {
+      // Hover state
+      &:hover,
+      &:focus {
+        z-index: 1; // Place hover/focus items above their siblings for proper border styling
+        color: var(--#{$prefix}list-group-action-hover-color);
+        text-decoration: none;
+        background-color: var(--#{$prefix}list-group-action-hover-bg);
+      }
 
-    &:active {
-      color: var(--#{$prefix}list-group-action-active-color);
-      background-color: var(--#{$prefix}list-group-action-active-bg);
+      &:active {
+        color: var(--#{$prefix}list-group-action-active-color);
+        background-color: var(--#{$prefix}list-group-action-active-bg);
+      }
     }
   }
-}
 
-// Horizontal
-//
-// Change the layout of list group items from vertical (default) to horizontal.
+  // Horizontal
+  //
+  // Change the layout of list group items from vertical (default) to horizontal.
 
-@each $breakpoint in map.keys($grid-breakpoints) {
-  @include media-breakpoint-up($breakpoint) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+  @each $breakpoint in map.keys($grid-breakpoints) {
+    @include media-breakpoint-up($breakpoint) {
+      $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
-    .list-group-horizontal#{$infix} {
-      flex-direction: row;
+      .list-group-horizontal#{$infix} {
+        flex-direction: row;
 
-      > .list-group-item {
-        &:first-child:not(:last-child) {
-          @include border-bottom-start-radius(var(--#{$prefix}list-group-border-radius));
-          @include border-top-end-radius(0);
-        }
+        > .list-group-item {
+          &:first-child:not(:last-child) {
+            @include border-bottom-start-radius(var(--#{$prefix}list-group-border-radius));
+            @include border-top-end-radius(0);
+          }
 
-        &:last-child:not(:first-child) {
-          @include border-top-end-radius(var(--#{$prefix}list-group-border-radius));
-          @include border-bottom-start-radius(0);
-        }
-
-        &.active {
-          margin-top: 0;
-        }
-
-        + .list-group-item {
-          border-top-width: var(--#{$prefix}list-group-border-width);
-          border-left-width: 0;
+          &:last-child:not(:first-child) {
+            @include border-top-end-radius(var(--#{$prefix}list-group-border-radius));
+            @include border-bottom-start-radius(0);
+          }
 
           &.active {
-            margin-left: calc(-1 * var(--#{$prefix}list-group-border-width)); // stylelint-disable-line function-disallowed-list
-            border-left-width: var(--#{$prefix}list-group-border-width);
+            margin-top: 0;
+          }
+
+          + .list-group-item {
+            border-top-width: var(--#{$prefix}list-group-border-width);
+            border-left-width: 0;
+
+            &.active {
+              margin-left: calc(-1 * var(--#{$prefix}list-group-border-width)); // stylelint-disable-line function-disallowed-list
+              border-left-width: var(--#{$prefix}list-group-border-width);
+            }
           }
         }
       }
     }
   }
-}
 
+  // Flush list items
+  //
+  // Remove borders and border-radius to keep list group items edge-to-edge. Most
+  // useful within other components (e.g., cards).
 
-// Flush list items
-//
-// Remove borders and border-radius to keep list group items edge-to-edge. Most
-// useful within other components (e.g., cards).
+  .list-group-flush {
+    @include border-radius(0);
 
-.list-group-flush {
-  @include border-radius(0);
+    > .list-group-item {
+      border-width: 0 0 var(--#{$prefix}list-group-border-width);
 
-  > .list-group-item {
-    border-width: 0 0 var(--#{$prefix}list-group-border-width);
-
-    &:last-child {
-      border-bottom-width: 0;
+      &:last-child {
+        border-bottom-width: 0;
+      }
     }
   }
-}
 
+  // scss-docs-start list-group-modifiers
+  // List group contextual variants
+  //
+  // Add modifier classes to change text and background color on individual items.
+  // Organizationally, this must come after the `:hover` states.
 
-// scss-docs-start list-group-modifiers
-// List group contextual variants
-//
-// Add modifier classes to change text and background color on individual items.
-// Organizationally, this must come after the `:hover` states.
-
-@each $state in map.keys($theme-colors) {
-  .list-group-item-#{$state} {
-    --#{$prefix}list-group-color: var(--#{$prefix}#{$state}-text-emphasis);
-    --#{$prefix}list-group-bg: var(--#{$prefix}#{$state}-bg-subtle);
-    --#{$prefix}list-group-border-color: var(--#{$prefix}#{$state}-border-subtle);
-    --#{$prefix}list-group-action-hover-color: var(--#{$prefix}emphasis-color);
-    --#{$prefix}list-group-action-hover-bg: var(--#{$prefix}#{$state}-border-subtle);
-    --#{$prefix}list-group-action-active-color: var(--#{$prefix}emphasis-color);
-    --#{$prefix}list-group-action-active-bg: var(--#{$prefix}#{$state}-border-subtle);
-    --#{$prefix}list-group-active-color: var(--#{$prefix}#{$state}-bg-subtle);
-    --#{$prefix}list-group-active-bg: var(--#{$prefix}#{$state}-text-emphasis);
-    --#{$prefix}list-group-active-border-color: var(--#{$prefix}#{$state}-text-emphasis);
+  @each $state in map.keys($theme-colors) {
+    .list-group-item-#{$state} {
+      --#{$prefix}list-group-color: var(--#{$prefix}#{$state}-text-emphasis);
+      --#{$prefix}list-group-bg: var(--#{$prefix}#{$state}-bg-subtle);
+      --#{$prefix}list-group-border-color: var(--#{$prefix}#{$state}-border-subtle);
+      --#{$prefix}list-group-action-hover-color: var(--#{$prefix}emphasis-color);
+      --#{$prefix}list-group-action-hover-bg: var(--#{$prefix}#{$state}-border-subtle);
+      --#{$prefix}list-group-action-active-color: var(--#{$prefix}emphasis-color);
+      --#{$prefix}list-group-action-active-bg: var(--#{$prefix}#{$state}-border-subtle);
+      --#{$prefix}list-group-active-color: var(--#{$prefix}#{$state}-bg-subtle);
+      --#{$prefix}list-group-active-bg: var(--#{$prefix}#{$state}-text-emphasis);
+      --#{$prefix}list-group-active-border-color: var(--#{$prefix}#{$state}-text-emphasis);
+    }
   }
+  // scss-docs-end list-group-modifiers
 }
-// scss-docs-end list-group-modifiers

--- a/core/scss/bootstrap/_modal.scss
+++ b/core/scss/bootstrap/_modal.scss
@@ -1,242 +1,244 @@
 // stylelint-disable function-disallowed-list
 
-@use "sass:map";
+@use 'sass:map';
 
 // .modal-open      - body class for killing the scroll
 // .modal           - container to scroll within
 // .modal-dialog    - positioning shell for the actual modal
 // .modal-content   - actual modal w/ bg and corners and stuff
 
-
 // Container that the modal scrolls within
-.modal {
-  // scss-docs-start modal-css-vars
-  --#{$prefix}modal-zindex: #{$zindex-modal};
-  --#{$prefix}modal-width: #{$modal-md};
-  --#{$prefix}modal-padding: #{$modal-inner-padding};
-  --#{$prefix}modal-margin: #{$modal-dialog-margin};
-  --#{$prefix}modal-color: #{$modal-content-color};
-  --#{$prefix}modal-bg: #{$modal-content-bg};
-  --#{$prefix}modal-border-color: #{$modal-content-border-color};
-  --#{$prefix}modal-border-width: #{$modal-content-border-width};
-  --#{$prefix}modal-border-radius: #{$modal-content-border-radius};
-  --#{$prefix}modal-box-shadow: #{$modal-content-box-shadow-xs};
-  --#{$prefix}modal-inner-border-radius: #{$modal-content-inner-border-radius};
-  --#{$prefix}modal-header-padding-x: #{$modal-header-padding-x};
-  --#{$prefix}modal-header-padding-y: #{$modal-header-padding-y};
-  --#{$prefix}modal-header-padding: #{$modal-header-padding}; // Todo in v6: Split this padding into x and y
-  --#{$prefix}modal-header-border-color: #{$modal-header-border-color};
-  --#{$prefix}modal-header-border-width: #{$modal-header-border-width};
-  --#{$prefix}modal-title-line-height: #{$modal-title-line-height};
-  --#{$prefix}modal-footer-gap: #{$modal-footer-margin-between};
-  --#{$prefix}modal-footer-bg: #{$modal-footer-bg};
-  --#{$prefix}modal-footer-border-color: #{$modal-footer-border-color};
-  --#{$prefix}modal-footer-border-width: #{$modal-footer-border-width};
-  // scss-docs-end modal-css-vars
 
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: var(--#{$prefix}modal-zindex);
-  display: none;
-  width: 100%;
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
-  // Prevent Chrome on Windows from adding a focus outline. For details, see
-  // https://github.com/twbs/bootstrap/pull/10951.
-  outline: 0;
-  // We deliberately don't use `-webkit-overflow-scrolling: touch;` due to a
-  // gnarly iOS Safari bug: https://bugs.webkit.org/show_bug.cgi?id=158342
-  // See also https://github.com/twbs/bootstrap/issues/17695
-}
-
-// Shell div to position the modal with bottom padding
-.modal-dialog {
-  position: relative;
-  width: auto;
-  margin: var(--#{$prefix}modal-margin);
-  // allow clicks to pass through for custom click handling to close modal
-  pointer-events: none;
-
-  // When fading in the modal, animate it to slide down
-  .modal.fade & {
-    transform: $modal-fade-transform;
-    @include transition($modal-transition);
-  }
-  .modal.show & {
-    transform: $modal-show-transform;
-  }
-
-  // When trying to close, animate focus to scale
-  .modal.modal-static & {
-    transform: $modal-scale-transform;
-  }
-}
-
-.modal-dialog-scrollable {
-  height: calc(100% - var(--#{$prefix}modal-margin) * 2);
-
-  .modal-content {
-    max-height: 100%;
-    overflow: hidden;
-  }
-
-  .modal-body {
-    overflow-y: auto;
-  }
-}
-
-.modal-dialog-centered {
-  display: flex;
-  align-items: center;
-  min-height: calc(100% - var(--#{$prefix}modal-margin) * 2);
-}
-
-// Actual modal
-.modal-content {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  width: 100%; // Ensure `.modal-content` extends the full width of the parent `.modal-dialog`
-  // counteract the pointer-events: none; in the .modal-dialog
-  color: var(--#{$prefix}modal-color);
-  pointer-events: auto;
-  background-color: var(--#{$prefix}modal-bg);
-  background-clip: padding-box;
-  border: var(--#{$prefix}modal-border-width) solid var(--#{$prefix}modal-border-color);
-  @include border-radius(var(--#{$prefix}modal-border-radius));
-  @include box-shadow(var(--#{$prefix}modal-box-shadow));
-  // Remove focus outline from opened modal
-  outline: 0;
-}
-
-// Modal background
-.modal-backdrop {
-  // scss-docs-start modal-backdrop-css-vars
-  --#{$prefix}backdrop-zindex: #{$zindex-modal-backdrop};
-  --#{$prefix}backdrop-bg: #{$modal-backdrop-bg};
-  --#{$prefix}backdrop-opacity: #{$modal-backdrop-opacity};
-  // scss-docs-end modal-backdrop-css-vars
-
-  @include overlay-backdrop(var(--#{$prefix}backdrop-zindex), var(--#{$prefix}backdrop-bg), var(--#{$prefix}backdrop-opacity));
-}
-
-// Modal header
-// Top section of the modal w/ title and dismiss
-.modal-header {
-  display: flex;
-  flex-shrink: 0;
-  align-items: center;
-  padding: var(--#{$prefix}modal-header-padding);
-  border-bottom: var(--#{$prefix}modal-header-border-width) solid var(--#{$prefix}modal-header-border-color);
-  @include border-top-radius(var(--#{$prefix}modal-inner-border-radius));
-
-  .btn-close {
-    padding: calc(var(--#{$prefix}modal-header-padding-y) * .5) calc(var(--#{$prefix}modal-header-padding-x) * .5);
-    // Split properties to avoid invalid calc() function if value is 0
-    margin-top: calc(-.5 * var(--#{$prefix}modal-header-padding-y));
-    margin-right: calc(-.5 * var(--#{$prefix}modal-header-padding-x));
-    margin-bottom: calc(-.5 * var(--#{$prefix}modal-header-padding-y));
-    margin-left: auto;
-  }
-}
-
-// Title text within header
-.modal-title {
-  margin-bottom: 0;
-  line-height: var(--#{$prefix}modal-title-line-height);
-}
-
-// Modal body
-// Where all modal content resides (sibling of .modal-header and .modal-footer)
-.modal-body {
-  position: relative;
-  // Enable `flex-grow: 1` so that the body take up as much space as possible
-  // when there should be a fixed height on `.modal-dialog`.
-  flex: 1 1 auto;
-  padding: var(--#{$prefix}modal-padding);
-}
-
-// Footer (for actions)
-.modal-footer {
-  display: flex;
-  flex-shrink: 0;
-  flex-wrap: wrap;
-  align-items: center; // vertically center
-  justify-content: flex-end; // Right align buttons with flex property because text-align doesn't work on flex items
-  padding: calc(var(--#{$prefix}modal-padding) - var(--#{$prefix}modal-footer-gap) * .5);
-  background-color: var(--#{$prefix}modal-footer-bg);
-  border-top: var(--#{$prefix}modal-footer-border-width) solid var(--#{$prefix}modal-footer-border-color);
-  @include border-bottom-radius(var(--#{$prefix}modal-inner-border-radius));
-
-  // Place margin between footer elements
-  // This solution is far from ideal because of the universal selector usage,
-  // but is needed to fix https://github.com/twbs/bootstrap/issues/24800
-  > * {
-    margin: calc(var(--#{$prefix}modal-footer-gap) * .5); // Todo in v6: replace with gap on parent class
-  }
-}
-
-// Scale up the modal
-@include media-breakpoint-up(sm) {
+@layer components {
   .modal {
-    --#{$prefix}modal-margin: #{$modal-dialog-margin-y-sm-up};
-    --#{$prefix}modal-box-shadow: #{$modal-content-box-shadow-sm-up};
+    // scss-docs-start modal-css-vars
+    --#{$prefix}modal-zindex: #{$zindex-modal};
+    --#{$prefix}modal-width: #{$modal-md};
+    --#{$prefix}modal-padding: #{$modal-inner-padding};
+    --#{$prefix}modal-margin: #{$modal-dialog-margin};
+    --#{$prefix}modal-color: #{$modal-content-color};
+    --#{$prefix}modal-bg: #{$modal-content-bg};
+    --#{$prefix}modal-border-color: #{$modal-content-border-color};
+    --#{$prefix}modal-border-width: #{$modal-content-border-width};
+    --#{$prefix}modal-border-radius: #{$modal-content-border-radius};
+    --#{$prefix}modal-box-shadow: #{$modal-content-box-shadow-xs};
+    --#{$prefix}modal-inner-border-radius: #{$modal-content-inner-border-radius};
+    --#{$prefix}modal-header-padding-x: #{$modal-header-padding-x};
+    --#{$prefix}modal-header-padding-y: #{$modal-header-padding-y};
+    --#{$prefix}modal-header-padding: #{$modal-header-padding}; // Todo in v6: Split this padding into x and y
+    --#{$prefix}modal-header-border-color: #{$modal-header-border-color};
+    --#{$prefix}modal-header-border-width: #{$modal-header-border-width};
+    --#{$prefix}modal-title-line-height: #{$modal-title-line-height};
+    --#{$prefix}modal-footer-gap: #{$modal-footer-margin-between};
+    --#{$prefix}modal-footer-bg: #{$modal-footer-bg};
+    --#{$prefix}modal-footer-border-color: #{$modal-footer-border-color};
+    --#{$prefix}modal-footer-border-width: #{$modal-footer-border-width};
+    // scss-docs-end modal-css-vars
+
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: var(--#{$prefix}modal-zindex);
+    display: none;
+    width: 100%;
+    height: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+    // Prevent Chrome on Windows from adding a focus outline. For details, see
+    // https://github.com/twbs/bootstrap/pull/10951.
+    outline: 0;
+    // We deliberately don't use `-webkit-overflow-scrolling: touch;` due to a
+    // gnarly iOS Safari bug: https://bugs.webkit.org/show_bug.cgi?id=158342
+    // See also https://github.com/twbs/bootstrap/issues/17695
   }
 
-  // Automatically set modal's width for larger viewports
+  // Shell div to position the modal with bottom padding
   .modal-dialog {
-    max-width: var(--#{$prefix}modal-width);
-    margin-right: auto;
-    margin-left: auto;
+    position: relative;
+    width: auto;
+    margin: var(--#{$prefix}modal-margin);
+    // allow clicks to pass through for custom click handling to close modal
+    pointer-events: none;
+
+    // When fading in the modal, animate it to slide down
+    .modal.fade & {
+      transform: $modal-fade-transform;
+      @include transition($modal-transition);
+    }
+    .modal.show & {
+      transform: $modal-show-transform;
+    }
+
+    // When trying to close, animate focus to scale
+    .modal.modal-static & {
+      transform: $modal-scale-transform;
+    }
   }
 
-  .modal-sm {
-    --#{$prefix}modal-width: #{$modal-sm};
+  .modal-dialog-scrollable {
+    height: calc(100% - var(--#{$prefix}modal-margin) * 2);
+
+    .modal-content {
+      max-height: 100%;
+      overflow: hidden;
+    }
+
+    .modal-body {
+      overflow-y: auto;
+    }
   }
-}
 
-@include media-breakpoint-up(lg) {
-  .modal-lg,
-  .modal-xl {
-    --#{$prefix}modal-width: #{$modal-lg};
+  .modal-dialog-centered {
+    display: flex;
+    align-items: center;
+    min-height: calc(100% - var(--#{$prefix}modal-margin) * 2);
   }
-}
 
-@include media-breakpoint-up(xl) {
-  .modal-xl {
-    --#{$prefix}modal-width: #{$modal-xl};
+  // Actual modal
+  .modal-content {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 100%; // Ensure `.modal-content` extends the full width of the parent `.modal-dialog`
+    // counteract the pointer-events: none; in the .modal-dialog
+    color: var(--#{$prefix}modal-color);
+    pointer-events: auto;
+    background-color: var(--#{$prefix}modal-bg);
+    background-clip: padding-box;
+    border: var(--#{$prefix}modal-border-width) solid var(--#{$prefix}modal-border-color);
+    @include border-radius(var(--#{$prefix}modal-border-radius));
+    @include box-shadow(var(--#{$prefix}modal-box-shadow));
+    // Remove focus outline from opened modal
+    outline: 0;
   }
-}
 
-// scss-docs-start modal-fullscreen-loop
-@each $breakpoint in map.keys($grid-breakpoints) {
-  $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
-  $postfix: if(sass($infix != ""): $infix + "-down"; else: "");
+  // Modal background
+  .modal-backdrop {
+    // scss-docs-start modal-backdrop-css-vars
+    --#{$prefix}backdrop-zindex: #{$zindex-modal-backdrop};
+    --#{$prefix}backdrop-bg: #{$modal-backdrop-bg};
+    --#{$prefix}backdrop-opacity: #{$modal-backdrop-opacity};
+    // scss-docs-end modal-backdrop-css-vars
 
-  @include media-breakpoint-down($breakpoint) {
-    .modal-fullscreen#{$postfix} {
-      width: 100vw;
-      max-width: none;
-      height: 100%;
-      margin: 0;
+    @include overlay-backdrop(var(--#{$prefix}backdrop-zindex), var(--#{$prefix}backdrop-bg), var(--#{$prefix}backdrop-opacity));
+  }
 
-      .modal-content {
+  // Modal header
+  // Top section of the modal w/ title and dismiss
+  .modal-header {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    padding: var(--#{$prefix}modal-header-padding);
+    border-bottom: var(--#{$prefix}modal-header-border-width) solid var(--#{$prefix}modal-header-border-color);
+    @include border-top-radius(var(--#{$prefix}modal-inner-border-radius));
+
+    .btn-close {
+      padding: calc(var(--#{$prefix}modal-header-padding-y) * 0.5) calc(var(--#{$prefix}modal-header-padding-x) * 0.5);
+      // Split properties to avoid invalid calc() function if value is 0
+      margin-top: calc(-0.5 * var(--#{$prefix}modal-header-padding-y));
+      margin-right: calc(-0.5 * var(--#{$prefix}modal-header-padding-x));
+      margin-bottom: calc(-0.5 * var(--#{$prefix}modal-header-padding-y));
+      margin-left: auto;
+    }
+  }
+
+  // Title text within header
+  .modal-title {
+    margin-bottom: 0;
+    line-height: var(--#{$prefix}modal-title-line-height);
+  }
+
+  // Modal body
+  // Where all modal content resides (sibling of .modal-header and .modal-footer)
+  .modal-body {
+    position: relative;
+    // Enable `flex-grow: 1` so that the body take up as much space as possible
+    // when there should be a fixed height on `.modal-dialog`.
+    flex: 1 1 auto;
+    padding: var(--#{$prefix}modal-padding);
+  }
+
+  // Footer (for actions)
+  .modal-footer {
+    display: flex;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+    align-items: center; // vertically center
+    justify-content: flex-end; // Right align buttons with flex property because text-align doesn't work on flex items
+    padding: calc(var(--#{$prefix}modal-padding) - var(--#{$prefix}modal-footer-gap) * 0.5);
+    background-color: var(--#{$prefix}modal-footer-bg);
+    border-top: var(--#{$prefix}modal-footer-border-width) solid var(--#{$prefix}modal-footer-border-color);
+    @include border-bottom-radius(var(--#{$prefix}modal-inner-border-radius));
+
+    // Place margin between footer elements
+    // This solution is far from ideal because of the universal selector usage,
+    // but is needed to fix https://github.com/twbs/bootstrap/issues/24800
+    > * {
+      margin: calc(var(--#{$prefix}modal-footer-gap) * 0.5); // Todo in v6: replace with gap on parent class
+    }
+  }
+
+  // Scale up the modal
+  @include media-breakpoint-up(sm) {
+    .modal {
+      --#{$prefix}modal-margin: #{$modal-dialog-margin-y-sm-up};
+      --#{$prefix}modal-box-shadow: #{$modal-content-box-shadow-sm-up};
+    }
+
+    // Automatically set modal's width for larger viewports
+    .modal-dialog {
+      max-width: var(--#{$prefix}modal-width);
+      margin-right: auto;
+      margin-left: auto;
+    }
+
+    .modal-sm {
+      --#{$prefix}modal-width: #{$modal-sm};
+    }
+  }
+
+  @include media-breakpoint-up(lg) {
+    .modal-lg,
+    .modal-xl {
+      --#{$prefix}modal-width: #{$modal-lg};
+    }
+  }
+
+  @include media-breakpoint-up(xl) {
+    .modal-xl {
+      --#{$prefix}modal-width: #{$modal-xl};
+    }
+  }
+
+  // scss-docs-start modal-fullscreen-loop
+  @each $breakpoint in map.keys($grid-breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    $postfix: if(sass($infix != ''): $infix + '-down'; else: '');
+
+    @include media-breakpoint-down($breakpoint) {
+      .modal-fullscreen#{$postfix} {
+        width: 100vw;
+        max-width: none;
         height: 100%;
-        border: 0;
-        @include border-radius(0);
-      }
+        margin: 0;
 
-      .modal-header,
-      .modal-footer {
-        @include border-radius(0);
-      }
+        .modal-content {
+          height: 100%;
+          border: 0;
+          @include border-radius(0);
+        }
 
-      .modal-body {
-        overflow-y: auto;
+        .modal-header,
+        .modal-footer {
+          @include border-radius(0);
+        }
+
+        .modal-body {
+          overflow-y: auto;
+        }
       }
     }
   }
+  // scss-docs-end modal-fullscreen-loop
 }
-// scss-docs-end modal-fullscreen-loop

--- a/core/scss/bootstrap/_nav.scss
+++ b/core/scss/bootstrap/_nav.scss
@@ -3,195 +3,193 @@
 // Kickstart any navigation component with a set of style resets. Works with
 // `<nav>`s, `<ul>`s or `<ol>`s.
 
-.nav {
-  // scss-docs-start nav-css-vars
-  --#{$prefix}nav-link-padding-x: #{$nav-link-padding-x};
-  --#{$prefix}nav-link-padding-y: #{$nav-link-padding-y};
-  @include rfs($nav-link-font-size, --#{$prefix}nav-link-font-size);
-  --#{$prefix}nav-link-font-weight: #{$nav-link-font-weight};
-  --#{$prefix}nav-link-color: #{$nav-link-color};
-  --#{$prefix}nav-link-hover-color: #{$nav-link-hover-color};
-  --#{$prefix}nav-link-disabled-color: #{$nav-link-disabled-color};
-  // scss-docs-end nav-css-vars
+@layer components {
+  .nav {
+    // scss-docs-start nav-css-vars
+    --#{$prefix}nav-link-padding-x: #{$nav-link-padding-x};
+    --#{$prefix}nav-link-padding-y: #{$nav-link-padding-y};
+    @include rfs($nav-link-font-size, --#{$prefix}nav-link-font-size);
+    --#{$prefix}nav-link-font-weight: #{$nav-link-font-weight};
+    --#{$prefix}nav-link-color: #{$nav-link-color};
+    --#{$prefix}nav-link-hover-color: #{$nav-link-hover-color};
+    --#{$prefix}nav-link-disabled-color: #{$nav-link-disabled-color};
+    // scss-docs-end nav-css-vars
 
-  display: flex;
-  flex-wrap: wrap;
-  padding-left: 0;
-  margin-bottom: 0;
-  list-style: none;
-}
-
-.nav-link {
-  display: block;
-  padding: var(--#{$prefix}nav-link-padding-y) var(--#{$prefix}nav-link-padding-x);
-  @include font-size(var(--#{$prefix}nav-link-font-size));
-  font-weight: var(--#{$prefix}nav-link-font-weight);
-  color: var(--#{$prefix}nav-link-color);
-  text-decoration: if(sass($link-decoration == none): null; else: none);
-  background: none;
-  border: 0;
-  @include transition($nav-link-transition);
-
-  &:hover,
-  &:focus {
-    color: var(--#{$prefix}nav-link-hover-color);
-    text-decoration: if(sass($link-hover-decoration == underline): none; else: null);
+    display: flex;
+    flex-wrap: wrap;
+    padding-left: 0;
+    margin-bottom: 0;
+    list-style: none;
   }
-
-  &:focus-visible {
-    outline: 0;
-    box-shadow: $nav-link-focus-box-shadow;
-  }
-
-  // Disabled state lightens text
-  &.disabled,
-  &:disabled {
-    color: var(--#{$prefix}nav-link-disabled-color);
-    pointer-events: none;
-    cursor: default;
-  }
-}
-
-//
-// Tabs
-//
-
-.nav-tabs {
-  // scss-docs-start nav-tabs-css-vars
-  --#{$prefix}nav-tabs-border-width: #{$nav-tabs-border-width};
-  --#{$prefix}nav-tabs-border-color: #{$nav-tabs-border-color};
-  --#{$prefix}nav-tabs-border-radius: #{$nav-tabs-border-radius};
-  --#{$prefix}nav-tabs-link-hover-border-color: #{$nav-tabs-link-hover-border-color};
-  --#{$prefix}nav-tabs-link-active-color: #{$nav-tabs-link-active-color};
-  --#{$prefix}nav-tabs-link-active-bg: #{$nav-tabs-link-active-bg};
-  --#{$prefix}nav-tabs-link-active-border-color: #{$nav-tabs-link-active-border-color};
-  // scss-docs-end nav-tabs-css-vars
-
-  border-bottom: var(--#{$prefix}nav-tabs-border-width) solid var(--#{$prefix}nav-tabs-border-color);
 
   .nav-link {
-    margin-bottom: calc(-1 * var(--#{$prefix}nav-tabs-border-width)); // stylelint-disable-line function-disallowed-list
-    border: var(--#{$prefix}nav-tabs-border-width) solid transparent;
-    @include border-top-radius(var(--#{$prefix}nav-tabs-border-radius));
+    display: block;
+    padding: var(--#{$prefix}nav-link-padding-y) var(--#{$prefix}nav-link-padding-x);
+    @include font-size(var(--#{$prefix}nav-link-font-size));
+    font-weight: var(--#{$prefix}nav-link-font-weight);
+    color: var(--#{$prefix}nav-link-color);
+    text-decoration: if(sass($link-decoration == none): null; else: none);
+    background: none;
+    border: 0;
+    @include transition($nav-link-transition);
 
     &:hover,
     &:focus {
-      // Prevents active .nav-link tab overlapping focus outline of previous/next .nav-link
-      isolation: isolate;
-      border-color: var(--#{$prefix}nav-tabs-link-hover-border-color);
+      color: var(--#{$prefix}nav-link-hover-color);
+      text-decoration: if(sass($link-hover-decoration == underline): none; else: null);
+    }
+
+    &:focus-visible {
+      outline: 0;
+      box-shadow: $nav-link-focus-box-shadow;
+    }
+
+    // Disabled state lightens text
+    &.disabled,
+    &:disabled {
+      color: var(--#{$prefix}nav-link-disabled-color);
+      pointer-events: none;
+      cursor: default;
     }
   }
 
-  .nav-link.active,
-  .nav-item.show .nav-link {
-    color: var(--#{$prefix}nav-tabs-link-active-color);
-    background-color: var(--#{$prefix}nav-tabs-link-active-bg);
-    border-color: var(--#{$prefix}nav-tabs-link-active-border-color);
+  //
+  // Tabs
+  //
+
+  .nav-tabs {
+    // scss-docs-start nav-tabs-css-vars
+    --#{$prefix}nav-tabs-border-width: #{$nav-tabs-border-width};
+    --#{$prefix}nav-tabs-border-color: #{$nav-tabs-border-color};
+    --#{$prefix}nav-tabs-border-radius: #{$nav-tabs-border-radius};
+    --#{$prefix}nav-tabs-link-hover-border-color: #{$nav-tabs-link-hover-border-color};
+    --#{$prefix}nav-tabs-link-active-color: #{$nav-tabs-link-active-color};
+    --#{$prefix}nav-tabs-link-active-bg: #{$nav-tabs-link-active-bg};
+    --#{$prefix}nav-tabs-link-active-border-color: #{$nav-tabs-link-active-border-color};
+    // scss-docs-end nav-tabs-css-vars
+
+    border-bottom: var(--#{$prefix}nav-tabs-border-width) solid var(--#{$prefix}nav-tabs-border-color);
+
+    .nav-link {
+      margin-bottom: calc(-1 * var(--#{$prefix}nav-tabs-border-width)); // stylelint-disable-line function-disallowed-list
+      border: var(--#{$prefix}nav-tabs-border-width) solid transparent;
+      @include border-top-radius(var(--#{$prefix}nav-tabs-border-radius));
+
+      &:hover,
+      &:focus {
+        // Prevents active .nav-link tab overlapping focus outline of previous/next .nav-link
+        isolation: isolate;
+        border-color: var(--#{$prefix}nav-tabs-link-hover-border-color);
+      }
+    }
+
+    .nav-link.active,
+    .nav-item.show .nav-link {
+      color: var(--#{$prefix}nav-tabs-link-active-color);
+      background-color: var(--#{$prefix}nav-tabs-link-active-bg);
+      border-color: var(--#{$prefix}nav-tabs-link-active-border-color);
+    }
+
+    .dropdown-menu {
+      // Make dropdown border overlap tab border
+      margin-top: calc(-1 * var(--#{$prefix}nav-tabs-border-width)); // stylelint-disable-line function-disallowed-list
+      // Remove the top rounded corners here since there is a hard edge above the menu
+      @include border-top-radius(0);
+    }
   }
 
-  .dropdown-menu {
-    // Make dropdown border overlap tab border
-    margin-top: calc(-1 * var(--#{$prefix}nav-tabs-border-width)); // stylelint-disable-line function-disallowed-list
-    // Remove the top rounded corners here since there is a hard edge above the menu
-    @include border-top-radius(0);
-  }
-}
+  //
+  // Pills
+  //
 
+  .nav-pills {
+    // scss-docs-start nav-pills-css-vars
+    --#{$prefix}nav-pills-border-radius: #{$nav-pills-border-radius};
+    --#{$prefix}nav-pills-link-active-color: #{$nav-pills-link-active-color};
+    --#{$prefix}nav-pills-link-active-bg: #{$nav-pills-link-active-bg};
+    // scss-docs-end nav-pills-css-vars
 
-//
-// Pills
-//
+    .nav-link {
+      @include border-radius(var(--#{$prefix}nav-pills-border-radius));
+    }
 
-.nav-pills {
-  // scss-docs-start nav-pills-css-vars
-  --#{$prefix}nav-pills-border-radius: #{$nav-pills-border-radius};
-  --#{$prefix}nav-pills-link-active-color: #{$nav-pills-link-active-color};
-  --#{$prefix}nav-pills-link-active-bg: #{$nav-pills-link-active-bg};
-  // scss-docs-end nav-pills-css-vars
-
-  .nav-link {
-    @include border-radius(var(--#{$prefix}nav-pills-border-radius));
+    .nav-link.active,
+    .show > .nav-link {
+      color: var(--#{$prefix}nav-pills-link-active-color);
+      @include gradient-bg(var(--#{$prefix}nav-pills-link-active-bg));
+    }
   }
 
-  .nav-link.active,
-  .show > .nav-link {
-    color: var(--#{$prefix}nav-pills-link-active-color);
-    @include gradient-bg(var(--#{$prefix}nav-pills-link-active-bg));
-  }
-}
+  //
+  // Underline
+  //
 
+  .nav-underline {
+    // scss-docs-start nav-underline-css-vars
+    --#{$prefix}nav-underline-gap: #{$nav-underline-gap};
+    --#{$prefix}nav-underline-border-width: #{$nav-underline-border-width};
+    --#{$prefix}nav-underline-link-active-color: #{$nav-underline-link-active-color};
+    // scss-docs-end nav-underline-css-vars
 
-//
-// Underline
-//
+    gap: var(--#{$prefix}nav-underline-gap);
 
-.nav-underline {
-  // scss-docs-start nav-underline-css-vars
-  --#{$prefix}nav-underline-gap: #{$nav-underline-gap};
-  --#{$prefix}nav-underline-border-width: #{$nav-underline-border-width};
-  --#{$prefix}nav-underline-link-active-color: #{$nav-underline-link-active-color};
-  // scss-docs-end nav-underline-css-vars
+    .nav-link {
+      padding-right: 0;
+      padding-left: 0;
+      border-bottom: var(--#{$prefix}nav-underline-border-width) solid transparent;
 
-  gap: var(--#{$prefix}nav-underline-gap);
+      &:hover,
+      &:focus {
+        border-bottom-color: currentcolor;
+      }
+    }
 
-  .nav-link {
-    padding-right: 0;
-    padding-left: 0;
-    border-bottom: var(--#{$prefix}nav-underline-border-width) solid transparent;
-
-    &:hover,
-    &:focus {
+    .nav-link.active,
+    .show > .nav-link {
+      font-weight: $font-weight-bold;
+      color: var(--#{$prefix}nav-underline-link-active-color);
       border-bottom-color: currentcolor;
     }
   }
 
-  .nav-link.active,
-  .show > .nav-link {
-    font-weight: $font-weight-bold;
-    color: var(--#{$prefix}nav-underline-link-active-color);
-    border-bottom-color: currentcolor;
+  //
+  // Justified variants
+  //
+
+  .nav-fill {
+    > .nav-link,
+    .nav-item {
+      flex: 1 1 auto;
+      text-align: center;
+    }
   }
-}
 
-
-//
-// Justified variants
-//
-
-.nav-fill {
-  > .nav-link,
-  .nav-item {
-    flex: 1 1 auto;
-    text-align: center;
+  .nav-justified {
+    > .nav-link,
+    .nav-item {
+      flex-grow: 1;
+      flex-basis: 0;
+      text-align: center;
+    }
   }
-}
 
-.nav-justified {
-  > .nav-link,
-  .nav-item {
-    flex-grow: 1;
-    flex-basis: 0;
-    text-align: center;
+  .nav-fill,
+  .nav-justified {
+    .nav-item .nav-link {
+      width: 100%; // Make sure button will grow
+    }
   }
-}
 
-.nav-fill,
-.nav-justified {
-  .nav-item .nav-link {
-    width: 100%; // Make sure button will grow
-  }
-}
+  // Tabbable tabs
+  //
+  // Hide tabbable panes to start, show them when `.active`
 
-
-// Tabbable tabs
-//
-// Hide tabbable panes to start, show them when `.active`
-
-.tab-content {
-  > .tab-pane {
-    display: none;
-  }
-  > .active {
-    display: block;
+  .tab-content {
+    > .tab-pane {
+      display: none;
+    }
+    > .active {
+      display: block;
+    }
   }
 }

--- a/core/scss/bootstrap/_navbar.scss
+++ b/core/scss/bootstrap/_navbar.scss
@@ -1,292 +1,290 @@
-@use "sass:map";
+@use 'sass:map';
 
 // Navbar
 //
 // Provide a static navbar from which we expand to create full-width, fixed, and
 // other navbar variations.
 
-.navbar {
-  // scss-docs-start navbar-css-vars
-  --#{$prefix}navbar-padding-x: #{if(sass($navbar-padding-x == null): 0; else: $navbar-padding-x)};
-  --#{$prefix}navbar-padding-y: #{$navbar-padding-y};
-  --#{$prefix}navbar-color: #{$navbar-light-color};
-  --#{$prefix}navbar-hover-color: #{$navbar-light-hover-color};
-  --#{$prefix}navbar-disabled-color: #{$navbar-light-disabled-color};
-  --#{$prefix}navbar-active-color: #{$navbar-light-active-color};
-  --#{$prefix}navbar-brand-padding-y: #{$navbar-brand-padding-y};
-  --#{$prefix}navbar-brand-margin-end: #{$navbar-brand-margin-end};
-  --#{$prefix}navbar-brand-font-size: #{$navbar-brand-font-size};
-  --#{$prefix}navbar-brand-color: #{$navbar-light-brand-color};
-  --#{$prefix}navbar-brand-hover-color: #{$navbar-light-brand-hover-color};
-  --#{$prefix}navbar-nav-link-padding-x: #{$navbar-nav-link-padding-x};
-  --#{$prefix}navbar-toggler-padding-y: #{$navbar-toggler-padding-y};
-  --#{$prefix}navbar-toggler-padding-x: #{$navbar-toggler-padding-x};
-  --#{$prefix}navbar-toggler-font-size: #{$navbar-toggler-font-size};
-  --#{$prefix}navbar-toggler-icon-bg: #{escape-svg($navbar-light-toggler-icon-bg)};
-  --#{$prefix}navbar-toggler-border-color: #{$navbar-light-toggler-border-color};
-  --#{$prefix}navbar-toggler-border-radius: #{$navbar-toggler-border-radius};
-  --#{$prefix}navbar-toggler-focus-width: #{$navbar-toggler-focus-width};
-  --#{$prefix}navbar-toggler-transition: #{$navbar-toggler-transition};
-  // scss-docs-end navbar-css-vars
+@layer components {
+  .navbar {
+    // scss-docs-start navbar-css-vars
+    --#{$prefix}navbar-padding-x: #{if(sass($navbar-padding-x == null): 0; else: $navbar-padding-x)};
+    --#{$prefix}navbar-padding-y: #{$navbar-padding-y};
+    --#{$prefix}navbar-color: #{$navbar-light-color};
+    --#{$prefix}navbar-hover-color: #{$navbar-light-hover-color};
+    --#{$prefix}navbar-disabled-color: #{$navbar-light-disabled-color};
+    --#{$prefix}navbar-active-color: #{$navbar-light-active-color};
+    --#{$prefix}navbar-brand-padding-y: #{$navbar-brand-padding-y};
+    --#{$prefix}navbar-brand-margin-end: #{$navbar-brand-margin-end};
+    --#{$prefix}navbar-brand-font-size: #{$navbar-brand-font-size};
+    --#{$prefix}navbar-brand-color: #{$navbar-light-brand-color};
+    --#{$prefix}navbar-brand-hover-color: #{$navbar-light-brand-hover-color};
+    --#{$prefix}navbar-nav-link-padding-x: #{$navbar-nav-link-padding-x};
+    --#{$prefix}navbar-toggler-padding-y: #{$navbar-toggler-padding-y};
+    --#{$prefix}navbar-toggler-padding-x: #{$navbar-toggler-padding-x};
+    --#{$prefix}navbar-toggler-font-size: #{$navbar-toggler-font-size};
+    --#{$prefix}navbar-toggler-icon-bg: #{escape-svg($navbar-light-toggler-icon-bg)};
+    --#{$prefix}navbar-toggler-border-color: #{$navbar-light-toggler-border-color};
+    --#{$prefix}navbar-toggler-border-radius: #{$navbar-toggler-border-radius};
+    --#{$prefix}navbar-toggler-focus-width: #{$navbar-toggler-focus-width};
+    --#{$prefix}navbar-toggler-transition: #{$navbar-toggler-transition};
+    // scss-docs-end navbar-css-vars
 
-  position: relative;
-  display: flex;
-  flex-wrap: wrap; // allow us to do the line break for collapsing content
-  align-items: center;
-  justify-content: space-between; // space out brand from logo
-  padding: var(--#{$prefix}navbar-padding-y) var(--#{$prefix}navbar-padding-x);
-  @include gradient-bg();
-
-  // Because flex properties aren't inherited, we need to redeclare these first
-  // few properties so that content nested within behave properly.
-  // The `flex-wrap` property is inherited to simplify the expanded navbars
-  %container-flex-properties {
+    position: relative;
     display: flex;
-    flex-wrap: inherit;
+    flex-wrap: wrap; // allow us to do the line break for collapsing content
     align-items: center;
-    justify-content: space-between;
-  }
+    justify-content: space-between; // space out brand from logo
+    padding: var(--#{$prefix}navbar-padding-y) var(--#{$prefix}navbar-padding-x);
+    @include gradient-bg();
 
-  > .container,
-  > .container-fluid {
-    @extend %container-flex-properties;
-  }
+    // Because flex properties aren't inherited, we need to redeclare these first
+    // few properties so that content nested within behave properly.
+    // The `flex-wrap` property is inherited to simplify the expanded navbars
+    %container-flex-properties {
+      display: flex;
+      flex-wrap: inherit;
+      align-items: center;
+      justify-content: space-between;
+    }
 
-  @each $breakpoint, $container-max-width in $container-max-widths {
-    > .container#{breakpoint-infix($breakpoint, $container-max-widths)} {
+    > .container,
+    > .container-fluid {
       @extend %container-flex-properties;
     }
+
+    @each $breakpoint, $container-max-width in $container-max-widths {
+      > .container#{breakpoint-infix($breakpoint, $container-max-widths)} {
+        @extend %container-flex-properties;
+      }
+    }
   }
-}
 
+  // Navbar brand
+  //
+  // Used for brand, project, or site names.
 
-// Navbar brand
-//
-// Used for brand, project, or site names.
+  .navbar-brand {
+    padding-top: var(--#{$prefix}navbar-brand-padding-y);
+    padding-bottom: var(--#{$prefix}navbar-brand-padding-y);
+    margin-right: var(--#{$prefix}navbar-brand-margin-end);
+    @include font-size(var(--#{$prefix}navbar-brand-font-size));
+    color: var(--#{$prefix}navbar-brand-color);
+    text-decoration: if(sass($link-decoration == none): null; else: none);
+    white-space: nowrap;
 
-.navbar-brand {
-  padding-top: var(--#{$prefix}navbar-brand-padding-y);
-  padding-bottom: var(--#{$prefix}navbar-brand-padding-y);
-  margin-right: var(--#{$prefix}navbar-brand-margin-end);
-  @include font-size(var(--#{$prefix}navbar-brand-font-size));
-  color: var(--#{$prefix}navbar-brand-color);
-  text-decoration: if(sass($link-decoration == none): null; else: none);
-  white-space: nowrap;
-
-  &:hover,
-  &:focus {
-    color: var(--#{$prefix}navbar-brand-hover-color);
-    text-decoration: if(sass($link-hover-decoration == underline): none; else: null);
+    &:hover,
+    &:focus {
+      color: var(--#{$prefix}navbar-brand-hover-color);
+      text-decoration: if(sass($link-hover-decoration == underline): none; else: null);
+    }
   }
-}
 
+  // Navbar nav
+  //
+  // Custom navbar navigation (doesn't require `.nav`, but does make use of `.nav-link`).
 
-// Navbar nav
-//
-// Custom navbar navigation (doesn't require `.nav`, but does make use of `.nav-link`).
+  .navbar-nav {
+    // scss-docs-start navbar-nav-css-vars
+    --#{$prefix}nav-link-padding-x: 0;
+    --#{$prefix}nav-link-padding-y: #{$nav-link-padding-y};
+    @include rfs($nav-link-font-size, --#{$prefix}nav-link-font-size);
+    --#{$prefix}nav-link-font-weight: #{$nav-link-font-weight};
+    --#{$prefix}nav-link-color: var(--#{$prefix}navbar-color);
+    --#{$prefix}nav-link-hover-color: var(--#{$prefix}navbar-hover-color);
+    --#{$prefix}nav-link-disabled-color: var(--#{$prefix}navbar-disabled-color);
+    // scss-docs-end navbar-nav-css-vars
 
-.navbar-nav {
-  // scss-docs-start navbar-nav-css-vars
-  --#{$prefix}nav-link-padding-x: 0;
-  --#{$prefix}nav-link-padding-y: #{$nav-link-padding-y};
-  @include rfs($nav-link-font-size, --#{$prefix}nav-link-font-size);
-  --#{$prefix}nav-link-font-weight: #{$nav-link-font-weight};
-  --#{$prefix}nav-link-color: var(--#{$prefix}navbar-color);
-  --#{$prefix}nav-link-hover-color: var(--#{$prefix}navbar-hover-color);
-  --#{$prefix}nav-link-disabled-color: var(--#{$prefix}navbar-disabled-color);
-  // scss-docs-end navbar-nav-css-vars
+    display: flex;
+    flex-direction: column; // cannot use `inherit` to get the `.navbar`s value
+    padding-left: 0;
+    margin-bottom: 0;
+    list-style: none;
 
-  display: flex;
-  flex-direction: column; // cannot use `inherit` to get the `.navbar`s value
-  padding-left: 0;
-  margin-bottom: 0;
-  list-style: none;
+    .nav-link {
+      &.active,
+      &.show {
+        color: var(--#{$prefix}navbar-active-color);
+      }
+    }
 
-  .nav-link {
-    &.active,
-    &.show {
+    .dropdown-menu {
+      position: static;
+    }
+  }
+
+  // Navbar text
+  //
+  //
+
+  .navbar-text {
+    padding-top: $nav-link-padding-y;
+    padding-bottom: $nav-link-padding-y;
+    color: var(--#{$prefix}navbar-color);
+
+    a,
+    a:hover,
+    a:focus {
       color: var(--#{$prefix}navbar-active-color);
     }
   }
 
-  .dropdown-menu {
-    position: static;
-  }
-}
+  // Responsive navbar
+  //
+  // Custom styles for responsive collapsing and toggling of navbar contents.
+  // Powered by the collapse Bootstrap JavaScript plugin.
 
-
-// Navbar text
-//
-//
-
-.navbar-text {
-  padding-top: $nav-link-padding-y;
-  padding-bottom: $nav-link-padding-y;
-  color: var(--#{$prefix}navbar-color);
-
-  a,
-  a:hover,
-  a:focus  {
-    color: var(--#{$prefix}navbar-active-color);
-  }
-}
-
-
-// Responsive navbar
-//
-// Custom styles for responsive collapsing and toggling of navbar contents.
-// Powered by the collapse Bootstrap JavaScript plugin.
-
-// When collapsed, prevent the toggleable navbar contents from appearing in
-// the default flexbox row orientation. Requires the use of `flex-wrap: wrap`
-// on the `.navbar` parent.
-.navbar-collapse {
-  flex-grow: 1;
-  flex-basis: 100%;
-  // For always expanded or extra full navbars, ensure content aligns itself
-  // properly vertically. Can be easily overridden with flex utilities.
-  align-items: center;
-}
-
-// Button for toggling the navbar when in its collapsed state
-.navbar-toggler {
-  padding: var(--#{$prefix}navbar-toggler-padding-y) var(--#{$prefix}navbar-toggler-padding-x);
-  @include font-size(var(--#{$prefix}navbar-toggler-font-size));
-  line-height: 1;
-  color: var(--#{$prefix}navbar-color);
-  background-color: transparent; // remove default button style
-  border: var(--#{$prefix}border-width) solid var(--#{$prefix}navbar-toggler-border-color); // remove default button style
-  @include border-radius(var(--#{$prefix}navbar-toggler-border-radius));
-  @include transition(var(--#{$prefix}navbar-toggler-transition));
-
-  &:hover {
-    text-decoration: none;
+  // When collapsed, prevent the toggleable navbar contents from appearing in
+  // the default flexbox row orientation. Requires the use of `flex-wrap: wrap`
+  // on the `.navbar` parent.
+  .navbar-collapse {
+    flex-grow: 1;
+    flex-basis: 100%;
+    // For always expanded or extra full navbars, ensure content aligns itself
+    // properly vertically. Can be easily overridden with flex utilities.
+    align-items: center;
   }
 
-  &:focus {
-    text-decoration: none;
-    outline: 0;
-    box-shadow: 0 0 0 var(--#{$prefix}navbar-toggler-focus-width);
+  // Button for toggling the navbar when in its collapsed state
+  .navbar-toggler {
+    padding: var(--#{$prefix}navbar-toggler-padding-y) var(--#{$prefix}navbar-toggler-padding-x);
+    @include font-size(var(--#{$prefix}navbar-toggler-font-size));
+    line-height: 1;
+    color: var(--#{$prefix}navbar-color);
+    background-color: transparent; // remove default button style
+    border: var(--#{$prefix}border-width) solid var(--#{$prefix}navbar-toggler-border-color); // remove default button style
+    @include border-radius(var(--#{$prefix}navbar-toggler-border-radius));
+    @include transition(var(--#{$prefix}navbar-toggler-transition));
+
+    &:hover {
+      text-decoration: none;
+    }
+
+    &:focus {
+      text-decoration: none;
+      outline: 0;
+      box-shadow: 0 0 0 var(--#{$prefix}navbar-toggler-focus-width);
+    }
   }
-}
 
-// Keep as a separate element so folks can easily override it with another icon
-// or image file as needed.
-.navbar-toggler-icon {
-  display: inline-block;
-  width: 1.5em;
-  height: 1.5em;
-  vertical-align: middle;
-  background-image: var(--#{$prefix}navbar-toggler-icon-bg);
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 100%;
-}
+  // Keep as a separate element so folks can easily override it with another icon
+  // or image file as needed.
+  .navbar-toggler-icon {
+    display: inline-block;
+    width: 1.5em;
+    height: 1.5em;
+    vertical-align: middle;
+    background-image: var(--#{$prefix}navbar-toggler-icon-bg);
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 100%;
+  }
 
-.navbar-nav-scroll {
-  max-height: var(--#{$prefix}scroll-height, 75vh);
-  overflow-y: auto;
-}
+  .navbar-nav-scroll {
+    max-height: var(--#{$prefix}scroll-height, 75vh);
+    overflow-y: auto;
+  }
 
-// scss-docs-start navbar-expand-loop
-// Generate series of `.navbar-expand-*` responsive classes for configuring
-// where your navbar collapses.
-.navbar-expand {
-  @each $breakpoint in map.keys($grid-breakpoints) {
-    $next: breakpoint-next($breakpoint, $grid-breakpoints);
-    $infix: breakpoint-infix($next, $grid-breakpoints);
+  // scss-docs-start navbar-expand-loop
+  // Generate series of `.navbar-expand-*` responsive classes for configuring
+  // where your navbar collapses.
+  .navbar-expand {
+    @each $breakpoint in map.keys($grid-breakpoints) {
+      $next: breakpoint-next($breakpoint, $grid-breakpoints);
+      $infix: breakpoint-infix($next, $grid-breakpoints);
 
-    // stylelint-disable-next-line scss/selector-no-union-class-name
-    &#{$infix} {
-      @include media-breakpoint-up($next) {
-        flex-wrap: nowrap;
-        justify-content: flex-start;
+      // stylelint-disable-next-line scss/selector-no-union-class-name
+      &#{$infix} {
+        @include media-breakpoint-up($next) {
+          flex-wrap: nowrap;
+          justify-content: flex-start;
 
-        .navbar-nav {
-          flex-direction: row;
+          .navbar-nav {
+            flex-direction: row;
 
-          .dropdown-menu {
-            position: absolute;
+            .dropdown-menu {
+              position: absolute;
+            }
+
+            .nav-link {
+              padding-right: var(--#{$prefix}navbar-nav-link-padding-x);
+              padding-left: var(--#{$prefix}navbar-nav-link-padding-x);
+            }
           }
 
-          .nav-link {
-            padding-right: var(--#{$prefix}navbar-nav-link-padding-x);
-            padding-left: var(--#{$prefix}navbar-nav-link-padding-x);
+          .navbar-nav-scroll {
+            overflow: visible;
           }
-        }
 
-        .navbar-nav-scroll {
-          overflow: visible;
-        }
+          .navbar-collapse {
+            display: flex !important; // stylelint-disable-line declaration-no-important
+            flex-basis: auto;
+          }
 
-        .navbar-collapse {
-          display: flex !important; // stylelint-disable-line declaration-no-important
-          flex-basis: auto;
-        }
-
-        .navbar-toggler {
-          display: none;
-        }
-
-        .offcanvas {
-          // stylelint-disable declaration-no-important
-          position: static;
-          z-index: auto;
-          flex-grow: 1;
-          width: auto !important;
-          height: auto !important;
-          visibility: visible !important;
-          background-color: transparent !important;
-          border: 0 !important;
-          transform: none !important;
-          @include box-shadow(none);
-          @include transition(none);
-          // stylelint-enable declaration-no-important
-
-          .offcanvas-header {
+          .navbar-toggler {
             display: none;
           }
 
-          .offcanvas-body {
-            display: flex;
-            flex-grow: 0;
-            padding: 0;
-            overflow-y: visible;
+          .offcanvas {
+            // stylelint-disable declaration-no-important
+            position: static;
+            z-index: auto;
+            flex-grow: 1;
+            width: auto !important;
+            height: auto !important;
+            visibility: visible !important;
+            background-color: transparent !important;
+            border: 0 !important;
+            transform: none !important;
+            @include box-shadow(none);
+            @include transition(none);
+            // stylelint-enable declaration-no-important
+
+            .offcanvas-header {
+              display: none;
+            }
+
+            .offcanvas-body {
+              display: flex;
+              flex-grow: 0;
+              padding: 0;
+              overflow-y: visible;
+            }
           }
         }
       }
     }
   }
-}
-// scss-docs-end navbar-expand-loop
+  // scss-docs-end navbar-expand-loop
 
-// Navbar themes
-//
-// Styles for switching between navbars with light or dark background.
+  // Navbar themes
+  //
+  // Styles for switching between navbars with light or dark background.
 
-.navbar-light {
-  @include deprecate("`.navbar-light`", "v5.2.0", "v6.0.0", true);
-}
+  .navbar-light {
+    @include deprecate('`.navbar-light`', 'v5.2.0', 'v6.0.0', true);
+  }
 
-.navbar-dark,
-.navbar[data-bs-theme="dark"],
-.navbar[data-theme="dark"] {
-  // scss-docs-start navbar-dark-css-vars
-  --#{$prefix}navbar-color: #{$navbar-dark-color};
-  --#{$prefix}navbar-hover-color: #{$navbar-dark-hover-color};
-  --#{$prefix}navbar-disabled-color: #{$navbar-dark-disabled-color};
-  --#{$prefix}navbar-active-color: #{$navbar-dark-active-color};
-  --#{$prefix}navbar-brand-color: #{$navbar-dark-brand-color};
-  --#{$prefix}navbar-brand-hover-color: #{$navbar-dark-brand-hover-color};
-  --#{$prefix}navbar-toggler-border-color: #{$navbar-dark-toggler-border-color};
-  --#{$prefix}navbar-toggler-icon-bg: #{escape-svg($navbar-dark-toggler-icon-bg)};
-  // scss-docs-end navbar-dark-css-vars
-}
+  .navbar-dark,
+  .navbar[data-bs-theme='dark'],
+  .navbar[data-theme='dark'] {
+    // scss-docs-start navbar-dark-css-vars
+    --#{$prefix}navbar-color: #{$navbar-dark-color};
+    --#{$prefix}navbar-hover-color: #{$navbar-dark-hover-color};
+    --#{$prefix}navbar-disabled-color: #{$navbar-dark-disabled-color};
+    --#{$prefix}navbar-active-color: #{$navbar-dark-active-color};
+    --#{$prefix}navbar-brand-color: #{$navbar-dark-brand-color};
+    --#{$prefix}navbar-brand-hover-color: #{$navbar-dark-brand-hover-color};
+    --#{$prefix}navbar-toggler-border-color: #{$navbar-dark-toggler-border-color};
+    --#{$prefix}navbar-toggler-icon-bg: #{escape-svg($navbar-dark-toggler-icon-bg)};
+    // scss-docs-end navbar-dark-css-vars
+  }
 
-@if $enable-dark-mode {
-  @include color-mode(dark) {
-    .navbar-toggler-icon {
-      --#{$prefix}navbar-toggler-icon-bg: #{escape-svg($navbar-dark-toggler-icon-bg)};
+  @if $enable-dark-mode {
+    @include color-mode(dark) {
+      .navbar-toggler-icon {
+        --#{$prefix}navbar-toggler-icon-bg: #{escape-svg($navbar-dark-toggler-icon-bg)};
+      }
     }
   }
 }

--- a/core/scss/bootstrap/_offcanvas.scss
+++ b/core/scss/bootstrap/_offcanvas.scss
@@ -1,149 +1,151 @@
 // stylelint-disable function-disallowed-list
 
-@use "sass:map";
+@use 'sass:map';
 
-%offcanvas-css-vars {
-  // scss-docs-start offcanvas-css-vars
-  --#{$prefix}offcanvas-zindex: #{$zindex-offcanvas};
-  --#{$prefix}offcanvas-width: #{$offcanvas-horizontal-width};
-  --#{$prefix}offcanvas-height: #{$offcanvas-vertical-height};
-  --#{$prefix}offcanvas-padding-x: #{$offcanvas-padding-x};
-  --#{$prefix}offcanvas-padding-y: #{$offcanvas-padding-y};
-  --#{$prefix}offcanvas-color: #{$offcanvas-color};
-  --#{$prefix}offcanvas-bg: #{$offcanvas-bg-color};
-  --#{$prefix}offcanvas-border-width: #{$offcanvas-border-width};
-  --#{$prefix}offcanvas-border-color: #{$offcanvas-border-color};
-  --#{$prefix}offcanvas-box-shadow: #{$offcanvas-box-shadow};
-  --#{$prefix}offcanvas-transition: #{transform $offcanvas-transition-duration ease-in-out};
-  --#{$prefix}offcanvas-title-line-height: #{$offcanvas-title-line-height};
-  // scss-docs-end offcanvas-css-vars
-}
-
-@each $breakpoint in map.keys($grid-breakpoints) {
-  $next: breakpoint-next($breakpoint, $grid-breakpoints);
-  $infix: breakpoint-infix($next, $grid-breakpoints);
-
-  .offcanvas#{$infix} {
-    @extend %offcanvas-css-vars;
+@layer components {
+  %offcanvas-css-vars {
+    // scss-docs-start offcanvas-css-vars
+    --#{$prefix}offcanvas-zindex: #{$zindex-offcanvas};
+    --#{$prefix}offcanvas-width: #{$offcanvas-horizontal-width};
+    --#{$prefix}offcanvas-height: #{$offcanvas-vertical-height};
+    --#{$prefix}offcanvas-padding-x: #{$offcanvas-padding-x};
+    --#{$prefix}offcanvas-padding-y: #{$offcanvas-padding-y};
+    --#{$prefix}offcanvas-color: #{$offcanvas-color};
+    --#{$prefix}offcanvas-bg: #{$offcanvas-bg-color};
+    --#{$prefix}offcanvas-border-width: #{$offcanvas-border-width};
+    --#{$prefix}offcanvas-border-color: #{$offcanvas-border-color};
+    --#{$prefix}offcanvas-box-shadow: #{$offcanvas-box-shadow};
+    --#{$prefix}offcanvas-transition: #{transform $offcanvas-transition-duration ease-in-out};
+    --#{$prefix}offcanvas-title-line-height: #{$offcanvas-title-line-height};
+    // scss-docs-end offcanvas-css-vars
   }
-}
 
-@each $breakpoint in map.keys($grid-breakpoints) {
-  $next: breakpoint-next($breakpoint, $grid-breakpoints);
-  $infix: breakpoint-infix($next, $grid-breakpoints);
+  @each $breakpoint in map.keys($grid-breakpoints) {
+    $next: breakpoint-next($breakpoint, $grid-breakpoints);
+    $infix: breakpoint-infix($next, $grid-breakpoints);
 
-  .offcanvas#{$infix} {
-    @include media-breakpoint-down($next) {
-      position: fixed;
-      bottom: 0;
-      z-index: var(--#{$prefix}offcanvas-zindex);
-      display: flex;
-      flex-direction: column;
-      max-width: 100%;
-      color: var(--#{$prefix}offcanvas-color);
-      visibility: hidden;
-      background-color: var(--#{$prefix}offcanvas-bg);
-      background-clip: padding-box;
-      outline: 0;
-      @include box-shadow(var(--#{$prefix}offcanvas-box-shadow));
-      @include transition(var(--#{$prefix}offcanvas-transition));
-
-      &.offcanvas-start {
-        top: 0;
-        left: 0;
-        width: var(--#{$prefix}offcanvas-width);
-        border-right: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
-        transform: translateX(-100%);
-      }
-
-      &.offcanvas-end {
-        top: 0;
-        right: 0;
-        width: var(--#{$prefix}offcanvas-width);
-        border-left: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
-        transform: translateX(100%);
-      }
-
-      &.offcanvas-top {
-        top: 0;
-        right: 0;
-        left: 0;
-        height: var(--#{$prefix}offcanvas-height);
-        max-height: 100%;
-        border-bottom: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
-        transform: translateY(-100%);
-      }
-
-      &.offcanvas-bottom {
-        right: 0;
-        left: 0;
-        height: var(--#{$prefix}offcanvas-height);
-        max-height: 100%;
-        border-top: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
-        transform: translateY(100%);
-      }
-
-      &.showing,
-      &.show:not(.hiding) {
-        transform: none;
-      }
-
-      &.showing,
-      &.hiding,
-      &.show {
-        visibility: visible;
-      }
+    .offcanvas#{$infix} {
+      @extend %offcanvas-css-vars;
     }
+  }
 
-    @if not ($infix == "") {
-      @include media-breakpoint-up($next) {
-        --#{$prefix}offcanvas-height: auto;
-        --#{$prefix}offcanvas-border-width: 0;
-        background-color: transparent !important; // stylelint-disable-line declaration-no-important
+  @each $breakpoint in map.keys($grid-breakpoints) {
+    $next: breakpoint-next($breakpoint, $grid-breakpoints);
+    $infix: breakpoint-infix($next, $grid-breakpoints);
 
-        .offcanvas-header {
-          display: none;
+    .offcanvas#{$infix} {
+      @include media-breakpoint-down($next) {
+        position: fixed;
+        bottom: 0;
+        z-index: var(--#{$prefix}offcanvas-zindex);
+        display: flex;
+        flex-direction: column;
+        max-width: 100%;
+        color: var(--#{$prefix}offcanvas-color);
+        visibility: hidden;
+        background-color: var(--#{$prefix}offcanvas-bg);
+        background-clip: padding-box;
+        outline: 0;
+        @include box-shadow(var(--#{$prefix}offcanvas-box-shadow));
+        @include transition(var(--#{$prefix}offcanvas-transition));
+
+        &.offcanvas-start {
+          top: 0;
+          left: 0;
+          width: var(--#{$prefix}offcanvas-width);
+          border-right: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
+          transform: translateX(-100%);
         }
 
-        .offcanvas-body {
-          display: flex;
-          flex-grow: 0;
-          padding: 0;
-          overflow-y: visible;
-          // Reset `background-color` in case `.bg-*` classes are used in offcanvas
+        &.offcanvas-end {
+          top: 0;
+          right: 0;
+          width: var(--#{$prefix}offcanvas-width);
+          border-left: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
+          transform: translateX(100%);
+        }
+
+        &.offcanvas-top {
+          top: 0;
+          right: 0;
+          left: 0;
+          height: var(--#{$prefix}offcanvas-height);
+          max-height: 100%;
+          border-bottom: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
+          transform: translateY(-100%);
+        }
+
+        &.offcanvas-bottom {
+          right: 0;
+          left: 0;
+          height: var(--#{$prefix}offcanvas-height);
+          max-height: 100%;
+          border-top: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
+          transform: translateY(100%);
+        }
+
+        &.showing,
+        &.show:not(.hiding) {
+          transform: none;
+        }
+
+        &.showing,
+        &.hiding,
+        &.show {
+          visibility: visible;
+        }
+      }
+
+      @if not($infix == '') {
+        @include media-breakpoint-up($next) {
+          --#{$prefix}offcanvas-height: auto;
+          --#{$prefix}offcanvas-border-width: 0;
           background-color: transparent !important; // stylelint-disable-line declaration-no-important
+
+          .offcanvas-header {
+            display: none;
+          }
+
+          .offcanvas-body {
+            display: flex;
+            flex-grow: 0;
+            padding: 0;
+            overflow-y: visible;
+            // Reset `background-color` in case `.bg-*` classes are used in offcanvas
+            background-color: transparent !important; // stylelint-disable-line declaration-no-important
+          }
         }
       }
     }
   }
-}
 
-.offcanvas-backdrop {
-  @include overlay-backdrop($zindex-offcanvas-backdrop, $offcanvas-backdrop-bg, $offcanvas-backdrop-opacity);
-}
-
-.offcanvas-header {
-  display: flex;
-  align-items: center;
-  padding: var(--#{$prefix}offcanvas-padding-y) var(--#{$prefix}offcanvas-padding-x);
-
-  .btn-close {
-    padding: calc(var(--#{$prefix}offcanvas-padding-y) * .5) calc(var(--#{$prefix}offcanvas-padding-x) * .5);
-    // Split properties to avoid invalid calc() function if value is 0
-    margin-top: calc(-.5 * var(--#{$prefix}offcanvas-padding-y));
-    margin-right: calc(-.5 * var(--#{$prefix}offcanvas-padding-x));
-    margin-bottom: calc(-.5 * var(--#{$prefix}offcanvas-padding-y));
-    margin-left: auto;
+  .offcanvas-backdrop {
+    @include overlay-backdrop($zindex-offcanvas-backdrop, $offcanvas-backdrop-bg, $offcanvas-backdrop-opacity);
   }
-}
 
-.offcanvas-title {
-  margin-bottom: 0;
-  line-height: var(--#{$prefix}offcanvas-title-line-height);
-}
+  .offcanvas-header {
+    display: flex;
+    align-items: center;
+    padding: var(--#{$prefix}offcanvas-padding-y) var(--#{$prefix}offcanvas-padding-x);
 
-.offcanvas-body {
-  flex-grow: 1;
-  padding: var(--#{$prefix}offcanvas-padding-y) var(--#{$prefix}offcanvas-padding-x);
-  overflow-y: auto;
+    .btn-close {
+      padding: calc(var(--#{$prefix}offcanvas-padding-y) * 0.5) calc(var(--#{$prefix}offcanvas-padding-x) * 0.5);
+      // Split properties to avoid invalid calc() function if value is 0
+      margin-top: calc(-0.5 * var(--#{$prefix}offcanvas-padding-y));
+      margin-right: calc(-0.5 * var(--#{$prefix}offcanvas-padding-x));
+      margin-bottom: calc(-0.5 * var(--#{$prefix}offcanvas-padding-y));
+      margin-left: auto;
+    }
+  }
+
+  .offcanvas-title {
+    margin-bottom: 0;
+    line-height: var(--#{$prefix}offcanvas-title-line-height);
+  }
+
+  .offcanvas-body {
+    flex-grow: 1;
+    padding: var(--#{$prefix}offcanvas-padding-y) var(--#{$prefix}offcanvas-padding-x);
+    overflow-y: auto;
+  }
 }

--- a/core/scss/bootstrap/_pagination.scss
+++ b/core/scss/bootstrap/_pagination.scss
@@ -1,109 +1,110 @@
-.pagination {
-  // scss-docs-start pagination-css-vars
-  --#{$prefix}pagination-padding-x: #{$pagination-padding-x};
-  --#{$prefix}pagination-padding-y: #{$pagination-padding-y};
-  @include rfs($pagination-font-size, --#{$prefix}pagination-font-size);
-  --#{$prefix}pagination-color: #{$pagination-color};
-  --#{$prefix}pagination-bg: #{$pagination-bg};
-  --#{$prefix}pagination-border-width: #{$pagination-border-width};
-  --#{$prefix}pagination-border-color: #{$pagination-border-color};
-  --#{$prefix}pagination-border-radius: #{$pagination-border-radius};
-  --#{$prefix}pagination-hover-color: #{$pagination-hover-color};
-  --#{$prefix}pagination-hover-bg: #{$pagination-hover-bg};
-  --#{$prefix}pagination-hover-border-color: #{$pagination-hover-border-color};
-  --#{$prefix}pagination-focus-color: #{$pagination-focus-color};
-  --#{$prefix}pagination-focus-bg: #{$pagination-focus-bg};
-  --#{$prefix}pagination-focus-box-shadow: #{$pagination-focus-box-shadow};
-  --#{$prefix}pagination-active-color: #{$pagination-active-color};
-  --#{$prefix}pagination-active-bg: #{$pagination-active-bg};
-  --#{$prefix}pagination-active-border-color: #{$pagination-active-border-color};
-  --#{$prefix}pagination-disabled-color: #{$pagination-disabled-color};
-  --#{$prefix}pagination-disabled-bg: #{$pagination-disabled-bg};
-  --#{$prefix}pagination-disabled-border-color: #{$pagination-disabled-border-color};
-  // scss-docs-end pagination-css-vars
+@layer components {
+  .pagination {
+    // scss-docs-start pagination-css-vars
+    --#{$prefix}pagination-padding-x: #{$pagination-padding-x};
+    --#{$prefix}pagination-padding-y: #{$pagination-padding-y};
+    @include rfs($pagination-font-size, --#{$prefix}pagination-font-size);
+    --#{$prefix}pagination-color: #{$pagination-color};
+    --#{$prefix}pagination-bg: #{$pagination-bg};
+    --#{$prefix}pagination-border-width: #{$pagination-border-width};
+    --#{$prefix}pagination-border-color: #{$pagination-border-color};
+    --#{$prefix}pagination-border-radius: #{$pagination-border-radius};
+    --#{$prefix}pagination-hover-color: #{$pagination-hover-color};
+    --#{$prefix}pagination-hover-bg: #{$pagination-hover-bg};
+    --#{$prefix}pagination-hover-border-color: #{$pagination-hover-border-color};
+    --#{$prefix}pagination-focus-color: #{$pagination-focus-color};
+    --#{$prefix}pagination-focus-bg: #{$pagination-focus-bg};
+    --#{$prefix}pagination-focus-box-shadow: #{$pagination-focus-box-shadow};
+    --#{$prefix}pagination-active-color: #{$pagination-active-color};
+    --#{$prefix}pagination-active-bg: #{$pagination-active-bg};
+    --#{$prefix}pagination-active-border-color: #{$pagination-active-border-color};
+    --#{$prefix}pagination-disabled-color: #{$pagination-disabled-color};
+    --#{$prefix}pagination-disabled-bg: #{$pagination-disabled-bg};
+    --#{$prefix}pagination-disabled-border-color: #{$pagination-disabled-border-color};
+    // scss-docs-end pagination-css-vars
 
-  display: flex;
-  @include list-unstyled();
-}
-
-.page-link {
-  position: relative;
-  display: block;
-  padding: var(--#{$prefix}pagination-padding-y) var(--#{$prefix}pagination-padding-x);
-  @include font-size(var(--#{$prefix}pagination-font-size));
-  color: var(--#{$prefix}pagination-color);
-  text-decoration: if(sass($link-decoration == none): null; else: none);
-  background-color: var(--#{$prefix}pagination-bg);
-  border: var(--#{$prefix}pagination-border-width) solid var(--#{$prefix}pagination-border-color);
-  @include transition($pagination-transition);
-
-  &:hover {
-    z-index: 2;
-    color: var(--#{$prefix}pagination-hover-color);
-    text-decoration: if(sass($link-hover-decoration == underline): none; else: null);
-    background-color: var(--#{$prefix}pagination-hover-bg);
-    border-color: var(--#{$prefix}pagination-hover-border-color);
+    display: flex;
+    @include list-unstyled();
   }
 
-  &:focus {
-    z-index: 3;
-    color: var(--#{$prefix}pagination-focus-color);
-    background-color: var(--#{$prefix}pagination-focus-bg);
-    outline: $pagination-focus-outline;
-    box-shadow: var(--#{$prefix}pagination-focus-box-shadow);
+  .page-link {
+    position: relative;
+    display: block;
+    padding: var(--#{$prefix}pagination-padding-y) var(--#{$prefix}pagination-padding-x);
+    @include font-size(var(--#{$prefix}pagination-font-size));
+    color: var(--#{$prefix}pagination-color);
+    text-decoration: if(sass($link-decoration == none): null; else: none);
+    background-color: var(--#{$prefix}pagination-bg);
+    border: var(--#{$prefix}pagination-border-width) solid var(--#{$prefix}pagination-border-color);
+    @include transition($pagination-transition);
+
+    &:hover {
+      z-index: 2;
+      color: var(--#{$prefix}pagination-hover-color);
+      text-decoration: if(sass($link-hover-decoration == underline): none; else: null);
+      background-color: var(--#{$prefix}pagination-hover-bg);
+      border-color: var(--#{$prefix}pagination-hover-border-color);
+    }
+
+    &:focus {
+      z-index: 3;
+      color: var(--#{$prefix}pagination-focus-color);
+      background-color: var(--#{$prefix}pagination-focus-bg);
+      outline: $pagination-focus-outline;
+      box-shadow: var(--#{$prefix}pagination-focus-box-shadow);
+    }
+
+    &.active,
+    .active > & {
+      z-index: 3;
+      color: var(--#{$prefix}pagination-active-color);
+      @include gradient-bg(var(--#{$prefix}pagination-active-bg));
+      border-color: var(--#{$prefix}pagination-active-border-color);
+    }
+
+    &.disabled,
+    .disabled > & {
+      color: var(--#{$prefix}pagination-disabled-color);
+      pointer-events: none;
+      background-color: var(--#{$prefix}pagination-disabled-bg);
+      border-color: var(--#{$prefix}pagination-disabled-border-color);
+    }
   }
 
-  &.active,
-  .active > & {
-    z-index: 3;
-    color: var(--#{$prefix}pagination-active-color);
-    @include gradient-bg(var(--#{$prefix}pagination-active-bg));
-    border-color: var(--#{$prefix}pagination-active-border-color);
-  }
+  .page-item {
+    &:not(:first-child) .page-link {
+      margin-left: $pagination-margin-start;
+    }
 
-  &.disabled,
-  .disabled > & {
-    color: var(--#{$prefix}pagination-disabled-color);
-    pointer-events: none;
-    background-color: var(--#{$prefix}pagination-disabled-bg);
-    border-color: var(--#{$prefix}pagination-disabled-border-color);
-  }
-}
+    @if $pagination-margin-start == calc(-1 * #{$pagination-border-width}) {
+      &:first-child {
+        .page-link {
+          @include border-start-radius(var(--#{$prefix}pagination-border-radius));
+        }
+      }
 
-.page-item {
-  &:not(:first-child) .page-link {
-    margin-left: $pagination-margin-start;
-  }
-
-  @if $pagination-margin-start == calc(-1 * #{$pagination-border-width}) {
-    &:first-child {
+      &:last-child {
+        .page-link {
+          @include border-end-radius(var(--#{$prefix}pagination-border-radius));
+        }
+      }
+    } @else {
+      // Add border-radius to all pageLinks in case they have left margin
       .page-link {
-        @include border-start-radius(var(--#{$prefix}pagination-border-radius));
+        @include border-radius(var(--#{$prefix}pagination-border-radius));
       }
     }
-
-    &:last-child {
-      .page-link {
-        @include border-end-radius(var(--#{$prefix}pagination-border-radius));
-      }
-    }
-  } @else {
-    // Add border-radius to all pageLinks in case they have left margin
-    .page-link {
-      @include border-radius(var(--#{$prefix}pagination-border-radius));
-    }
   }
-}
 
+  //
+  // Sizing
+  //
 
-//
-// Sizing
-//
+  .pagination-lg {
+    @include pagination-size($pagination-padding-y-lg, $pagination-padding-x-lg, $font-size-lg, $pagination-border-radius-lg);
+  }
 
-.pagination-lg {
-  @include pagination-size($pagination-padding-y-lg, $pagination-padding-x-lg, $font-size-lg, $pagination-border-radius-lg);
-}
-
-.pagination-sm {
-  @include pagination-size($pagination-padding-y-sm, $pagination-padding-x-sm, $font-size-sm, $pagination-border-radius-sm);
+  .pagination-sm {
+    @include pagination-size($pagination-padding-y-sm, $pagination-padding-x-sm, $font-size-sm, $pagination-border-radius-sm);
+  }
 }

--- a/core/scss/bootstrap/_placeholders.scss
+++ b/core/scss/bootstrap/_placeholders.scss
@@ -1,51 +1,53 @@
-.placeholder {
-  display: inline-block;
-  min-height: 1em;
-  vertical-align: middle;
-  cursor: wait;
-  background-color: currentcolor;
-  opacity: $placeholder-opacity-max;
-
-  &.btn::before {
-    display: inline-block;
-    content: "";
-  }
-}
-
-// Sizing
-.placeholder-xs {
-  min-height: .6em;
-}
-
-.placeholder-sm {
-  min-height: .8em;
-}
-
-.placeholder-lg {
-  min-height: 1.2em;
-}
-
-// Animation
-.placeholder-glow {
+@layer components {
   .placeholder {
-    animation: placeholder-glow 2s ease-in-out infinite;
+    display: inline-block;
+    min-height: 1em;
+    vertical-align: middle;
+    cursor: wait;
+    background-color: currentcolor;
+    opacity: $placeholder-opacity-max;
+
+    &.btn::before {
+      display: inline-block;
+      content: '';
+    }
   }
-}
 
-@keyframes placeholder-glow {
-  50% {
-    opacity: $placeholder-opacity-min;
+  // Sizing
+  .placeholder-xs {
+    min-height: 0.6em;
   }
-}
 
-.placeholder-wave {
-  mask-image: linear-gradient(130deg, $black 55%, rgba(0, 0, 0, (1 - $placeholder-opacity-min)) 75%, $black 95%);
-  mask-size: 200% 100%;
-  animation: placeholder-wave 2s linear infinite;
-}
+  .placeholder-sm {
+    min-height: 0.8em;
+  }
 
-@keyframes placeholder-wave {
-  100% {
-    mask-position: -200% 0%;
+  .placeholder-lg {
+    min-height: 1.2em;
+  }
+
+  // Animation
+  .placeholder-glow {
+    .placeholder {
+      animation: placeholder-glow 2s ease-in-out infinite;
+    }
+  }
+
+  @keyframes placeholder-glow {
+    50% {
+      opacity: $placeholder-opacity-min;
+    }
+  }
+
+  .placeholder-wave {
+    mask-image: linear-gradient(130deg, $black 55%, rgba(0, 0, 0, (1 - $placeholder-opacity-min)) 75%, $black 95%);
+    mask-size: 200% 100%;
+    animation: placeholder-wave 2s linear infinite;
+  }
+
+  @keyframes placeholder-wave {
+    100% {
+      mask-position: -200% 0%;
+    }
   }
 }

--- a/core/scss/bootstrap/_popover.scss
+++ b/core/scss/bootstrap/_popover.scss
@@ -1,196 +1,198 @@
-.popover {
-  // scss-docs-start popover-css-vars
-  --#{$prefix}popover-zindex: #{$zindex-popover};
-  --#{$prefix}popover-max-width: #{$popover-max-width};
-  @include rfs($popover-font-size, --#{$prefix}popover-font-size);
-  --#{$prefix}popover-bg: #{$popover-bg};
-  --#{$prefix}popover-border-width: #{$popover-border-width};
-  --#{$prefix}popover-border-color: #{$popover-border-color};
-  --#{$prefix}popover-border-radius: #{$popover-border-radius};
-  --#{$prefix}popover-inner-border-radius: #{$popover-inner-border-radius};
-  --#{$prefix}popover-box-shadow: #{$popover-box-shadow};
-  --#{$prefix}popover-header-padding-x: #{$popover-header-padding-x};
-  --#{$prefix}popover-header-padding-y: #{$popover-header-padding-y};
-  @include rfs($popover-header-font-size, --#{$prefix}popover-header-font-size);
-  --#{$prefix}popover-header-color: #{$popover-header-color};
-  --#{$prefix}popover-header-bg: #{$popover-header-bg};
-  --#{$prefix}popover-body-padding-x: #{$popover-body-padding-x};
-  --#{$prefix}popover-body-padding-y: #{$popover-body-padding-y};
-  --#{$prefix}popover-body-color: #{$popover-body-color};
-  --#{$prefix}popover-arrow-width: #{$popover-arrow-width};
-  --#{$prefix}popover-arrow-height: #{$popover-arrow-height};
-  --#{$prefix}popover-arrow-border: var(--#{$prefix}popover-border-color);
-  // scss-docs-end popover-css-vars
+@layer components {
+  .popover {
+    // scss-docs-start popover-css-vars
+    --#{$prefix}popover-zindex: #{$zindex-popover};
+    --#{$prefix}popover-max-width: #{$popover-max-width};
+    @include rfs($popover-font-size, --#{$prefix}popover-font-size);
+    --#{$prefix}popover-bg: #{$popover-bg};
+    --#{$prefix}popover-border-width: #{$popover-border-width};
+    --#{$prefix}popover-border-color: #{$popover-border-color};
+    --#{$prefix}popover-border-radius: #{$popover-border-radius};
+    --#{$prefix}popover-inner-border-radius: #{$popover-inner-border-radius};
+    --#{$prefix}popover-box-shadow: #{$popover-box-shadow};
+    --#{$prefix}popover-header-padding-x: #{$popover-header-padding-x};
+    --#{$prefix}popover-header-padding-y: #{$popover-header-padding-y};
+    @include rfs($popover-header-font-size, --#{$prefix}popover-header-font-size);
+    --#{$prefix}popover-header-color: #{$popover-header-color};
+    --#{$prefix}popover-header-bg: #{$popover-header-bg};
+    --#{$prefix}popover-body-padding-x: #{$popover-body-padding-x};
+    --#{$prefix}popover-body-padding-y: #{$popover-body-padding-y};
+    --#{$prefix}popover-body-color: #{$popover-body-color};
+    --#{$prefix}popover-arrow-width: #{$popover-arrow-width};
+    --#{$prefix}popover-arrow-height: #{$popover-arrow-height};
+    --#{$prefix}popover-arrow-border: var(--#{$prefix}popover-border-color);
+    // scss-docs-end popover-css-vars
 
-  z-index: var(--#{$prefix}popover-zindex);
-  display: block;
-  max-width: var(--#{$prefix}popover-max-width);
-  // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
-  // So reset our font and text properties to avoid inheriting weird values.
-  @include reset-text();
-  @include font-size(var(--#{$prefix}popover-font-size));
-  // Allow breaking very long words so they don't overflow the popover's bounds
-  word-wrap: break-word;
-  background-color: var(--#{$prefix}popover-bg);
-  background-clip: padding-box;
-  border: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-border-color);
-  @include border-radius(var(--#{$prefix}popover-border-radius));
-  @include box-shadow(var(--#{$prefix}popover-box-shadow));
-
-  .popover-arrow {
+    z-index: var(--#{$prefix}popover-zindex);
     display: block;
-    width: var(--#{$prefix}popover-arrow-width);
-    height: var(--#{$prefix}popover-arrow-height);
+    max-width: var(--#{$prefix}popover-max-width);
+    // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
+    // So reset our font and text properties to avoid inheriting weird values.
+    @include reset-text();
+    @include font-size(var(--#{$prefix}popover-font-size));
+    // Allow breaking very long words so they don't overflow the popover's bounds
+    word-wrap: break-word;
+    background-color: var(--#{$prefix}popover-bg);
+    background-clip: padding-box;
+    border: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-border-color);
+    @include border-radius(var(--#{$prefix}popover-border-radius));
+    @include box-shadow(var(--#{$prefix}popover-box-shadow));
 
-    &::before,
-    &::after {
-      position: absolute;
+    .popover-arrow {
       display: block;
-      content: "";
-      border-color: transparent;
-      border-style: solid;
-      border-width: 0;
+      width: var(--#{$prefix}popover-arrow-width);
+      height: var(--#{$prefix}popover-arrow-height);
+
+      &::before,
+      &::after {
+        position: absolute;
+        display: block;
+        content: '';
+        border-color: transparent;
+        border-style: solid;
+        border-width: 0;
+      }
     }
   }
-}
 
-.bs-popover-top {
-  > .popover-arrow {
-    bottom: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+  .bs-popover-top {
+    > .popover-arrow {
+      bottom: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
 
-    &::before,
-    &::after {
-      border-width: var(--#{$prefix}popover-arrow-height) calc(var(--#{$prefix}popover-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
-    }
+      &::before,
+      &::after {
+        border-width: var(--#{$prefix}popover-arrow-height) calc(var(--#{$prefix}popover-arrow-width) * 0.5) 0; // stylelint-disable-line function-disallowed-list
+      }
 
-    &::before {
-      bottom: 0;
-      border-top-color: var(--#{$prefix}popover-arrow-border);
-    }
+      &::before {
+        bottom: 0;
+        border-top-color: var(--#{$prefix}popover-arrow-border);
+      }
 
-    &::after {
-      bottom: var(--#{$prefix}popover-border-width);
-      border-top-color: var(--#{$prefix}popover-bg);
-    }
-  }
-}
-
-/* rtl:begin:ignore */
-.bs-popover-end {
-  > .popover-arrow {
-    left: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
-    width: var(--#{$prefix}popover-arrow-height);
-    height: var(--#{$prefix}popover-arrow-width);
-
-    &::before,
-    &::after {
-      border-width: calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height) calc(var(--#{$prefix}popover-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
-    }
-
-    &::before {
-      left: 0;
-      border-right-color: var(--#{$prefix}popover-arrow-border);
-    }
-
-    &::after {
-      left: var(--#{$prefix}popover-border-width);
-      border-right-color: var(--#{$prefix}popover-bg);
+      &::after {
+        bottom: var(--#{$prefix}popover-border-width);
+        border-top-color: var(--#{$prefix}popover-bg);
+      }
     }
   }
-}
 
-/* rtl:end:ignore */
+  /* rtl:begin:ignore */
+  .bs-popover-end {
+    > .popover-arrow {
+      left: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+      width: var(--#{$prefix}popover-arrow-height);
+      height: var(--#{$prefix}popover-arrow-width);
 
-.bs-popover-bottom {
-  > .popover-arrow {
-    top: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+      &::before,
+      &::after {
+        border-width: calc(var(--#{$prefix}popover-arrow-width) * 0.5) var(--#{$prefix}popover-arrow-height) calc(var(--#{$prefix}popover-arrow-width) * 0.5) 0; // stylelint-disable-line function-disallowed-list
+      }
 
-    &::before,
-    &::after {
-      border-width: 0 calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height); // stylelint-disable-line function-disallowed-list
+      &::before {
+        left: 0;
+        border-right-color: var(--#{$prefix}popover-arrow-border);
+      }
+
+      &::after {
+        left: var(--#{$prefix}popover-border-width);
+        border-right-color: var(--#{$prefix}popover-bg);
+      }
+    }
+  }
+
+  /* rtl:end:ignore */
+
+  .bs-popover-bottom {
+    > .popover-arrow {
+      top: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+
+      &::before,
+      &::after {
+        border-width: 0 calc(var(--#{$prefix}popover-arrow-width) * 0.5) var(--#{$prefix}popover-arrow-height); // stylelint-disable-line function-disallowed-list
+      }
+
+      &::before {
+        top: 0;
+        border-bottom-color: var(--#{$prefix}popover-arrow-border);
+      }
+
+      &::after {
+        top: var(--#{$prefix}popover-border-width);
+        border-bottom-color: var(--#{$prefix}popover-bg);
+      }
     }
 
-    &::before {
+    // This will remove the popover-header's border just below the arrow
+    .popover-header::before {
+      position: absolute;
       top: 0;
-      border-bottom-color: var(--#{$prefix}popover-arrow-border);
-    }
-
-    &::after {
-      top: var(--#{$prefix}popover-border-width);
-      border-bottom-color: var(--#{$prefix}popover-bg);
-    }
-  }
-
-  // This will remove the popover-header's border just below the arrow
-  .popover-header::before {
-    position: absolute;
-    top: 0;
-    left: 50%;
-    display: block;
-    width: var(--#{$prefix}popover-arrow-width);
-    margin-left: calc(-.5 * var(--#{$prefix}popover-arrow-width)); // stylelint-disable-line function-disallowed-list
-    content: "";
-    border-bottom: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-header-bg);
-  }
-}
-
-/* rtl:begin:ignore */
-.bs-popover-start {
-  > .popover-arrow {
-    right: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
-    width: var(--#{$prefix}popover-arrow-height);
-    height: var(--#{$prefix}popover-arrow-width);
-
-    &::before,
-    &::after {
-      border-width: calc(var(--#{$prefix}popover-arrow-width) * .5) 0 calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height); // stylelint-disable-line function-disallowed-list
-    }
-
-    &::before {
-      right: 0;
-      border-left-color: var(--#{$prefix}popover-arrow-border);
-    }
-
-    &::after {
-      right: var(--#{$prefix}popover-border-width);
-      border-left-color: var(--#{$prefix}popover-bg);
+      left: 50%;
+      display: block;
+      width: var(--#{$prefix}popover-arrow-width);
+      margin-left: calc(-0.5 * var(--#{$prefix}popover-arrow-width)); // stylelint-disable-line function-disallowed-list
+      content: '';
+      border-bottom: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-header-bg);
     }
   }
-}
 
-/* rtl:end:ignore */
+  /* rtl:begin:ignore */
+  .bs-popover-start {
+    > .popover-arrow {
+      right: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+      width: var(--#{$prefix}popover-arrow-height);
+      height: var(--#{$prefix}popover-arrow-width);
 
-.bs-popover-auto {
-  &[data-popper-placement^="top"] {
-    @extend .bs-popover-top;
-  }
-  &[data-popper-placement^="right"] {
-    @extend .bs-popover-end;
-  }
-  &[data-popper-placement^="bottom"] {
-    @extend .bs-popover-bottom;
-  }
-  &[data-popper-placement^="left"] {
-    @extend .bs-popover-start;
-  }
-}
+      &::before,
+      &::after {
+        border-width: calc(var(--#{$prefix}popover-arrow-width) * 0.5) 0 calc(var(--#{$prefix}popover-arrow-width) * 0.5) var(--#{$prefix}popover-arrow-height); // stylelint-disable-line function-disallowed-list
+      }
 
-// Offset the popover to account for the popover arrow
-.popover-header {
-  padding: var(--#{$prefix}popover-header-padding-y) var(--#{$prefix}popover-header-padding-x);
-  margin-bottom: 0; // Reset the default from Reboot
-  @include font-size(var(--#{$prefix}popover-header-font-size));
-  color: var(--#{$prefix}popover-header-color);
-  background-color: var(--#{$prefix}popover-header-bg);
-  border-bottom: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-border-color);
-  @include border-top-radius(var(--#{$prefix}popover-inner-border-radius));
+      &::before {
+        right: 0;
+        border-left-color: var(--#{$prefix}popover-arrow-border);
+      }
 
-  &:empty {
-    display: none;
+      &::after {
+        right: var(--#{$prefix}popover-border-width);
+        border-left-color: var(--#{$prefix}popover-bg);
+      }
+    }
   }
-}
 
-.popover-body {
-  padding: var(--#{$prefix}popover-body-padding-y) var(--#{$prefix}popover-body-padding-x);
-  color: var(--#{$prefix}popover-body-color);
+  /* rtl:end:ignore */
+
+  .bs-popover-auto {
+    &[data-popper-placement^='top'] {
+      @extend .bs-popover-top;
+    }
+    &[data-popper-placement^='right'] {
+      @extend .bs-popover-end;
+    }
+    &[data-popper-placement^='bottom'] {
+      @extend .bs-popover-bottom;
+    }
+    &[data-popper-placement^='left'] {
+      @extend .bs-popover-start;
+    }
+  }
+
+  // Offset the popover to account for the popover arrow
+  .popover-header {
+    padding: var(--#{$prefix}popover-header-padding-y) var(--#{$prefix}popover-header-padding-x);
+    margin-bottom: 0; // Reset the default from Reboot
+    @include font-size(var(--#{$prefix}popover-header-font-size));
+    color: var(--#{$prefix}popover-header-color);
+    background-color: var(--#{$prefix}popover-header-bg);
+    border-bottom: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-border-color);
+    @include border-top-radius(var(--#{$prefix}popover-inner-border-radius));
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  .popover-body {
+    padding: var(--#{$prefix}popover-body-padding-y) var(--#{$prefix}popover-body-padding-x);
+    color: var(--#{$prefix}popover-body-color);
+  }
 }

--- a/core/scss/bootstrap/_progress.scss
+++ b/core/scss/bootstrap/_progress.scss
@@ -1,67 +1,72 @@
 // Disable animation if transitions are disabled
 
 // scss-docs-start progress-keyframes
-@if $enable-transitions {
-  @keyframes progress-bar-stripes {
-    0% { background-position-x: var(--#{$prefix}progress-height); }
+
+@layer components {
+  @if $enable-transitions {
+    @keyframes progress-bar-stripes {
+      0% {
+        background-position-x: var(--#{$prefix}progress-height);
+      }
+    }
   }
-}
-// scss-docs-end progress-keyframes
+  // scss-docs-end progress-keyframes
 
-.progress,
-.progress-stacked {
-  // scss-docs-start progress-css-vars
-  --#{$prefix}progress-height: #{$progress-height};
-  @include rfs($progress-font-size, --#{$prefix}progress-font-size);
-  --#{$prefix}progress-bg: #{$progress-bg};
-  --#{$prefix}progress-border-radius: #{$progress-border-radius};
-  --#{$prefix}progress-box-shadow: #{$progress-box-shadow};
-  --#{$prefix}progress-bar-color: #{$progress-bar-color};
-  --#{$prefix}progress-bar-bg: #{$progress-bar-bg};
-  --#{$prefix}progress-bar-transition: #{$progress-bar-transition};
-  // scss-docs-end progress-css-vars
+  .progress,
+  .progress-stacked {
+    // scss-docs-start progress-css-vars
+    --#{$prefix}progress-height: #{$progress-height};
+    @include rfs($progress-font-size, --#{$prefix}progress-font-size);
+    --#{$prefix}progress-bg: #{$progress-bg};
+    --#{$prefix}progress-border-radius: #{$progress-border-radius};
+    --#{$prefix}progress-box-shadow: #{$progress-box-shadow};
+    --#{$prefix}progress-bar-color: #{$progress-bar-color};
+    --#{$prefix}progress-bar-bg: #{$progress-bar-bg};
+    --#{$prefix}progress-bar-transition: #{$progress-bar-transition};
+    // scss-docs-end progress-css-vars
 
-  display: flex;
-  height: var(--#{$prefix}progress-height);
-  overflow: hidden; // force rounded corners by cropping it
-  @include font-size(var(--#{$prefix}progress-font-size));
-  background-color: var(--#{$prefix}progress-bg);
-  @include border-radius(var(--#{$prefix}progress-border-radius));
-  @include box-shadow(var(--#{$prefix}progress-box-shadow));
-}
+    display: flex;
+    height: var(--#{$prefix}progress-height);
+    overflow: hidden; // force rounded corners by cropping it
+    @include font-size(var(--#{$prefix}progress-font-size));
+    background-color: var(--#{$prefix}progress-bg);
+    @include border-radius(var(--#{$prefix}progress-border-radius));
+    @include box-shadow(var(--#{$prefix}progress-box-shadow));
+  }
 
-.progress-bar {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  overflow: hidden;
-  color: var(--#{$prefix}progress-bar-color);
-  text-align: center;
-  white-space: nowrap;
-  background-color: var(--#{$prefix}progress-bar-bg);
-  @include transition(var(--#{$prefix}progress-bar-transition));
-}
+  .progress-bar {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    overflow: hidden;
+    color: var(--#{$prefix}progress-bar-color);
+    text-align: center;
+    white-space: nowrap;
+    background-color: var(--#{$prefix}progress-bar-bg);
+    @include transition(var(--#{$prefix}progress-bar-transition));
+  }
 
-.progress-bar-striped {
-  @include gradient-striped();
-  background-size: var(--#{$prefix}progress-height) var(--#{$prefix}progress-height);
-}
+  .progress-bar-striped {
+    @include gradient-striped();
+    background-size: var(--#{$prefix}progress-height) var(--#{$prefix}progress-height);
+  }
 
-.progress-stacked > .progress {
-  overflow: visible;
-}
+  .progress-stacked > .progress {
+    overflow: visible;
+  }
 
-.progress-stacked > .progress > .progress-bar {
-  width: 100%;
-}
+  .progress-stacked > .progress > .progress-bar {
+    width: 100%;
+  }
 
-@if $enable-transitions {
-  .progress-bar-animated {
-    animation: $progress-bar-animation-timing progress-bar-stripes;
+  @if $enable-transitions {
+    .progress-bar-animated {
+      animation: $progress-bar-animation-timing progress-bar-stripes;
 
-    @if $enable-reduced-motion {
-      @media (prefers-reduced-motion: reduce) {
-        animation: none;
+      @if $enable-reduced-motion {
+        @media (prefers-reduced-motion: reduce) {
+          animation: none;
+        }
       }
     }
   }

--- a/core/scss/bootstrap/_reboot.scss
+++ b/core/scss/bootstrap/_reboot.scss
@@ -1,6 +1,5 @@
 // stylelint-disable declaration-no-important, selector-no-qualifying-type, property-no-vendor-prefix
 
-
 // Reboot
 //
 // Normalization of HTML elements, manually forked from Normalize.css to remove
@@ -8,610 +7,593 @@
 //
 // Normalize is licensed MIT. https://github.com/necolas/normalize.css
 
-
 // Document
 //
 // Change from `box-sizing: content-box` so that `width` is not affected by `padding` or `border`.
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-
-// Root
-//
-// Ability to the value of the root font sizes, affecting the value of `rem`.
-// null by default, thus nothing is generated.
-
-:root {
-  @if $font-size-root != null {
-    @include font-size(var(--#{$prefix}root-font-size));
+@layer reboot {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
   }
 
-  @if $enable-smooth-scroll {
-    @media (prefers-reduced-motion: no-preference) {
-      scroll-behavior: smooth;
+  // Root
+  //
+  // Ability to the value of the root font sizes, affecting the value of `rem`.
+  // null by default, thus nothing is generated.
+
+  :root {
+    @if $font-size-root != null {
+      @include font-size(var(--#{$prefix}root-font-size));
+    }
+
+    @if $enable-smooth-scroll {
+      @media (prefers-reduced-motion: no-preference) {
+        scroll-behavior: smooth;
+      }
     }
   }
-}
 
+  // Body
+  //
+  // 1. Remove the margin in all browsers.
+  // 2. As a best practice, apply a default `background-color`.
+  // 3. Prevent adjustments of font size after orientation changes in iOS.
+  // 4. Change the default tap highlight to be completely transparent in iOS.
 
-// Body
-//
-// 1. Remove the margin in all browsers.
-// 2. As a best practice, apply a default `background-color`.
-// 3. Prevent adjustments of font size after orientation changes in iOS.
-// 4. Change the default tap highlight to be completely transparent in iOS.
-
-// scss-docs-start reboot-body-rules
-body {
-  margin: 0; // 1
-  font-family: var(--#{$prefix}body-font-family);
-  @include font-size(var(--#{$prefix}body-font-size));
-  font-weight: var(--#{$prefix}body-font-weight);
-  line-height: var(--#{$prefix}body-line-height);
-  color: var(--#{$prefix}body-color);
-  text-align: var(--#{$prefix}body-text-align);
-  background-color: var(--#{$prefix}body-bg); // 2
-  -webkit-text-size-adjust: 100%; // 3
-  -webkit-tap-highlight-color: rgba($black, 0); // 4
-}
-// scss-docs-end reboot-body-rules
-
-
-// Content grouping
-//
-// 1. Reset Firefox's gray color
-
-hr {
-  margin: $hr-margin-y 0;
-  color: $hr-color; // 1
-  border: 0;
-  border-top: $hr-border-width solid $hr-border-color;
-  opacity: $hr-opacity;
-}
-
-
-// Typography
-//
-// 1. Remove top margins from headings
-//    By default, `<h1>`-`<h6>` all receive top and bottom margins. We nuke the top
-//    margin for easier control within type scales as it avoids margin collapsing.
-
-%heading {
-  margin-top: 0; // 1
-  margin-bottom: $headings-margin-bottom;
-  font-family: $headings-font-family;
-  font-style: $headings-font-style;
-  font-weight: $headings-font-weight;
-  line-height: $headings-line-height;
-  color: var(--#{$prefix}heading-color);
-}
-
-h1 {
-  @extend %heading;
-  @include font-size($h1-font-size);
-}
-
-h2 {
-  @extend %heading;
-  @include font-size($h2-font-size);
-}
-
-h3 {
-  @extend %heading;
-  @include font-size($h3-font-size);
-}
-
-h4 {
-  @extend %heading;
-  @include font-size($h4-font-size);
-}
-
-h5 {
-  @extend %heading;
-  @include font-size($h5-font-size);
-}
-
-h6 {
-  @extend %heading;
-  @include font-size($h6-font-size);
-}
-
-
-// Reset margins on paragraphs
-//
-// Similarly, the top margin on `<p>`s get reset. However, we also reset the
-// bottom margin to use `rem` units instead of `em`.
-
-p {
-  margin-top: 0;
-  margin-bottom: $paragraph-margin-bottom;
-}
-
-
-// Abbreviations
-//
-// 1. Add the correct text decoration in Chrome, Edge, Opera, and Safari.
-// 2. Add explicit cursor to indicate changed behavior.
-// 3. Prevent the text-decoration to be skipped.
-
-abbr[title] {
-  text-decoration: underline dotted; // 1
-  cursor: help; // 2
-  text-decoration-skip-ink: none; // 3
-}
-
-
-// Address
-
-address {
-  margin-bottom: 1rem;
-  font-style: normal;
-  line-height: inherit;
-}
-
-
-// Lists
-
-ol,
-ul {
-  padding-left: 2rem;
-}
-
-ol,
-ul,
-dl {
-  margin-top: 0;
-  margin-bottom: 1rem;
-}
-
-ol ol,
-ul ul,
-ol ul,
-ul ol {
-  margin-bottom: 0;
-}
-
-dt {
-  font-weight: $dt-font-weight;
-}
-
-// 1. Undo browser default
-
-dd {
-  margin-bottom: .5rem;
-  margin-left: 0; // 1
-}
-
-
-// Blockquote
-
-blockquote {
-  margin: 0 0 1rem;
-}
-
-
-// Strong
-//
-// Add the correct font weight in Chrome, Edge, and Safari
-
-b,
-strong {
-  font-weight: $font-weight-bolder;
-}
-
-
-// Small
-//
-// Add the correct font size in all browsers
-
-small {
-  @include font-size($small-font-size);
-}
-
-
-// Mark
-
-mark {
-  padding: $mark-padding;
-  color: var(--#{$prefix}highlight-color);
-  background-color: var(--#{$prefix}highlight-bg);
-}
-
-
-// Sub and Sup
-//
-// Prevent `sub` and `sup` elements from affecting the line height in
-// all browsers.
-
-sub,
-sup {
-  position: relative;
-  @include font-size($sub-sup-font-size);
-  line-height: 0;
-  vertical-align: baseline;
-}
-
-sub { bottom: -.25em; }
-sup { top: -.5em; }
-
-
-// Links
-
-a {
-  color: rgba(var(--#{$prefix}link-color-rgb), var(--#{$prefix}link-opacity, 1));
-  text-decoration: $link-decoration;
-
-  &:hover {
-    --#{$prefix}link-color-rgb: var(--#{$prefix}link-hover-color-rgb);
-    text-decoration: $link-hover-decoration;
+  // scss-docs-start reboot-body-rules
+  body {
+    margin: 0; // 1
+    font-family: var(--#{$prefix}body-font-family);
+    @include font-size(var(--#{$prefix}body-font-size));
+    font-weight: var(--#{$prefix}body-font-weight);
+    line-height: var(--#{$prefix}body-line-height);
+    color: var(--#{$prefix}body-color);
+    text-align: var(--#{$prefix}body-text-align);
+    background-color: var(--#{$prefix}body-bg); // 2
+    -webkit-text-size-adjust: 100%; // 3
+    -webkit-tap-highlight-color: rgba($black, 0); // 4
   }
-}
+  // scss-docs-end reboot-body-rules
 
-// And undo these styles for placeholder links/named anchors (without href).
-// It would be more straightforward to just use a[href] in previous block, but that
-// causes specificity issues in many other styles that are too complex to fix.
-// See https://github.com/twbs/bootstrap/issues/19402
+  // Content grouping
+  //
+  // 1. Reset Firefox's gray color
 
-a:not([href]):not([class]) {
-  &,
-  &:hover {
-    color: inherit;
-    text-decoration: none;
+  hr {
+    margin: $hr-margin-y 0;
+    color: $hr-color; // 1
+    border: 0;
+    border-top: $hr-border-width solid $hr-border-color;
+    opacity: $hr-opacity;
   }
-}
 
+  // Typography
+  //
+  // 1. Remove top margins from headings
+  //    By default, `<h1>`-`<h6>` all receive top and bottom margins. We nuke the top
+  //    margin for easier control within type scales as it avoids margin collapsing.
 
-// Code
+  %heading {
+    margin-top: 0; // 1
+    margin-bottom: $headings-margin-bottom;
+    font-family: $headings-font-family;
+    font-style: $headings-font-style;
+    font-weight: $headings-font-weight;
+    line-height: $headings-line-height;
+    color: var(--#{$prefix}heading-color);
+  }
 
-pre,
-code,
-kbd,
-samp {
-  font-family: $font-family-code;
-  @include font-size(1em); // Correct the odd `em` font sizing in all browsers.
-}
+  h1 {
+    @extend %heading;
+    @include font-size($h1-font-size);
+  }
 
-// 1. Remove browser default top margin
-// 2. Reset browser default of `1em` to use `rem`s
-// 3. Don't allow content to break outside
+  h2 {
+    @extend %heading;
+    @include font-size($h2-font-size);
+  }
 
-pre {
-  display: block;
-  margin-top: 0; // 1
-  margin-bottom: 1rem; // 2
-  overflow: auto; // 3
-  @include font-size($code-font-size);
-  color: $pre-color;
+  h3 {
+    @extend %heading;
+    @include font-size($h3-font-size);
+  }
 
-  // Account for some code outputs that place code tags in pre tags
+  h4 {
+    @extend %heading;
+    @include font-size($h4-font-size);
+  }
+
+  h5 {
+    @extend %heading;
+    @include font-size($h5-font-size);
+  }
+
+  h6 {
+    @extend %heading;
+    @include font-size($h6-font-size);
+  }
+
+  // Reset margins on paragraphs
+  //
+  // Similarly, the top margin on `<p>`s get reset. However, we also reset the
+  // bottom margin to use `rem` units instead of `em`.
+
+  p {
+    margin-top: 0;
+    margin-bottom: $paragraph-margin-bottom;
+  }
+
+  // Abbreviations
+  //
+  // 1. Add the correct text decoration in Chrome, Edge, Opera, and Safari.
+  // 2. Add explicit cursor to indicate changed behavior.
+  // 3. Prevent the text-decoration to be skipped.
+
+  abbr[title] {
+    text-decoration: underline dotted; // 1
+    cursor: help; // 2
+    text-decoration-skip-ink: none; // 3
+  }
+
+  // Address
+
+  address {
+    margin-bottom: 1rem;
+    font-style: normal;
+    line-height: inherit;
+  }
+
+  // Lists
+
+  ol,
+  ul {
+    padding-left: 2rem;
+  }
+
+  ol,
+  ul,
+  dl {
+    margin-top: 0;
+    margin-bottom: 1rem;
+  }
+
+  ol ol,
+  ul ul,
+  ol ul,
+  ul ol {
+    margin-bottom: 0;
+  }
+
+  dt {
+    font-weight: $dt-font-weight;
+  }
+
+  // 1. Undo browser default
+
+  dd {
+    margin-bottom: 0.5rem;
+    margin-left: 0; // 1
+  }
+
+  // Blockquote
+
+  blockquote {
+    margin: 0 0 1rem;
+  }
+
+  // Strong
+  //
+  // Add the correct font weight in Chrome, Edge, and Safari
+
+  b,
+  strong {
+    font-weight: $font-weight-bolder;
+  }
+
+  // Small
+  //
+  // Add the correct font size in all browsers
+
+  small {
+    @include font-size($small-font-size);
+  }
+
+  // Mark
+
+  mark {
+    padding: $mark-padding;
+    color: var(--#{$prefix}highlight-color);
+    background-color: var(--#{$prefix}highlight-bg);
+  }
+
+  // Sub and Sup
+  //
+  // Prevent `sub` and `sup` elements from affecting the line height in
+  // all browsers.
+
+  sub,
+  sup {
+    position: relative;
+    @include font-size($sub-sup-font-size);
+    line-height: 0;
+    vertical-align: baseline;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+  sup {
+    top: -0.5em;
+  }
+
+  // Links
+
+  a {
+    color: rgba(var(--#{$prefix}link-color-rgb), var(--#{$prefix}link-opacity, 1));
+    text-decoration: $link-decoration;
+
+    &:hover {
+      --#{$prefix}link-color-rgb: var(--#{$prefix}link-hover-color-rgb);
+      text-decoration: $link-hover-decoration;
+    }
+  }
+
+  // And undo these styles for placeholder links/named anchors (without href).
+  // It would be more straightforward to just use a[href] in previous block, but that
+  // causes specificity issues in many other styles that are too complex to fix.
+  // See https://github.com/twbs/bootstrap/issues/19402
+
+  a:not([href]):not([class]) {
+    &,
+    &:hover {
+      color: inherit;
+      text-decoration: none;
+    }
+  }
+
+  // Code
+
+  pre,
+  code,
+  kbd,
+  samp {
+    font-family: $font-family-code;
+    @include font-size(1em); // Correct the odd `em` font sizing in all browsers.
+  }
+
+  // 1. Remove browser default top margin
+  // 2. Reset browser default of `1em` to use `rem`s
+  // 3. Don't allow content to break outside
+
+  pre {
+    display: block;
+    margin-top: 0; // 1
+    margin-bottom: 1rem; // 2
+    overflow: auto; // 3
+    @include font-size($code-font-size);
+    color: $pre-color;
+
+    // Account for some code outputs that place code tags in pre tags
+    code {
+      @include font-size(inherit);
+      color: inherit;
+      word-break: normal;
+    }
+  }
+
   code {
-    @include font-size(inherit);
-    color: inherit;
-    word-break: normal;
+    @include font-size($code-font-size);
+    color: var(--#{$prefix}code-color);
+    word-wrap: break-word;
+
+    // Streamline the style when inside anchors to avoid broken underline and more
+    a > & {
+      color: inherit;
+    }
   }
-}
-
-code {
-  @include font-size($code-font-size);
-  color: var(--#{$prefix}code-color);
-  word-wrap: break-word;
-
-  // Streamline the style when inside anchors to avoid broken underline and more
-  a > & {
-    color: inherit;
-  }
-}
-
-kbd {
-  padding: $kbd-padding-y $kbd-padding-x;
-  @include font-size($kbd-font-size);
-  color: $kbd-color;
-  background-color: $kbd-bg;
-  @include border-radius($border-radius-sm);
 
   kbd {
-    padding: 0;
-    @include font-size(1em);
-    font-weight: $nested-kbd-font-weight;
-  }
-}
+    padding: $kbd-padding-y $kbd-padding-x;
+    @include font-size($kbd-font-size);
+    color: $kbd-color;
+    background-color: $kbd-bg;
+    @include border-radius($border-radius-sm);
 
-
-// Figures
-//
-// Apply a consistent margin strategy (matches our type styles).
-
-figure {
-  margin: 0 0 1rem;
-}
-
-
-// Images and content
-
-img,
-svg {
-  vertical-align: middle;
-}
-
-
-// Tables
-//
-// Prevent double borders
-
-table {
-  caption-side: bottom;
-  border-collapse: collapse;
-}
-
-caption {
-  padding-top: $table-cell-padding-y;
-  padding-bottom: $table-cell-padding-y;
-  color: $table-caption-color;
-  text-align: left;
-}
-
-// 1. Removes font-weight bold by inheriting
-// 2. Matches default `<td>` alignment by inheriting `text-align`.
-// 3. Fix alignment for Safari
-
-th {
-  font-weight: $table-th-font-weight; // 1
-  text-align: inherit; // 2
-  text-align: -webkit-match-parent; // 3
-}
-
-thead,
-tbody,
-tfoot,
-tr,
-td,
-th {
-  border-color: inherit;
-  border-style: solid;
-  border-width: 0;
-}
-
-
-// Forms
-//
-// 1. Allow labels to use `margin` for spacing.
-
-label {
-  display: inline-block; // 1
-}
-
-// Remove the default `border-radius` that macOS Chrome adds.
-// See https://github.com/twbs/bootstrap/issues/24093
-
-button {
-  // stylelint-disable-next-line property-disallowed-list
-  border-radius: 0;
-}
-
-// Explicitly remove focus outline in Chromium when it shouldn't be
-// visible (e.g. as result of mouse click or touch tap). It already
-// should be doing this automatically, but seems to currently be
-// confused and applies its very visible two-tone outline anyway.
-
-button:focus:not(:focus-visible) {
-  outline: 0;
-}
-
-// 1. Remove the margin in Firefox and Safari
-
-input,
-button,
-select,
-optgroup,
-textarea {
-  margin: 0; // 1
-  font-family: inherit;
-  @include font-size(inherit);
-  line-height: inherit;
-}
-
-// Remove the inheritance of text transform in Firefox
-button,
-select {
-  text-transform: none;
-}
-// Set the cursor for non-`<button>` buttons
-//
-// Details at https://github.com/twbs/bootstrap/pull/30562
-[role="button"] {
-  cursor: pointer;
-}
-
-select {
-  // Remove the inheritance of word-wrap in Safari.
-  // See https://github.com/twbs/bootstrap/issues/24990
-  word-wrap: normal;
-
-  // Undo the opacity change from Chrome
-  &:disabled {
-    opacity: 1;
-  }
-}
-
-// Remove the dropdown arrow only from text type inputs built with datalists in Chrome.
-// See https://stackoverflow.com/a/54997118
-
-[list]:not([type="date"]):not([type="datetime-local"]):not([type="month"]):not([type="week"]):not([type="time"])::-webkit-calendar-picker-indicator {
-  display: none !important;
-}
-
-// 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
-//    controls in Android 4.
-// 2. Correct the inability to style clickable types in iOS and Safari.
-// 3. Opinionated: add "hand" cursor to non-disabled button elements.
-
-button,
-[type="button"], // 1
-[type="reset"],
-[type="submit"] {
-  -webkit-appearance: button; // 2
-
-  @if $enable-button-pointers {
-    &:not(:disabled) {
-      cursor: pointer; // 3
+    kbd {
+      padding: 0;
+      @include font-size(1em);
+      font-weight: $nested-kbd-font-weight;
     }
   }
-}
 
-// Remove inner border and padding from Firefox, but don't restore the outline like Normalize.
+  // Figures
+  //
+  // Apply a consistent margin strategy (matches our type styles).
 
-::-moz-focus-inner {
-  padding: 0;
-  border-style: none;
-}
-
-// 1. Textareas should really only resize vertically so they don't break their (horizontal) containers.
-
-textarea {
-  resize: vertical; // 1
-}
-
-// 1. Browsers set a default `min-width: min-content;` on fieldsets,
-//    unlike e.g. `<div>`s, which have `min-width: 0;` by default.
-//    So we reset that to ensure fieldsets behave more like a standard block element.
-//    See https://github.com/twbs/bootstrap/issues/12359
-//    and https://html.spec.whatwg.org/multipage/#the-fieldset-and-legend-elements
-// 2. Reset the default outline behavior of fieldsets so they don't affect page layout.
-
-fieldset {
-  min-width: 0; // 1
-  padding: 0; // 2
-  margin: 0; // 2
-  border: 0; // 2
-}
-
-// 1. By using `float: left`, the legend will behave like a block element.
-//    This way the border of a fieldset wraps around the legend if present.
-// 2. Fix wrapping bug.
-//    See https://github.com/twbs/bootstrap/issues/29712
-
-legend {
-  float: left; // 1
-  width: 100%;
-  padding: 0;
-  margin-bottom: $legend-margin-bottom;
-  font-weight: $legend-font-weight;
-  line-height: inherit;
-  @include font-size($legend-font-size);
-
-  + * {
-    clear: left; // 2
+  figure {
+    margin: 0 0 1rem;
   }
-}
 
-// Fix height of inputs with a type of datetime-local, date, month, week, or time
-// See https://github.com/twbs/bootstrap/issues/18842
+  // Images and content
 
-::-webkit-datetime-edit-fields-wrapper,
-::-webkit-datetime-edit-text,
-::-webkit-datetime-edit-minute,
-::-webkit-datetime-edit-hour-field,
-::-webkit-datetime-edit-day-field,
-::-webkit-datetime-edit-month-field,
-::-webkit-datetime-edit-year-field {
-  padding: 0;
-}
+  img,
+  svg {
+    vertical-align: middle;
+  }
 
-::-webkit-inner-spin-button {
-  height: auto;
-}
+  // Tables
+  //
+  // Prevent double borders
 
-// 1. This overrides the extra rounded corners on search inputs in iOS so that our
-//    `.form-control` class can properly style them. Note that this cannot simply
-//    be added to `.form-control` as it's not specific enough. For details, see
-//    https://github.com/twbs/bootstrap/issues/11586.
-// 2. Correct the outline style in Safari.
+  table {
+    caption-side: bottom;
+    border-collapse: collapse;
+  }
 
-[type="search"] {
-  -webkit-appearance: textfield; // 1
-  outline-offset: -2px; // 2
+  caption {
+    padding-top: $table-cell-padding-y;
+    padding-bottom: $table-cell-padding-y;
+    color: $table-caption-color;
+    text-align: left;
+  }
 
-  // 3. Better affordance and consistent appearance for search cancel button
-  &::-webkit-search-cancel-button {
+  // 1. Removes font-weight bold by inheriting
+  // 2. Matches default `<td>` alignment by inheriting `text-align`.
+  // 3. Fix alignment for Safari
+
+  th {
+    font-weight: $table-th-font-weight; // 1
+    text-align: inherit; // 2
+    text-align: -webkit-match-parent; // 3
+  }
+
+  thead,
+  tbody,
+  tfoot,
+  tr,
+  td,
+  th {
+    border-color: inherit;
+    border-style: solid;
+    border-width: 0;
+  }
+
+  // Forms
+  //
+  // 1. Allow labels to use `margin` for spacing.
+
+  label {
+    display: inline-block; // 1
+  }
+
+  // Remove the default `border-radius` that macOS Chrome adds.
+  // See https://github.com/twbs/bootstrap/issues/24093
+
+  button {
+    // stylelint-disable-next-line property-disallowed-list
+    border-radius: 0;
+  }
+
+  // Explicitly remove focus outline in Chromium when it shouldn't be
+  // visible (e.g. as result of mouse click or touch tap). It already
+  // should be doing this automatically, but seems to currently be
+  // confused and applies its very visible two-tone outline anyway.
+
+  button:focus:not(:focus-visible) {
+    outline: 0;
+  }
+
+  // 1. Remove the margin in Firefox and Safari
+
+  input,
+  button,
+  select,
+  optgroup,
+  textarea {
+    margin: 0; // 1
+    font-family: inherit;
+    @include font-size(inherit);
+    line-height: inherit;
+  }
+
+  // Remove the inheritance of text transform in Firefox
+  button,
+  select {
+    text-transform: none;
+  }
+  // Set the cursor for non-`<button>` buttons
+  //
+  // Details at https://github.com/twbs/bootstrap/pull/30562
+  [role='button'] {
     cursor: pointer;
-    filter: grayscale(1);
   }
-}
 
-// 1. A few input types should stay LTR
-// See https://rtlstyling.com/posts/rtl-styling#form-inputs
-// 2. RTL only output
-// See https://rtlcss.com/learn/usage-guide/control-directives/#raw
+  select {
+    // Remove the inheritance of word-wrap in Safari.
+    // See https://github.com/twbs/bootstrap/issues/24990
+    word-wrap: normal;
 
-/* rtl:raw:
-[type="tel"],
-[type="url"],
-[type="email"],
-[type="number"] {
-  direction: ltr;
-}
-*/
+    // Undo the opacity change from Chrome
+    &:disabled {
+      opacity: 1;
+    }
+  }
 
-// Remove the inner padding in Chrome and Safari on macOS.
+  // Remove the dropdown arrow only from text type inputs built with datalists in Chrome.
+  // See https://stackoverflow.com/a/54997118
 
-::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
+  [list]:not([type='date']):not([type='datetime-local']):not([type='month']):not([type='week']):not([type='time'])::-webkit-calendar-picker-indicator {
+    display: none !important;
+  }
 
-// Remove padding around color pickers in webkit browsers
+  // 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
+  //    controls in Android 4.
+  // 2. Correct the inability to style clickable types in iOS and Safari.
+  // 3. Opinionated: add "hand" cursor to non-disabled button elements.
 
-::-webkit-color-swatch-wrapper {
-  padding: 0;
-}
+  button,
+  [type="button"], // 1
+  [type="reset"],
+  [type="submit"] {
+    -webkit-appearance: button; // 2
 
+    @if $enable-button-pointers {
+      &:not(:disabled) {
+        cursor: pointer; // 3
+      }
+    }
+  }
 
-// 1. Inherit font family and line height for file input buttons
-// 2. Correct the inability to style clickable types in iOS and Safari.
+  // Remove inner border and padding from Firefox, but don't restore the outline like Normalize.
 
-::file-selector-button {
-  font: inherit; // 1
-  -webkit-appearance: button; // 2
-}
+  ::-moz-focus-inner {
+    padding: 0;
+    border-style: none;
+  }
 
-// Correct element displays
+  // 1. Textareas should really only resize vertically so they don't break their (horizontal) containers.
 
-output {
-  display: inline-block;
-}
+  textarea {
+    resize: vertical; // 1
+  }
 
-// Remove border from iframe
+  // 1. Browsers set a default `min-width: min-content;` on fieldsets,
+  //    unlike e.g. `<div>`s, which have `min-width: 0;` by default.
+  //    So we reset that to ensure fieldsets behave more like a standard block element.
+  //    See https://github.com/twbs/bootstrap/issues/12359
+  //    and https://html.spec.whatwg.org/multipage/#the-fieldset-and-legend-elements
+  // 2. Reset the default outline behavior of fieldsets so they don't affect page layout.
 
-iframe {
-  border: 0;
-}
+  fieldset {
+    min-width: 0; // 1
+    padding: 0; // 2
+    margin: 0; // 2
+    border: 0; // 2
+  }
 
-// Summary
-//
-// 1. Add the correct display in all browsers
+  // 1. By using `float: left`, the legend will behave like a block element.
+  //    This way the border of a fieldset wraps around the legend if present.
+  // 2. Fix wrapping bug.
+  //    See https://github.com/twbs/bootstrap/issues/29712
 
-summary {
-  display: list-item; // 1
-  cursor: pointer;
-}
+  legend {
+    float: left; // 1
+    width: 100%;
+    padding: 0;
+    margin-bottom: $legend-margin-bottom;
+    font-weight: $legend-font-weight;
+    line-height: inherit;
+    @include font-size($legend-font-size);
 
+    + * {
+      clear: left; // 2
+    }
+  }
 
-// Progress
-//
-// Add the correct vertical alignment in Chrome, Firefox, and Opera.
+  // Fix height of inputs with a type of datetime-local, date, month, week, or time
+  // See https://github.com/twbs/bootstrap/issues/18842
 
-progress {
-  vertical-align: baseline;
-}
+  ::-webkit-datetime-edit-fields-wrapper,
+  ::-webkit-datetime-edit-text,
+  ::-webkit-datetime-edit-minute,
+  ::-webkit-datetime-edit-hour-field,
+  ::-webkit-datetime-edit-day-field,
+  ::-webkit-datetime-edit-month-field,
+  ::-webkit-datetime-edit-year-field {
+    padding: 0;
+  }
 
+  ::-webkit-inner-spin-button {
+    height: auto;
+  }
 
-// Hidden attribute
-//
-// Always hide an element with the `hidden` HTML attribute.
+  // 1. This overrides the extra rounded corners on search inputs in iOS so that our
+  //    `.form-control` class can properly style them. Note that this cannot simply
+  //    be added to `.form-control` as it's not specific enough. For details, see
+  //    https://github.com/twbs/bootstrap/issues/11586.
+  // 2. Correct the outline style in Safari.
 
-[hidden] {
-  display: none !important;
+  [type='search'] {
+    -webkit-appearance: textfield; // 1
+    outline-offset: -2px; // 2
+
+    // 3. Better affordance and consistent appearance for search cancel button
+    &::-webkit-search-cancel-button {
+      cursor: pointer;
+      filter: grayscale(1);
+    }
+  }
+
+  // 1. A few input types should stay LTR
+  // See https://rtlstyling.com/posts/rtl-styling#form-inputs
+  // 2. RTL only output
+  // See https://rtlcss.com/learn/usage-guide/control-directives/#raw
+
+  /* rtl:raw:
+  [type="tel"],
+  [type="url"],
+  [type="email"],
+  [type="number"] {
+    direction: ltr;
+  }
+  */
+
+  // Remove the inner padding in Chrome and Safari on macOS.
+
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  // Remove padding around color pickers in webkit browsers
+
+  ::-webkit-color-swatch-wrapper {
+    padding: 0;
+  }
+
+  // 1. Inherit font family and line height for file input buttons
+  // 2. Correct the inability to style clickable types in iOS and Safari.
+
+  ::file-selector-button {
+    font: inherit; // 1
+    -webkit-appearance: button; // 2
+  }
+
+  // Correct element displays
+
+  output {
+    display: inline-block;
+  }
+
+  // Remove border from iframe
+
+  iframe {
+    border: 0;
+  }
+
+  // Summary
+  //
+  // 1. Add the correct display in all browsers
+
+  summary {
+    display: list-item; // 1
+    cursor: pointer;
+  }
+
+  // Progress
+  //
+  // Add the correct vertical alignment in Chrome, Firefox, and Opera.
+
+  progress {
+    vertical-align: baseline;
+  }
+
+  // Hidden attribute
+  //
+  // Always hide an element with the `hidden` HTML attribute.
+
+  [hidden] {
+    display: none !important;
+  }
 }

--- a/core/scss/bootstrap/_spinners.scss
+++ b/core/scss/bootstrap/_spinners.scss
@@ -2,85 +2,89 @@
 // Rotating border
 //
 
-.spinner-grow,
-.spinner-border {
-  display: inline-block;
-  flex-shrink: 0;
-  width: var(--#{$prefix}spinner-width);
-  height: var(--#{$prefix}spinner-height);
-  vertical-align: var(--#{$prefix}spinner-vertical-align);
-  // stylelint-disable-next-line property-disallowed-list
-  border-radius: 50%;
-  animation: var(--#{$prefix}spinner-animation-speed) linear infinite var(--#{$prefix}spinner-animation-name);
-}
-
-// scss-docs-start spinner-border-keyframes
-@keyframes spinner-border {
-  to { transform: rotate(360deg) #{"/* rtl:ignore */"}; }
-}
-// scss-docs-end spinner-border-keyframes
-
-.spinner-border {
-  // scss-docs-start spinner-border-css-vars
-  --#{$prefix}spinner-width: #{$spinner-width};
-  --#{$prefix}spinner-height: #{$spinner-height};
-  --#{$prefix}spinner-vertical-align: #{$spinner-vertical-align};
-  --#{$prefix}spinner-border-width: #{$spinner-border-width};
-  --#{$prefix}spinner-animation-speed: #{$spinner-animation-speed};
-  --#{$prefix}spinner-animation-name: spinner-border;
-  // scss-docs-end spinner-border-css-vars
-
-  border: var(--#{$prefix}spinner-border-width) solid currentcolor;
-  border-right-color: transparent;
-}
-
-.spinner-border-sm {
-  // scss-docs-start spinner-border-sm-css-vars
-  --#{$prefix}spinner-width: #{$spinner-width-sm};
-  --#{$prefix}spinner-height: #{$spinner-height-sm};
-  --#{$prefix}spinner-border-width: #{$spinner-border-width-sm};
-  // scss-docs-end spinner-border-sm-css-vars
-}
-
-//
-// Growing circle
-//
-
-// scss-docs-start spinner-grow-keyframes
-@keyframes spinner-grow {
-  0% {
-    transform: scale(0);
+@layer components {
+  .spinner-grow,
+  .spinner-border {
+    display: inline-block;
+    flex-shrink: 0;
+    width: var(--#{$prefix}spinner-width);
+    height: var(--#{$prefix}spinner-height);
+    vertical-align: var(--#{$prefix}spinner-vertical-align);
+    // stylelint-disable-next-line property-disallowed-list
+    border-radius: 50%;
+    animation: var(--#{$prefix}spinner-animation-speed) linear infinite var(--#{$prefix}spinner-animation-name);
   }
-  50% {
-    opacity: 1;
-    transform: none;
+
+  // scss-docs-start spinner-border-keyframes
+  @keyframes spinner-border {
+    to {
+      transform: rotate(360deg) #{'/* rtl:ignore */'};
+    }
   }
-}
-// scss-docs-end spinner-grow-keyframes
+  // scss-docs-end spinner-border-keyframes
 
-.spinner-grow {
-  // scss-docs-start spinner-grow-css-vars
-  --#{$prefix}spinner-width: #{$spinner-width};
-  --#{$prefix}spinner-height: #{$spinner-height};
-  --#{$prefix}spinner-vertical-align: #{$spinner-vertical-align};
-  --#{$prefix}spinner-animation-speed: #{$spinner-animation-speed};
-  --#{$prefix}spinner-animation-name: spinner-grow;
-  // scss-docs-end spinner-grow-css-vars
+  .spinner-border {
+    // scss-docs-start spinner-border-css-vars
+    --#{$prefix}spinner-width: #{$spinner-width};
+    --#{$prefix}spinner-height: #{$spinner-height};
+    --#{$prefix}spinner-vertical-align: #{$spinner-vertical-align};
+    --#{$prefix}spinner-border-width: #{$spinner-border-width};
+    --#{$prefix}spinner-animation-speed: #{$spinner-animation-speed};
+    --#{$prefix}spinner-animation-name: spinner-border;
+    // scss-docs-end spinner-border-css-vars
 
-  background-color: currentcolor;
-  opacity: 0;
-}
+    border: var(--#{$prefix}spinner-border-width) solid currentcolor;
+    border-right-color: transparent;
+  }
 
-.spinner-grow-sm {
-  --#{$prefix}spinner-width: #{$spinner-width-sm};
-  --#{$prefix}spinner-height: #{$spinner-height-sm};
-}
+  .spinner-border-sm {
+    // scss-docs-start spinner-border-sm-css-vars
+    --#{$prefix}spinner-width: #{$spinner-width-sm};
+    --#{$prefix}spinner-height: #{$spinner-height-sm};
+    --#{$prefix}spinner-border-width: #{$spinner-border-width-sm};
+    // scss-docs-end spinner-border-sm-css-vars
+  }
 
-@if $enable-reduced-motion {
-  @media (prefers-reduced-motion: reduce) {
-    .spinner-border,
-    .spinner-grow {
-      --#{$prefix}spinner-animation-speed: #{$spinner-animation-speed * 2};
+  //
+  // Growing circle
+  //
+
+  // scss-docs-start spinner-grow-keyframes
+  @keyframes spinner-grow {
+    0% {
+      transform: scale(0);
+    }
+    50% {
+      opacity: 1;
+      transform: none;
+    }
+  }
+  // scss-docs-end spinner-grow-keyframes
+
+  .spinner-grow {
+    // scss-docs-start spinner-grow-css-vars
+    --#{$prefix}spinner-width: #{$spinner-width};
+    --#{$prefix}spinner-height: #{$spinner-height};
+    --#{$prefix}spinner-vertical-align: #{$spinner-vertical-align};
+    --#{$prefix}spinner-animation-speed: #{$spinner-animation-speed};
+    --#{$prefix}spinner-animation-name: spinner-grow;
+    // scss-docs-end spinner-grow-css-vars
+
+    background-color: currentcolor;
+    opacity: 0;
+  }
+
+  .spinner-grow-sm {
+    --#{$prefix}spinner-width: #{$spinner-width-sm};
+    --#{$prefix}spinner-height: #{$spinner-height-sm};
+  }
+
+  @if $enable-reduced-motion {
+    @media (prefers-reduced-motion: reduce) {
+      .spinner-border,
+      .spinner-grow {
+        --#{$prefix}spinner-animation-speed: #{$spinner-animation-speed * 2};
+      }
     }
   }
 }

--- a/core/scss/bootstrap/_tables.scss
+++ b/core/scss/bootstrap/_tables.scss
@@ -1,173 +1,172 @@
-@use "sass:map";
+@use 'sass:map';
 
 //
 // Basic Bootstrap table
 //
 
-.table {
-  // Reset needed for nesting tables
-  --#{$prefix}table-color-type: initial;
-  --#{$prefix}table-bg-type: initial;
-  --#{$prefix}table-color-state: initial;
-  --#{$prefix}table-bg-state: initial;
-  // End of reset
-  --#{$prefix}table-color: #{$table-color};
-  --#{$prefix}table-bg: #{$table-bg};
-  --#{$prefix}table-border-color: #{$table-border-color};
-  --#{$prefix}table-accent-bg: #{$table-accent-bg};
-  --#{$prefix}table-striped-color: #{$table-striped-color};
-  --#{$prefix}table-striped-bg: #{$table-striped-bg};
-  --#{$prefix}table-active-color: #{$table-active-color};
-  --#{$prefix}table-active-bg: #{$table-active-bg};
-  --#{$prefix}table-hover-color: #{$table-hover-color};
-  --#{$prefix}table-hover-bg: #{$table-hover-bg};
+@layer content {
+  .table {
+    // Reset needed for nesting tables
+    --#{$prefix}table-color-type: initial;
+    --#{$prefix}table-bg-type: initial;
+    --#{$prefix}table-color-state: initial;
+    --#{$prefix}table-bg-state: initial;
+    // End of reset
+    --#{$prefix}table-color: #{$table-color};
+    --#{$prefix}table-bg: #{$table-bg};
+    --#{$prefix}table-border-color: #{$table-border-color};
+    --#{$prefix}table-accent-bg: #{$table-accent-bg};
+    --#{$prefix}table-striped-color: #{$table-striped-color};
+    --#{$prefix}table-striped-bg: #{$table-striped-bg};
+    --#{$prefix}table-active-color: #{$table-active-color};
+    --#{$prefix}table-active-bg: #{$table-active-bg};
+    --#{$prefix}table-hover-color: #{$table-hover-color};
+    --#{$prefix}table-hover-bg: #{$table-hover-bg};
 
-  width: 100%;
-  margin-bottom: $spacer;
-  vertical-align: $table-cell-vertical-align;
-  border-color: var(--#{$prefix}table-border-color);
+    width: 100%;
+    margin-bottom: $spacer;
+    vertical-align: $table-cell-vertical-align;
+    border-color: var(--#{$prefix}table-border-color);
 
-  // Target th & td
-  // We need the child combinator to prevent styles leaking to nested tables which doesn't have a `.table` class.
-  // We use the universal selectors here to simplify the selector (else we would need 6 different selectors).
-  // Another advantage is that this generates less code and makes the selector less specific making it easier to override.
-  // stylelint-disable-next-line selector-max-universal
-  > :not(caption) > * > * {
-    padding: $table-cell-padding-y $table-cell-padding-x;
-    // Following the precept of cascades: https://codepen.io/miriamsuzanne/full/vYNgodb
-    color: var(--#{$prefix}table-color-state, var(--#{$prefix}table-color-type, var(--#{$prefix}table-color)));
-    background-color: var(--#{$prefix}table-bg);
-    border-bottom-width: $table-border-width;
-    box-shadow: inset 0 0 0 9999px var(--#{$prefix}table-bg-state, var(--#{$prefix}table-bg-type, var(--#{$prefix}table-accent-bg)));
-  }
-
-  > tbody {
-    vertical-align: inherit;
-  }
-
-  > thead {
-    vertical-align: bottom;
-  }
-}
-
-.table-group-divider {
-  border-top: calc(#{$table-border-width} * 2) solid $table-group-separator-color; // stylelint-disable-line function-disallowed-list
-}
-
-//
-// Change placement of captions with a class
-//
-
-.caption-top {
-  caption-side: top;
-}
-
-
-//
-// Condensed table w/ half padding
-//
-
-.table-sm {
-  // stylelint-disable-next-line selector-max-universal
-  > :not(caption) > * > * {
-    padding: $table-cell-padding-y-sm $table-cell-padding-x-sm;
-  }
-}
-
-
-// Border versions
-//
-// Add or remove borders all around the table and between all the columns.
-//
-// When borders are added on all sides of the cells, the corners can render odd when
-// these borders do not have the same color or if they are semi-transparent.
-// Therefore we add top and border bottoms to the `tr`s and left and right borders
-// to the `td`s or `th`s
-
-.table-bordered {
-  > :not(caption) > * {
-    border-width: $table-border-width 0;
-
+    // Target th & td
+    // We need the child combinator to prevent styles leaking to nested tables which doesn't have a `.table` class.
+    // We use the universal selectors here to simplify the selector (else we would need 6 different selectors).
+    // Another advantage is that this generates less code and makes the selector less specific making it easier to override.
     // stylelint-disable-next-line selector-max-universal
-    > * {
-      border-width: 0 $table-border-width;
+    > :not(caption) > * > * {
+      padding: $table-cell-padding-y $table-cell-padding-x;
+      // Following the precept of cascades: https://codepen.io/miriamsuzanne/full/vYNgodb
+      color: var(--#{$prefix}table-color-state, var(--#{$prefix}table-color-type, var(--#{$prefix}table-color)));
+      background-color: var(--#{$prefix}table-bg);
+      border-bottom-width: $table-border-width;
+      box-shadow: inset 0 0 0 9999px var(--#{$prefix}table-bg-state, var(--#{$prefix}table-bg-type, var(--#{$prefix}table-accent-bg)));
+    }
+
+    > tbody {
+      vertical-align: inherit;
+    }
+
+    > thead {
+      vertical-align: bottom;
     }
   }
-}
 
-.table-borderless {
-  // stylelint-disable-next-line selector-max-universal
-  > :not(caption) > * > * {
-    border-bottom-width: 0;
+  .table-group-divider {
+    border-top: calc(#{$table-border-width} * 2) solid $table-group-separator-color; // stylelint-disable-line function-disallowed-list
   }
 
-  > :not(:first-child) {
-    border-top-width: 0;
+  //
+  // Change placement of captions with a class
+  //
+
+  .caption-top {
+    caption-side: top;
   }
-}
 
-// Zebra-striping
-//
-// Default zebra-stripe styles (alternating gray and transparent backgrounds)
+  //
+  // Condensed table w/ half padding
+  //
 
-// For rows
-.table-striped {
-  > tbody > tr:nth-of-type(#{$table-striped-order}) > * {
-    --#{$prefix}table-color-type: var(--#{$prefix}table-striped-color);
-    --#{$prefix}table-bg-type: var(--#{$prefix}table-striped-bg);
+  .table-sm {
+    // stylelint-disable-next-line selector-max-universal
+    > :not(caption) > * > * {
+      padding: $table-cell-padding-y-sm $table-cell-padding-x-sm;
+    }
   }
-}
 
-// For columns
-.table-striped-columns {
-  > :not(caption) > tr > :nth-child(#{$table-striped-columns-order}) {
-    --#{$prefix}table-color-type: var(--#{$prefix}table-striped-color);
-    --#{$prefix}table-bg-type: var(--#{$prefix}table-striped-bg);
+  // Border versions
+  //
+  // Add or remove borders all around the table and between all the columns.
+  //
+  // When borders are added on all sides of the cells, the corners can render odd when
+  // these borders do not have the same color or if they are semi-transparent.
+  // Therefore we add top and border bottoms to the `tr`s and left and right borders
+  // to the `td`s or `th`s
+
+  .table-bordered {
+    > :not(caption) > * {
+      border-width: $table-border-width 0;
+
+      // stylelint-disable-next-line selector-max-universal
+      > * {
+        border-width: 0 $table-border-width;
+      }
+    }
   }
-}
 
-// Active table
-//
-// The `.table-active` class can be added to highlight rows or cells
+  .table-borderless {
+    // stylelint-disable-next-line selector-max-universal
+    > :not(caption) > * > * {
+      border-bottom-width: 0;
+    }
 
-.table-active {
-  --#{$prefix}table-color-state: var(--#{$prefix}table-active-color);
-  --#{$prefix}table-bg-state: var(--#{$prefix}table-active-bg);
-}
-
-// Hover effect
-//
-// Placed here since it has to come after the potential zebra striping
-
-.table-hover {
-  > tbody > tr:hover > * {
-    --#{$prefix}table-color-state: var(--#{$prefix}table-hover-color);
-    --#{$prefix}table-bg-state: var(--#{$prefix}table-hover-bg);
+    > :not(:first-child) {
+      border-top-width: 0;
+    }
   }
-}
 
+  // Zebra-striping
+  //
+  // Default zebra-stripe styles (alternating gray and transparent backgrounds)
 
-// Table variants
-//
-// Table variants set the table cell backgrounds, border colors
-// and the colors of the striped, hovered & active tables
+  // For rows
+  .table-striped {
+    > tbody > tr:nth-of-type(#{$table-striped-order}) > * {
+      --#{$prefix}table-color-type: var(--#{$prefix}table-striped-color);
+      --#{$prefix}table-bg-type: var(--#{$prefix}table-striped-bg);
+    }
+  }
 
-@each $color, $value in $table-variants {
-  @include table-variant($color, $value);
-}
+  // For columns
+  .table-striped-columns {
+    > :not(caption) > tr > :nth-child(#{$table-striped-columns-order}) {
+      --#{$prefix}table-color-type: var(--#{$prefix}table-striped-color);
+      --#{$prefix}table-bg-type: var(--#{$prefix}table-striped-bg);
+    }
+  }
 
-// Responsive tables
-//
-// Generate series of `.table-responsive-*` classes for configuring the screen
-// size of where your table will overflow.
+  // Active table
+  //
+  // The `.table-active` class can be added to highlight rows or cells
 
-@each $breakpoint in map.keys($grid-breakpoints) {
-  $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+  .table-active {
+    --#{$prefix}table-color-state: var(--#{$prefix}table-active-color);
+    --#{$prefix}table-bg-state: var(--#{$prefix}table-active-bg);
+  }
 
-  @include media-breakpoint-down($breakpoint) {
-    .table-responsive#{$infix} {
-      overflow-x: auto;
-      -webkit-overflow-scrolling: touch;
+  // Hover effect
+  //
+  // Placed here since it has to come after the potential zebra striping
+
+  .table-hover {
+    > tbody > tr:hover > * {
+      --#{$prefix}table-color-state: var(--#{$prefix}table-hover-color);
+      --#{$prefix}table-bg-state: var(--#{$prefix}table-hover-bg);
+    }
+  }
+
+  // Table variants
+  //
+  // Table variants set the table cell backgrounds, border colors
+  // and the colors of the striped, hovered & active tables
+
+  @each $color, $value in $table-variants {
+    @include table-variant($color, $value);
+  }
+
+  // Responsive tables
+  //
+  // Generate series of `.table-responsive-*` classes for configuring the screen
+  // size of where your table will overflow.
+
+  @each $breakpoint in map.keys($grid-breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+    @include media-breakpoint-down($breakpoint) {
+      .table-responsive#{$infix} {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+      }
     }
   }
 }

--- a/core/scss/bootstrap/_toasts.scss
+++ b/core/scss/bootstrap/_toasts.scss
@@ -1,73 +1,75 @@
-.toast {
-  // scss-docs-start toast-css-vars
-  --#{$prefix}toast-zindex: #{$zindex-toast};
-  --#{$prefix}toast-padding-x: #{$toast-padding-x};
-  --#{$prefix}toast-padding-y: #{$toast-padding-y};
-  --#{$prefix}toast-spacing: #{$toast-spacing};
-  --#{$prefix}toast-max-width: #{$toast-max-width};
-  @include rfs($toast-font-size, --#{$prefix}toast-font-size);
-  --#{$prefix}toast-color: #{$toast-color};
-  --#{$prefix}toast-bg: #{$toast-background-color};
-  --#{$prefix}toast-border-width: #{$toast-border-width};
-  --#{$prefix}toast-border-color: #{$toast-border-color};
-  --#{$prefix}toast-border-radius: #{$toast-border-radius};
-  --#{$prefix}toast-box-shadow: #{$toast-box-shadow};
-  --#{$prefix}toast-header-color: #{$toast-header-color};
-  --#{$prefix}toast-header-bg: #{$toast-header-background-color};
-  --#{$prefix}toast-header-border-color: #{$toast-header-border-color};
-  // scss-docs-end toast-css-vars
+@layer components {
+  .toast {
+    // scss-docs-start toast-css-vars
+    --#{$prefix}toast-zindex: #{$zindex-toast};
+    --#{$prefix}toast-padding-x: #{$toast-padding-x};
+    --#{$prefix}toast-padding-y: #{$toast-padding-y};
+    --#{$prefix}toast-spacing: #{$toast-spacing};
+    --#{$prefix}toast-max-width: #{$toast-max-width};
+    @include rfs($toast-font-size, --#{$prefix}toast-font-size);
+    --#{$prefix}toast-color: #{$toast-color};
+    --#{$prefix}toast-bg: #{$toast-background-color};
+    --#{$prefix}toast-border-width: #{$toast-border-width};
+    --#{$prefix}toast-border-color: #{$toast-border-color};
+    --#{$prefix}toast-border-radius: #{$toast-border-radius};
+    --#{$prefix}toast-box-shadow: #{$toast-box-shadow};
+    --#{$prefix}toast-header-color: #{$toast-header-color};
+    --#{$prefix}toast-header-bg: #{$toast-header-background-color};
+    --#{$prefix}toast-header-border-color: #{$toast-header-border-color};
+    // scss-docs-end toast-css-vars
 
-  width: var(--#{$prefix}toast-max-width);
-  max-width: 100%;
-  @include font-size(var(--#{$prefix}toast-font-size));
-  color: var(--#{$prefix}toast-color);
-  pointer-events: auto;
-  background-color: var(--#{$prefix}toast-bg);
-  background-clip: padding-box;
-  border: var(--#{$prefix}toast-border-width) solid var(--#{$prefix}toast-border-color);
-  box-shadow: var(--#{$prefix}toast-box-shadow);
-  @include border-radius(var(--#{$prefix}toast-border-radius));
+    width: var(--#{$prefix}toast-max-width);
+    max-width: 100%;
+    @include font-size(var(--#{$prefix}toast-font-size));
+    color: var(--#{$prefix}toast-color);
+    pointer-events: auto;
+    background-color: var(--#{$prefix}toast-bg);
+    background-clip: padding-box;
+    border: var(--#{$prefix}toast-border-width) solid var(--#{$prefix}toast-border-color);
+    box-shadow: var(--#{$prefix}toast-box-shadow);
+    @include border-radius(var(--#{$prefix}toast-border-radius));
 
-  &.showing {
-    opacity: 0;
+    &.showing {
+      opacity: 0;
+    }
+
+    &:not(.show) {
+      display: none;
+    }
   }
 
-  &:not(.show) {
-    display: none;
+  .toast-container {
+    --#{$prefix}toast-zindex: #{$zindex-toast};
+
+    position: absolute;
+    z-index: var(--#{$prefix}toast-zindex);
+    width: max-content;
+    max-width: 100%;
+    pointer-events: none;
+
+    > :not(:last-child) {
+      margin-bottom: var(--#{$prefix}toast-spacing);
+    }
   }
-}
 
-.toast-container {
-  --#{$prefix}toast-zindex: #{$zindex-toast};
+  .toast-header {
+    display: flex;
+    align-items: center;
+    padding: var(--#{$prefix}toast-padding-y) var(--#{$prefix}toast-padding-x);
+    color: var(--#{$prefix}toast-header-color);
+    background-color: var(--#{$prefix}toast-header-bg);
+    background-clip: padding-box;
+    border-bottom: var(--#{$prefix}toast-border-width) solid var(--#{$prefix}toast-header-border-color);
+    @include border-top-radius(calc(var(--#{$prefix}toast-border-radius) - var(--#{$prefix}toast-border-width)));
 
-  position: absolute;
-  z-index: var(--#{$prefix}toast-zindex);
-  width: max-content;
-  max-width: 100%;
-  pointer-events: none;
-
-  > :not(:last-child) {
-    margin-bottom: var(--#{$prefix}toast-spacing);
+    .btn-close {
+      margin-right: calc(-0.5 * var(--#{$prefix}toast-padding-x)); // stylelint-disable-line function-disallowed-list
+      margin-left: var(--#{$prefix}toast-padding-x);
+    }
   }
-}
 
-.toast-header {
-  display: flex;
-  align-items: center;
-  padding: var(--#{$prefix}toast-padding-y) var(--#{$prefix}toast-padding-x);
-  color: var(--#{$prefix}toast-header-color);
-  background-color: var(--#{$prefix}toast-header-bg);
-  background-clip: padding-box;
-  border-bottom: var(--#{$prefix}toast-border-width) solid var(--#{$prefix}toast-header-border-color);
-  @include border-top-radius(calc(var(--#{$prefix}toast-border-radius) - var(--#{$prefix}toast-border-width)));
-
-  .btn-close {
-    margin-right: calc(-.5 * var(--#{$prefix}toast-padding-x)); // stylelint-disable-line function-disallowed-list
-    margin-left: var(--#{$prefix}toast-padding-x);
+  .toast-body {
+    padding: var(--#{$prefix}toast-padding-x);
+    word-wrap: break-word;
   }
-}
-
-.toast-body {
-  padding: var(--#{$prefix}toast-padding-x);
-  word-wrap: break-word;
 }

--- a/core/scss/bootstrap/_tooltip.scss
+++ b/core/scss/bootstrap/_tooltip.scss
@@ -1,119 +1,124 @@
 // Base class
-.tooltip {
-  // scss-docs-start tooltip-css-vars
-  --#{$prefix}tooltip-zindex: #{$zindex-tooltip};
-  --#{$prefix}tooltip-max-width: #{$tooltip-max-width};
-  --#{$prefix}tooltip-padding-x: #{$tooltip-padding-x};
-  --#{$prefix}tooltip-padding-y: #{$tooltip-padding-y};
-  --#{$prefix}tooltip-margin: #{$tooltip-margin};
-  @include rfs($tooltip-font-size, --#{$prefix}tooltip-font-size);
-  --#{$prefix}tooltip-color: #{$tooltip-color};
-  --#{$prefix}tooltip-bg: #{$tooltip-bg};
-  --#{$prefix}tooltip-border-radius: #{$tooltip-border-radius};
-  --#{$prefix}tooltip-opacity: #{$tooltip-opacity};
-  --#{$prefix}tooltip-arrow-width: #{$tooltip-arrow-width};
-  --#{$prefix}tooltip-arrow-height: #{$tooltip-arrow-height};
-  // scss-docs-end tooltip-css-vars
 
-  z-index: var(--#{$prefix}tooltip-zindex);
-  display: block;
-  margin: var(--#{$prefix}tooltip-margin);
-  @include deprecate("`$tooltip-margin`", "v5", "v5.x", true);
-  // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
-  // So reset our font and text properties to avoid inheriting weird values.
-  @include reset-text();
-  @include font-size(var(--#{$prefix}tooltip-font-size));
-  // Allow breaking very long words so they don't overflow the tooltip's bounds
-  word-wrap: break-word;
-  opacity: 0;
+@layer components {
+  .tooltip {
+    // scss-docs-start tooltip-css-vars
+    --#{$prefix}tooltip-zindex: #{$zindex-tooltip};
+    --#{$prefix}tooltip-max-width: #{$tooltip-max-width};
+    --#{$prefix}tooltip-padding-x: #{$tooltip-padding-x};
+    --#{$prefix}tooltip-padding-y: #{$tooltip-padding-y};
+    --#{$prefix}tooltip-margin: #{$tooltip-margin};
+    @include rfs($tooltip-font-size, --#{$prefix}tooltip-font-size);
+    --#{$prefix}tooltip-color: #{$tooltip-color};
+    --#{$prefix}tooltip-bg: #{$tooltip-bg};
+    --#{$prefix}tooltip-border-radius: #{$tooltip-border-radius};
+    --#{$prefix}tooltip-opacity: #{$tooltip-opacity};
+    --#{$prefix}tooltip-arrow-width: #{$tooltip-arrow-width};
+    --#{$prefix}tooltip-arrow-height: #{$tooltip-arrow-height};
+    // scss-docs-end tooltip-css-vars
 
-  &.show { opacity: var(--#{$prefix}tooltip-opacity); }
-
-  .tooltip-arrow {
+    z-index: var(--#{$prefix}tooltip-zindex);
     display: block;
-    width: var(--#{$prefix}tooltip-arrow-width);
-    height: var(--#{$prefix}tooltip-arrow-height);
+    margin: var(--#{$prefix}tooltip-margin);
+    @include deprecate('`$tooltip-margin`', 'v5', 'v5.x', true);
+    // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
+    // So reset our font and text properties to avoid inheriting weird values.
+    @include reset-text();
+    @include font-size(var(--#{$prefix}tooltip-font-size));
+    // Allow breaking very long words so they don't overflow the tooltip's bounds
+    word-wrap: break-word;
+    opacity: 0;
 
-    &::before {
-      position: absolute;
-      content: "";
-      border-color: transparent;
-      border-style: solid;
+    &.show {
+      opacity: var(--#{$prefix}tooltip-opacity);
+    }
+
+    .tooltip-arrow {
+      display: block;
+      width: var(--#{$prefix}tooltip-arrow-width);
+      height: var(--#{$prefix}tooltip-arrow-height);
+
+      &::before {
+        position: absolute;
+        content: '';
+        border-color: transparent;
+        border-style: solid;
+      }
     }
   }
-}
 
-.bs-tooltip-top .tooltip-arrow {
-  bottom: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
+  .bs-tooltip-top .tooltip-arrow {
+    bottom: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
 
-  &::before {
-    top: -1px;
-    border-width: var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
-    border-top-color: var(--#{$prefix}tooltip-bg);
+    &::before {
+      top: -1px;
+      border-width: var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * 0.5) 0; // stylelint-disable-line function-disallowed-list
+      border-top-color: var(--#{$prefix}tooltip-bg);
+    }
   }
-}
 
-/* rtl:begin:ignore */
-.bs-tooltip-end .tooltip-arrow {
-  left: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
-  width: var(--#{$prefix}tooltip-arrow-height);
-  height: var(--#{$prefix}tooltip-arrow-width);
+  /* rtl:begin:ignore */
+  .bs-tooltip-end .tooltip-arrow {
+    left: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
+    width: var(--#{$prefix}tooltip-arrow-height);
+    height: var(--#{$prefix}tooltip-arrow-width);
 
-  &::before {
-    right: -1px;
-    border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
-    border-right-color: var(--#{$prefix}tooltip-bg);
+    &::before {
+      right: -1px;
+      border-width: calc(var(--#{$prefix}tooltip-arrow-width) * 0.5) var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * 0.5) 0; // stylelint-disable-line function-disallowed-list
+      border-right-color: var(--#{$prefix}tooltip-bg);
+    }
   }
-}
 
-/* rtl:end:ignore */
+  /* rtl:end:ignore */
 
-.bs-tooltip-bottom .tooltip-arrow {
-  top: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
+  .bs-tooltip-bottom .tooltip-arrow {
+    top: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
 
-  &::before {
-    bottom: -1px;
-    border-width: 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
-    border-bottom-color: var(--#{$prefix}tooltip-bg);
+    &::before {
+      bottom: -1px;
+      border-width: 0 calc(var(--#{$prefix}tooltip-arrow-width) * 0.5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
+      border-bottom-color: var(--#{$prefix}tooltip-bg);
+    }
   }
-}
 
-/* rtl:begin:ignore */
-.bs-tooltip-start .tooltip-arrow {
-  right: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
-  width: var(--#{$prefix}tooltip-arrow-height);
-  height: var(--#{$prefix}tooltip-arrow-width);
+  /* rtl:begin:ignore */
+  .bs-tooltip-start .tooltip-arrow {
+    right: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
+    width: var(--#{$prefix}tooltip-arrow-height);
+    height: var(--#{$prefix}tooltip-arrow-width);
 
-  &::before {
-    left: -1px;
-    border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
-    border-left-color: var(--#{$prefix}tooltip-bg);
+    &::before {
+      left: -1px;
+      border-width: calc(var(--#{$prefix}tooltip-arrow-width) * 0.5) 0 calc(var(--#{$prefix}tooltip-arrow-width) * 0.5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
+      border-left-color: var(--#{$prefix}tooltip-bg);
+    }
   }
-}
 
-/* rtl:end:ignore */
+  /* rtl:end:ignore */
 
-.bs-tooltip-auto {
-  &[data-popper-placement^="top"] {
-    @extend .bs-tooltip-top;
+  .bs-tooltip-auto {
+    &[data-popper-placement^='top'] {
+      @extend .bs-tooltip-top;
+    }
+    &[data-popper-placement^='right'] {
+      @extend .bs-tooltip-end;
+    }
+    &[data-popper-placement^='bottom'] {
+      @extend .bs-tooltip-bottom;
+    }
+    &[data-popper-placement^='left'] {
+      @extend .bs-tooltip-start;
+    }
   }
-  &[data-popper-placement^="right"] {
-    @extend .bs-tooltip-end;
-  }
-  &[data-popper-placement^="bottom"] {
-    @extend .bs-tooltip-bottom;
-  }
-  &[data-popper-placement^="left"] {
-    @extend .bs-tooltip-start;
-  }
-}
 
-// Wrapper for the tooltip content
-.tooltip-inner {
-  max-width: var(--#{$prefix}tooltip-max-width);
-  padding: var(--#{$prefix}tooltip-padding-y) var(--#{$prefix}tooltip-padding-x);
-  color: var(--#{$prefix}tooltip-color);
-  text-align: center;
-  background-color: var(--#{$prefix}tooltip-bg);
-  @include border-radius(var(--#{$prefix}tooltip-border-radius));
+  // Wrapper for the tooltip content
+  .tooltip-inner {
+    max-width: var(--#{$prefix}tooltip-max-width);
+    padding: var(--#{$prefix}tooltip-padding-y) var(--#{$prefix}tooltip-padding-x);
+    color: var(--#{$prefix}tooltip-color);
+    text-align: center;
+    background-color: var(--#{$prefix}tooltip-bg);
+    @include border-radius(var(--#{$prefix}tooltip-border-radius));
+  }
 }

--- a/core/scss/bootstrap/_transitions.scss
+++ b/core/scss/bootstrap/_transitions.scss
@@ -1,27 +1,29 @@
-.fade {
-  @include transition($transition-fade);
+@layer components {
+  .fade {
+    @include transition($transition-fade);
 
-  &:not(.show) {
-    opacity: 0;
+    &:not(.show) {
+      opacity: 0;
+    }
   }
-}
 
-// scss-docs-start collapse-classes
-.collapse {
-  &:not(.show) {
-    display: none;
+  // scss-docs-start collapse-classes
+  .collapse {
+    &:not(.show) {
+      display: none;
+    }
   }
-}
 
-.collapsing {
-  height: 0;
-  overflow: hidden;
-  @include transition($transition-collapse);
+  .collapsing {
+    height: 0;
+    overflow: hidden;
+    @include transition($transition-collapse);
 
-  &.collapse-horizontal {
-    width: 0;
-    height: auto;
-    @include transition($transition-collapse-width);
+    &.collapse-horizontal {
+      width: 0;
+      height: auto;
+      @include transition($transition-collapse-width);
+    }
   }
+  // scss-docs-end collapse-classes
 }
-// scss-docs-end collapse-classes

--- a/core/scss/bootstrap/_type.scss
+++ b/core/scss/bootstrap/_type.scss
@@ -1,106 +1,107 @@
 //
 // Headings
 //
-.h1 {
-  @extend h1;
-}
 
-.h2 {
-  @extend h2;
-}
-
-.h3 {
-  @extend h3;
-}
-
-.h4 {
-  @extend h4;
-}
-
-.h5 {
-  @extend h5;
-}
-
-.h6 {
-  @extend h6;
-}
-
-
-.lead {
-  @include font-size($lead-font-size);
-  font-weight: $lead-font-weight;
-}
-
-// Type display classes
-@each $display, $font-size in $display-font-sizes {
-  .display-#{$display} {
-    font-family: $display-font-family;
-    font-style: $display-font-style;
-    font-weight: $display-font-weight;
-    line-height: $display-line-height;
-    @include font-size($font-size);
+@layer content {
+  .h1 {
+    @extend h1;
   }
-}
 
-//
-// Emphasis
-//
-.small {
-  @extend small;
-}
-
-.mark {
-  @extend mark;
-}
-
-//
-// Lists
-//
-
-.list-unstyled {
-  @include list-unstyled();
-}
-
-// Inline turns list items into inline-block
-.list-inline {
-  @include list-unstyled();
-}
-.list-inline-item {
-  display: inline-block;
-
-  &:not(:last-child) {
-    margin-right: $list-inline-padding;
+  .h2 {
+    @extend h2;
   }
-}
 
-
-//
-// Misc
-//
-
-// Builds on `abbr`
-.initialism {
-  @include font-size($initialism-font-size);
-  text-transform: uppercase;
-}
-
-// Blockquotes
-.blockquote {
-  margin-bottom: $blockquote-margin-y;
-  @include font-size($blockquote-font-size);
-
-  > :last-child {
-    margin-bottom: 0;
+  .h3 {
+    @extend h3;
   }
-}
 
-.blockquote-footer {
-  margin-top: -$blockquote-margin-y;
-  margin-bottom: $blockquote-margin-y;
-  @include font-size($blockquote-footer-font-size);
-  color: $blockquote-footer-color;
+  .h4 {
+    @extend h4;
+  }
 
-  &::before {
-    content: "\2014\00A0"; // em dash, nbsp
+  .h5 {
+    @extend h5;
+  }
+
+  .h6 {
+    @extend h6;
+  }
+
+  .lead {
+    @include font-size($lead-font-size);
+    font-weight: $lead-font-weight;
+  }
+
+  // Type display classes
+  @each $display, $font-size in $display-font-sizes {
+    .display-#{$display} {
+      font-family: $display-font-family;
+      font-style: $display-font-style;
+      font-weight: $display-font-weight;
+      line-height: $display-line-height;
+      @include font-size($font-size);
+    }
+  }
+
+  //
+  // Emphasis
+  //
+  .small {
+    @extend small;
+  }
+
+  .mark {
+    @extend mark;
+  }
+
+  //
+  // Lists
+  //
+
+  .list-unstyled {
+    @include list-unstyled();
+  }
+
+  // Inline turns list items into inline-block
+  .list-inline {
+    @include list-unstyled();
+  }
+  .list-inline-item {
+    display: inline-block;
+
+    &:not(:last-child) {
+      margin-right: $list-inline-padding;
+    }
+  }
+
+  //
+  // Misc
+  //
+
+  // Builds on `abbr`
+  .initialism {
+    @include font-size($initialism-font-size);
+    text-transform: uppercase;
+  }
+
+  // Blockquotes
+  .blockquote {
+    margin-bottom: $blockquote-margin-y;
+    @include font-size($blockquote-font-size);
+
+    > :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .blockquote-footer {
+    margin-top: -$blockquote-margin-y;
+    margin-bottom: $blockquote-margin-y;
+    @include font-size($blockquote-footer-font-size);
+    color: $blockquote-footer-color;
+
+    &::before {
+      content: '\2014\00A0'; // em dash, nbsp
+    }
   }
 }

--- a/core/scss/bootstrap/forms/_floating-labels.scss
+++ b/core/scss/bootstrap/forms/_floating-labels.scss
@@ -1,97 +1,100 @@
-.form-floating {
-  position: relative;
+@layer forms {
+  .form-floating {
+    position: relative;
 
-  > .form-control,
-  > .form-control-plaintext,
-  > .form-select {
-    height: $form-floating-height;
-    min-height: $form-floating-height;
-    line-height: $form-floating-line-height;
-  }
-
-  > label {
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: 2;
-    max-width: 100%;
-    height: 100%; // allow textareas
-    padding: $form-floating-padding-y $form-floating-padding-x;
-    overflow: hidden;
-    color: rgba(var(--#{$prefix}body-color-rgb), #{$form-floating-label-opacity});
-    text-align: start;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    pointer-events: none;
-    border: $input-border-width solid transparent; // Required for aligning label's text with the input as it affects inner box model
-    transform-origin: 0 0;
-    @include transition($form-floating-transition);
-  }
-
-  > .form-control,
-  > .form-control-plaintext {
-    padding: $form-floating-padding-y $form-floating-padding-x;
-
-    &::placeholder {
-      color: transparent;
+    > .form-control,
+    > .form-control-plaintext,
+    > .form-select {
+      height: $form-floating-height;
+      min-height: $form-floating-height;
+      line-height: $form-floating-line-height;
     }
 
-    &:focus,
-    &:not(:placeholder-shown) {
+    > label {
+      position: absolute;
+      top: 0;
+      left: 0;
+      z-index: 2;
+      max-width: 100%;
+      height: 100%; // allow textareas
+      padding: $form-floating-padding-y $form-floating-padding-x;
+      overflow: hidden;
+      color: rgba(var(--#{$prefix}body-color-rgb), #{$form-floating-label-opacity});
+      text-align: start;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      pointer-events: none;
+      border: $input-border-width solid transparent; // Required for aligning label's text with the input as it affects inner box model
+      transform-origin: 0 0;
+      @include transition($form-floating-transition);
+    }
+
+    > .form-control,
+    > .form-control-plaintext {
+      padding: $form-floating-padding-y $form-floating-padding-x;
+
+      &::placeholder {
+        color: transparent;
+      }
+
+      &:focus,
+      &:not(:placeholder-shown) {
+        padding-top: $form-floating-input-padding-t;
+        padding-bottom: $form-floating-input-padding-b;
+      }
+      // Duplicated because `:-webkit-autofill` invalidates other selectors when grouped
+      &:-webkit-autofill {
+        padding-top: $form-floating-input-padding-t;
+        padding-bottom: $form-floating-input-padding-b;
+      }
+    }
+
+    > .form-select {
       padding-top: $form-floating-input-padding-t;
       padding-bottom: $form-floating-input-padding-b;
+      padding-left: $form-floating-padding-x;
+    }
+
+    > .form-control:focus,
+    > .form-control:not(:placeholder-shown),
+    > .form-control-plaintext,
+    > .form-select {
+      ~ label {
+        transform: $form-floating-label-transform;
+      }
     }
     // Duplicated because `:-webkit-autofill` invalidates other selectors when grouped
-    &:-webkit-autofill {
-      padding-top: $form-floating-input-padding-t;
-      padding-bottom: $form-floating-input-padding-b;
+    > .form-control:-webkit-autofill {
+      ~ label {
+        transform: $form-floating-label-transform;
+      }
     }
-  }
+    > textarea:focus,
+    > textarea:not(:placeholder-shown) {
+      ~ label::after {
+        position: absolute;
+        inset: $form-floating-padding-y ($form-floating-padding-x * 0.5);
+        z-index: -1;
+        height: $form-floating-label-height;
+        content: '';
+        background-color: $input-bg;
+        @include border-radius($input-border-radius);
+      }
+    }
+    > textarea:disabled ~ label::after {
+      background-color: $input-disabled-bg;
+    }
 
-  > .form-select {
-    padding-top: $form-floating-input-padding-t;
-    padding-bottom: $form-floating-input-padding-b;
-    padding-left: $form-floating-padding-x;
-  }
+    > .form-control-plaintext {
+      ~ label {
+        border-width: $input-border-width 0; // Required to properly position label text - as explained above
+      }
+    }
 
-  > .form-control:focus,
-  > .form-control:not(:placeholder-shown),
-  > .form-control-plaintext,
-  > .form-select {
-    ~ label {
-      transform: $form-floating-label-transform;
+    > :disabled ~ label,
+    > .form-control:disabled ~ label {
+      // Required for `.form-control`s because of specificity
+      color: $form-floating-label-disabled-color;
     }
-  }
-  // Duplicated because `:-webkit-autofill` invalidates other selectors when grouped
-  > .form-control:-webkit-autofill {
-    ~ label {
-      transform: $form-floating-label-transform;
-    }
-  }
-  > textarea:focus,
-  > textarea:not(:placeholder-shown) {
-    ~ label::after {
-      position: absolute;
-      inset: $form-floating-padding-y ($form-floating-padding-x * .5);
-      z-index: -1;
-      height: $form-floating-label-height;
-      content: "";
-      background-color: $input-bg;
-      @include border-radius($input-border-radius);
-    }
-  }
-  > textarea:disabled ~ label::after {
-    background-color: $input-disabled-bg;
-  }
-
-  > .form-control-plaintext {
-    ~ label {
-      border-width: $input-border-width 0; // Required to properly position label text - as explained above
-    }
-  }
-
-  > :disabled ~ label,
-  > .form-control:disabled ~ label { // Required for `.form-control`s because of specificity
-    color: $form-floating-label-disabled-color;
   }
 }

--- a/core/scss/bootstrap/forms/_form-check.scss
+++ b/core/scss/bootstrap/forms/_form-check.scss
@@ -2,188 +2,190 @@
 // Check/radio
 //
 
-.form-check {
-  display: block;
-  min-height: $form-check-min-height;
-  padding-left: $form-check-padding-start;
-  margin-bottom: $form-check-margin-bottom;
-
-  .form-check-input {
-    float: left;
-    margin-left: $form-check-padding-start * -1;
-  }
-}
-
-.form-check-reverse {
-  padding-right: $form-check-padding-start;
-  padding-left: 0;
-  text-align: right;
-
-  .form-check-input {
-    float: right;
-    margin-right: $form-check-padding-start * -1;
-    margin-left: 0;
-  }
-}
-
-.form-check-input {
-  --#{$prefix}form-check-bg: #{$form-check-input-bg};
-
-  flex-shrink: 0;
-  width: $form-check-input-width;
-  height: $form-check-input-width;
-  margin-top: ($line-height-base - $form-check-input-width) * .5; // line-height minus check height
-  vertical-align: top;
-  appearance: none;
-  background-color: var(--#{$prefix}form-check-bg);
-  background-image: var(--#{$prefix}form-check-bg-image);
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: contain;
-  border: $form-check-input-border;
-  print-color-adjust: exact; // Keep themed appearance for print
-  @include transition($form-check-transition);
-
-  &[type="checkbox"] {
-    @include border-radius($form-check-input-border-radius);
-  }
-
-  &[type="radio"] {
-    // stylelint-disable-next-line property-disallowed-list
-    border-radius: $form-check-radio-border-radius;
-  }
-
-  &:active {
-    filter: $form-check-input-active-filter;
-  }
-
-  &:focus {
-    border-color: $form-check-input-focus-border;
-    outline: 0;
-    box-shadow: $form-check-input-focus-box-shadow;
-  }
-
-  &:checked {
-    background-color: $form-check-input-checked-bg-color;
-    border-color: $form-check-input-checked-border-color;
-
-    &[type="checkbox"] {
-      @if $enable-gradients {
-        --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-checked-bg-image)}, var(--#{$prefix}gradient);
-      } @else {
-        --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-checked-bg-image)};
-      }
-    }
-
-    &[type="radio"] {
-      @if $enable-gradients {
-        --#{$prefix}form-check-bg-image: #{escape-svg($form-check-radio-checked-bg-image)}, var(--#{$prefix}gradient);
-      } @else {
-        --#{$prefix}form-check-bg-image: #{escape-svg($form-check-radio-checked-bg-image)};
-      }
-    }
-  }
-
-  &[type="checkbox"]:indeterminate {
-    background-color: $form-check-input-indeterminate-bg-color;
-    border-color: $form-check-input-indeterminate-border-color;
-
-    @if $enable-gradients {
-      --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-indeterminate-bg-image)}, var(--#{$prefix}gradient);
-    } @else {
-      --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-indeterminate-bg-image)};
-    }
-  }
-
-  &:disabled {
-    pointer-events: none;
-    filter: none;
-    opacity: $form-check-input-disabled-opacity;
-  }
-
-  // Use disabled attribute in addition of :disabled pseudo-class
-  // See: https://github.com/twbs/bootstrap/issues/28247
-  &[disabled],
-  &:disabled {
-    ~ .form-check-label {
-      cursor: default;
-      opacity: $form-check-label-disabled-opacity;
-    }
-  }
-}
-
-.form-check-label {
-  color: $form-check-label-color;
-  cursor: $form-check-label-cursor;
-}
-
-//
-// Switch
-//
-
-.form-switch {
-  padding-left: $form-switch-padding-start;
-
-  .form-check-input {
-    --#{$prefix}form-switch-bg: #{escape-svg($form-switch-bg-image)};
-
-    width: $form-switch-width;
-    margin-left: $form-switch-padding-start * -1;
-    background-image: var(--#{$prefix}form-switch-bg);
-    background-position: left center;
-    @include border-radius($form-switch-border-radius, 0);
-    @include transition($form-switch-transition);
-
-    &:focus {
-      --#{$prefix}form-switch-bg: #{escape-svg($form-switch-focus-bg-image)};
-    }
-
-    &:checked {
-      background-position: $form-switch-checked-bg-position;
-
-      @if $enable-gradients {
-        --#{$prefix}form-switch-bg: #{escape-svg($form-switch-checked-bg-image)}, var(--#{$prefix}gradient);
-      } @else {
-        --#{$prefix}form-switch-bg: #{escape-svg($form-switch-checked-bg-image)};
-      }
-    }
-  }
-
-  &.form-check-reverse {
-    padding-right: $form-switch-padding-start;
-    padding-left: 0;
+@layer forms {
+  .form-check {
+    display: block;
+    min-height: $form-check-min-height;
+    padding-left: $form-check-padding-start;
+    margin-bottom: $form-check-margin-bottom;
 
     .form-check-input {
-      margin-right: $form-switch-padding-start * -1;
+      float: left;
+      margin-left: $form-check-padding-start * -1;
+    }
+  }
+
+  .form-check-reverse {
+    padding-right: $form-check-padding-start;
+    padding-left: 0;
+    text-align: right;
+
+    .form-check-input {
+      float: right;
+      margin-right: $form-check-padding-start * -1;
       margin-left: 0;
     }
   }
-}
 
-.form-check-inline {
-  display: inline-block;
-  margin-right: $form-check-inline-margin-end;
-}
+  .form-check-input {
+    --#{$prefix}form-check-bg: #{$form-check-input-bg};
 
-.btn-check {
-  position: absolute;
-  clip: rect(0, 0, 0, 0);
-  pointer-events: none;
+    flex-shrink: 0;
+    width: $form-check-input-width;
+    height: $form-check-input-width;
+    margin-top: ($line-height-base - $form-check-input-width) * 0.5; // line-height minus check height
+    vertical-align: top;
+    appearance: none;
+    background-color: var(--#{$prefix}form-check-bg);
+    background-image: var(--#{$prefix}form-check-bg-image);
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+    border: $form-check-input-border;
+    print-color-adjust: exact; // Keep themed appearance for print
+    @include transition($form-check-transition);
 
-  &[disabled],
-  &:disabled {
-    + .btn {
+    &[type='checkbox'] {
+      @include border-radius($form-check-input-border-radius);
+    }
+
+    &[type='radio'] {
+      // stylelint-disable-next-line property-disallowed-list
+      border-radius: $form-check-radio-border-radius;
+    }
+
+    &:active {
+      filter: $form-check-input-active-filter;
+    }
+
+    &:focus {
+      border-color: $form-check-input-focus-border;
+      outline: 0;
+      box-shadow: $form-check-input-focus-box-shadow;
+    }
+
+    &:checked {
+      background-color: $form-check-input-checked-bg-color;
+      border-color: $form-check-input-checked-border-color;
+
+      &[type='checkbox'] {
+        @if $enable-gradients {
+          --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-checked-bg-image)}, var(--#{$prefix}gradient);
+        } @else {
+          --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-checked-bg-image)};
+        }
+      }
+
+      &[type='radio'] {
+        @if $enable-gradients {
+          --#{$prefix}form-check-bg-image: #{escape-svg($form-check-radio-checked-bg-image)}, var(--#{$prefix}gradient);
+        } @else {
+          --#{$prefix}form-check-bg-image: #{escape-svg($form-check-radio-checked-bg-image)};
+        }
+      }
+    }
+
+    &[type='checkbox']:indeterminate {
+      background-color: $form-check-input-indeterminate-bg-color;
+      border-color: $form-check-input-indeterminate-border-color;
+
+      @if $enable-gradients {
+        --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-indeterminate-bg-image)}, var(--#{$prefix}gradient);
+      } @else {
+        --#{$prefix}form-check-bg-image: #{escape-svg($form-check-input-indeterminate-bg-image)};
+      }
+    }
+
+    &:disabled {
       pointer-events: none;
       filter: none;
-      opacity: $form-check-btn-check-disabled-opacity;
+      opacity: $form-check-input-disabled-opacity;
+    }
+
+    // Use disabled attribute in addition of :disabled pseudo-class
+    // See: https://github.com/twbs/bootstrap/issues/28247
+    &[disabled],
+    &:disabled {
+      ~ .form-check-label {
+        cursor: default;
+        opacity: $form-check-label-disabled-opacity;
+      }
     }
   }
-}
 
-@if $enable-dark-mode {
-  @include color-mode(dark) {
-    .form-switch .form-check-input:not(:checked):not(:focus) {
-      --#{$prefix}form-switch-bg: #{escape-svg($form-switch-bg-image-dark)};
+  .form-check-label {
+    color: $form-check-label-color;
+    cursor: $form-check-label-cursor;
+  }
+
+  //
+  // Switch
+  //
+
+  .form-switch {
+    padding-left: $form-switch-padding-start;
+
+    .form-check-input {
+      --#{$prefix}form-switch-bg: #{escape-svg($form-switch-bg-image)};
+
+      width: $form-switch-width;
+      margin-left: $form-switch-padding-start * -1;
+      background-image: var(--#{$prefix}form-switch-bg);
+      background-position: left center;
+      @include border-radius($form-switch-border-radius, 0);
+      @include transition($form-switch-transition);
+
+      &:focus {
+        --#{$prefix}form-switch-bg: #{escape-svg($form-switch-focus-bg-image)};
+      }
+
+      &:checked {
+        background-position: $form-switch-checked-bg-position;
+
+        @if $enable-gradients {
+          --#{$prefix}form-switch-bg: #{escape-svg($form-switch-checked-bg-image)}, var(--#{$prefix}gradient);
+        } @else {
+          --#{$prefix}form-switch-bg: #{escape-svg($form-switch-checked-bg-image)};
+        }
+      }
+    }
+
+    &.form-check-reverse {
+      padding-right: $form-switch-padding-start;
+      padding-left: 0;
+
+      .form-check-input {
+        margin-right: $form-switch-padding-start * -1;
+        margin-left: 0;
+      }
+    }
+  }
+
+  .form-check-inline {
+    display: inline-block;
+    margin-right: $form-check-inline-margin-end;
+  }
+
+  .btn-check {
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    pointer-events: none;
+
+    &[disabled],
+    &:disabled {
+      + .btn {
+        pointer-events: none;
+        filter: none;
+        opacity: $form-check-btn-check-disabled-opacity;
+      }
+    }
+  }
+
+  @if $enable-dark-mode {
+    @include color-mode(dark) {
+      .form-switch .form-check-input:not(:checked):not(:focus) {
+        --#{$prefix}form-switch-bg: #{escape-svg($form-switch-bg-image-dark)};
+      }
     }
   }
 }

--- a/core/scss/bootstrap/forms/_form-control.scss
+++ b/core/scss/bootstrap/forms/_form-control.scss
@@ -1,216 +1,222 @@
-@use "sass:math";
+@use 'sass:math';
 
 //
 // General form controls (plus a few specific high-level interventions)
 //
 
-.form-control {
-  display: block;
-  width: 100%;
-  padding: $input-padding-y $input-padding-x;
-  font-family: $input-font-family;
-  @include font-size($input-font-size);
-  font-weight: $input-font-weight;
-  line-height: $input-line-height;
-  color: $input-color;
-  appearance: none; // Fix appearance for date inputs in Safari
-  background-color: $input-bg;
-  background-clip: padding-box;
-  border: $input-border-width solid $input-border-color;
+@layer forms {
+  .form-control {
+    display: block;
+    width: 100%;
+    padding: $input-padding-y $input-padding-x;
+    font-family: $input-font-family;
+    @include font-size($input-font-size);
+    font-weight: $input-font-weight;
+    line-height: $input-line-height;
+    color: $input-color;
+    appearance: none; // Fix appearance for date inputs in Safari
+    background-color: $input-bg;
+    background-clip: padding-box;
+    border: $input-border-width solid $input-border-color;
 
-  // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
-  @include border-radius($input-border-radius, 0);
+    // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
+    @include border-radius($input-border-radius, 0);
 
-  @include box-shadow($input-box-shadow);
-  @include transition($input-transition);
+    @include box-shadow($input-box-shadow);
+    @include transition($input-transition);
 
-  &[type="file"] {
-    overflow: hidden; // prevent pseudo element button overlap
+    &[type='file'] {
+      overflow: hidden; // prevent pseudo element button overlap
+
+      &:not(:disabled):not([readonly]) {
+        cursor: pointer;
+      }
+    }
+
+    // Customize the `:focus` state to imitate native WebKit styles.
+    &:focus {
+      color: $input-focus-color;
+      background-color: $input-focus-bg;
+      border-color: $input-focus-border-color;
+      outline: 0;
+      @if $enable-shadows {
+        @include box-shadow($input-box-shadow, $input-focus-box-shadow);
+      } @else {
+        // Avoid using mixin so we can pass custom focus shadow properly
+        box-shadow: $input-focus-box-shadow;
+      }
+    }
+
+    &::-webkit-date-and-time-value {
+      // On Android Chrome, form-control's "width: 100%" makes the input width too small
+      // Tested under Android 11 / Chrome 89, Android 12 / Chrome 100, Android 13 / Chrome 109
+      //
+      // On iOS Safari, form-control's "appearance: none" + "width: 100%" makes the input width too small
+      // Tested under iOS 16.2 / Safari 16.2
+      min-width: 85px; // Seems to be a good minimum safe width
+
+      // Add some height to date inputs on iOS
+      // https://github.com/twbs/bootstrap/issues/23307
+      // TODO: we can remove this workaround once https://bugs.webkit.org/show_bug.cgi?id=198959 is resolved
+      // Multiply line-height by 1em if it has no unit
+      height: if(sass(math.unit($input-line-height) == ''): $input-line-height * 1em; else: $input-line-height);
+
+      // Android Chrome type="date" is taller than the other inputs
+      // because of "margin: 1px 24px 1px 4px" inside the shadow DOM
+      // Tested under Android 11 / Chrome 89, Android 12 / Chrome 100, Android 13 / Chrome 109
+      margin: 0;
+    }
+
+    // Prevent excessive date input height in Webkit
+    // https://github.com/twbs/bootstrap/issues/34433
+    &::-webkit-datetime-edit {
+      display: block;
+      padding: 0;
+    }
+
+    // Placeholder
+    &::placeholder {
+      color: $input-placeholder-color;
+      // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
+      opacity: 1;
+    }
+
+    // Disabled inputs
+    //
+    // HTML5 says that controls under a fieldset > legend:first-child won't be
+    // disabled if the fieldset is disabled. Due to implementation difficulty, we
+    // don't honor that edge case; we style them as disabled anyway.
+    &:disabled {
+      color: $input-disabled-color;
+      background-color: $input-disabled-bg;
+      border-color: $input-disabled-border-color;
+      // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655.
+      opacity: 1;
+    }
+
+    // File input buttons theming
+    &::file-selector-button {
+      padding: $input-padding-y $input-padding-x;
+      margin: (-$input-padding-y) (-$input-padding-x);
+      margin-inline-end: $input-padding-x;
+      color: $form-file-button-color;
+      @include gradient-bg($form-file-button-bg);
+      pointer-events: none;
+      border-color: inherit;
+      border-style: solid;
+      border-width: 0;
+      border-inline-end-width: $input-border-width;
+      border-radius: 0; // stylelint-disable-line property-disallowed-list
+      @include transition($btn-transition);
+    }
+
+    &:hover:not(:disabled):not([readonly])::file-selector-button {
+      background-color: $form-file-button-hover-bg;
+    }
+  }
+
+  // Readonly controls as plain text
+  //
+  // Apply class to a readonly input to make it appear like regular plain
+  // text (without any border, background color, focus indicator)
+
+  .form-control-plaintext {
+    display: block;
+    width: 100%;
+    padding: $input-padding-y 0;
+    margin-bottom: 0; // match inputs if this class comes on inputs with default margins
+    line-height: $input-line-height;
+    color: $input-plaintext-color;
+    background-color: transparent;
+    border: solid transparent;
+    border-width: $input-border-width 0;
+
+    &:focus {
+      outline: 0;
+    }
+
+    &.form-control-sm,
+    &.form-control-lg {
+      padding-right: 0;
+      padding-left: 0;
+    }
+  }
+
+  // Form control sizing
+  //
+  // Build on `.form-control` with modifier classes to decrease or increase the
+  // height and font-size of form controls.
+  //
+  // Repeated in `_input_group.scss` to avoid Sass extend issues.
+
+  .form-control-sm {
+    min-height: $input-height-sm;
+    padding: $input-padding-y-sm $input-padding-x-sm;
+    @include font-size($input-font-size-sm);
+    @include border-radius($input-border-radius-sm);
+
+    &::file-selector-button {
+      padding: $input-padding-y-sm $input-padding-x-sm;
+      margin: (-$input-padding-y-sm) (-$input-padding-x-sm);
+      margin-inline-end: $input-padding-x-sm;
+    }
+  }
+
+  .form-control-lg {
+    min-height: $input-height-lg;
+    padding: $input-padding-y-lg $input-padding-x-lg;
+    @include font-size($input-font-size-lg);
+    @include border-radius($input-border-radius-lg);
+
+    &::file-selector-button {
+      padding: $input-padding-y-lg $input-padding-x-lg;
+      margin: (-$input-padding-y-lg) (-$input-padding-x-lg);
+      margin-inline-end: $input-padding-x-lg;
+    }
+  }
+
+  // Make sure textareas don't shrink too much when resized
+  // https://github.com/twbs/bootstrap/pull/29124
+  // stylelint-disable selector-no-qualifying-type
+  textarea {
+    &.form-control {
+      min-height: $input-height;
+    }
+
+    &.form-control-sm {
+      min-height: $input-height-sm;
+    }
+
+    &.form-control-lg {
+      min-height: $input-height-lg;
+    }
+  }
+  // stylelint-enable selector-no-qualifying-type
+
+  .form-control-color {
+    width: $form-color-width;
+    height: $input-height;
+    padding: $input-padding-y;
 
     &:not(:disabled):not([readonly]) {
       cursor: pointer;
     }
-  }
 
-  // Customize the `:focus` state to imitate native WebKit styles.
-  &:focus {
-    color: $input-focus-color;
-    background-color: $input-focus-bg;
-    border-color: $input-focus-border-color;
-    outline: 0;
-    @if $enable-shadows {
-      @include box-shadow($input-box-shadow, $input-focus-box-shadow);
-    } @else {
-      // Avoid using mixin so we can pass custom focus shadow properly
-      box-shadow: $input-focus-box-shadow;
+    &::-moz-color-swatch {
+      border: 0 !important; // stylelint-disable-line declaration-no-important
+      @include border-radius($input-border-radius);
+    }
+
+    &::-webkit-color-swatch {
+      border: 0 !important; // stylelint-disable-line declaration-no-important
+      @include border-radius($input-border-radius);
+    }
+
+    &.form-control-sm {
+      height: $input-height-sm;
+    }
+    &.form-control-lg {
+      height: $input-height-lg;
     }
   }
-
-  &::-webkit-date-and-time-value {
-    // On Android Chrome, form-control's "width: 100%" makes the input width too small
-    // Tested under Android 11 / Chrome 89, Android 12 / Chrome 100, Android 13 / Chrome 109
-    //
-    // On iOS Safari, form-control's "appearance: none" + "width: 100%" makes the input width too small
-    // Tested under iOS 16.2 / Safari 16.2
-    min-width: 85px; // Seems to be a good minimum safe width
-
-    // Add some height to date inputs on iOS
-    // https://github.com/twbs/bootstrap/issues/23307
-    // TODO: we can remove this workaround once https://bugs.webkit.org/show_bug.cgi?id=198959 is resolved
-    // Multiply line-height by 1em if it has no unit
-    height: if(sass(math.unit($input-line-height) == ""): $input-line-height * 1em; else: $input-line-height);
-
-    // Android Chrome type="date" is taller than the other inputs
-    // because of "margin: 1px 24px 1px 4px" inside the shadow DOM
-    // Tested under Android 11 / Chrome 89, Android 12 / Chrome 100, Android 13 / Chrome 109
-    margin: 0;
-  }
-
-  // Prevent excessive date input height in Webkit
-  // https://github.com/twbs/bootstrap/issues/34433
-  &::-webkit-datetime-edit {
-    display: block;
-    padding: 0;
-  }
-
-  // Placeholder
-  &::placeholder {
-    color: $input-placeholder-color;
-    // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
-    opacity: 1;
-  }
-
-  // Disabled inputs
-  //
-  // HTML5 says that controls under a fieldset > legend:first-child won't be
-  // disabled if the fieldset is disabled. Due to implementation difficulty, we
-  // don't honor that edge case; we style them as disabled anyway.
-  &:disabled {
-    color: $input-disabled-color;
-    background-color: $input-disabled-bg;
-    border-color: $input-disabled-border-color;
-    // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655.
-    opacity: 1;
-  }
-
-  // File input buttons theming
-  &::file-selector-button {
-    padding: $input-padding-y $input-padding-x;
-    margin: (-$input-padding-y) (-$input-padding-x);
-    margin-inline-end: $input-padding-x;
-    color: $form-file-button-color;
-    @include gradient-bg($form-file-button-bg);
-    pointer-events: none;
-    border-color: inherit;
-    border-style: solid;
-    border-width: 0;
-    border-inline-end-width: $input-border-width;
-    border-radius: 0; // stylelint-disable-line property-disallowed-list
-    @include transition($btn-transition);
-  }
-
-  &:hover:not(:disabled):not([readonly])::file-selector-button {
-    background-color: $form-file-button-hover-bg;
-  }
-}
-
-// Readonly controls as plain text
-//
-// Apply class to a readonly input to make it appear like regular plain
-// text (without any border, background color, focus indicator)
-
-.form-control-plaintext {
-  display: block;
-  width: 100%;
-  padding: $input-padding-y 0;
-  margin-bottom: 0; // match inputs if this class comes on inputs with default margins
-  line-height: $input-line-height;
-  color: $input-plaintext-color;
-  background-color: transparent;
-  border: solid transparent;
-  border-width: $input-border-width 0;
-
-  &:focus {
-    outline: 0;
-  }
-
-  &.form-control-sm,
-  &.form-control-lg {
-    padding-right: 0;
-    padding-left: 0;
-  }
-}
-
-// Form control sizing
-//
-// Build on `.form-control` with modifier classes to decrease or increase the
-// height and font-size of form controls.
-//
-// Repeated in `_input_group.scss` to avoid Sass extend issues.
-
-.form-control-sm {
-  min-height: $input-height-sm;
-  padding: $input-padding-y-sm $input-padding-x-sm;
-  @include font-size($input-font-size-sm);
-  @include border-radius($input-border-radius-sm);
-
-  &::file-selector-button {
-    padding: $input-padding-y-sm $input-padding-x-sm;
-    margin: (-$input-padding-y-sm) (-$input-padding-x-sm);
-    margin-inline-end: $input-padding-x-sm;
-  }
-}
-
-.form-control-lg {
-  min-height: $input-height-lg;
-  padding: $input-padding-y-lg $input-padding-x-lg;
-  @include font-size($input-font-size-lg);
-  @include border-radius($input-border-radius-lg);
-
-  &::file-selector-button {
-    padding: $input-padding-y-lg $input-padding-x-lg;
-    margin: (-$input-padding-y-lg) (-$input-padding-x-lg);
-    margin-inline-end: $input-padding-x-lg;
-  }
-}
-
-// Make sure textareas don't shrink too much when resized
-// https://github.com/twbs/bootstrap/pull/29124
-// stylelint-disable selector-no-qualifying-type
-textarea {
-  &.form-control {
-    min-height: $input-height;
-  }
-
-  &.form-control-sm {
-    min-height: $input-height-sm;
-  }
-
-  &.form-control-lg {
-    min-height: $input-height-lg;
-  }
-}
-// stylelint-enable selector-no-qualifying-type
-
-.form-control-color {
-  width: $form-color-width;
-  height: $input-height;
-  padding: $input-padding-y;
-
-  &:not(:disabled):not([readonly]) {
-    cursor: pointer;
-  }
-
-  &::-moz-color-swatch {
-    border: 0 !important; // stylelint-disable-line declaration-no-important
-    @include border-radius($input-border-radius);
-  }
-
-  &::-webkit-color-swatch {
-    border: 0 !important; // stylelint-disable-line declaration-no-important
-    @include border-radius($input-border-radius);
-  }
-
-  &.form-control-sm { height: $input-height-sm; }
-  &.form-control-lg { height: $input-height-lg; }
 }

--- a/core/scss/bootstrap/forms/_form-range.scss
+++ b/core/scss/bootstrap/forms/_form-range.scss
@@ -4,88 +4,94 @@
 // elements cannot be mixed. As such, there are no shared styles for focus or
 // active states on prefixed selectors.
 
-.form-range {
-  width: 100%;
-  height: add($form-range-thumb-height, $form-range-thumb-focus-box-shadow-width * 2);
-  padding: 0; // Need to reset padding
-  appearance: none;
-  background-color: transparent;
-
-  &:focus {
-    outline: 0;
-
-    // Pseudo-elements must be split across multiple rulesets to have an effect.
-    // No box-shadow() mixin for focus accessibility.
-    &::-webkit-slider-thumb { box-shadow: $form-range-thumb-focus-box-shadow; }
-    &::-moz-range-thumb     { box-shadow: $form-range-thumb-focus-box-shadow; }
-  }
-
-  &::-moz-focus-outer {
-    border: 0;
-  }
-
-  &::-webkit-slider-thumb {
-    width: $form-range-thumb-width;
-    height: $form-range-thumb-height;
-    margin-top: ($form-range-track-height - $form-range-thumb-height) * .5; // Webkit specific
+@layer forms {
+  .form-range {
+    width: 100%;
+    height: add($form-range-thumb-height, $form-range-thumb-focus-box-shadow-width * 2);
+    padding: 0; // Need to reset padding
     appearance: none;
-    @include gradient-bg($form-range-thumb-bg);
-    border: $form-range-thumb-border;
-    @include border-radius($form-range-thumb-border-radius);
-    @include box-shadow($form-range-thumb-box-shadow);
-    @include transition($form-range-thumb-transition);
+    background-color: transparent;
 
-    &:active {
-      @include gradient-bg($form-range-thumb-active-bg);
+    &:focus {
+      outline: 0;
+
+      // Pseudo-elements must be split across multiple rulesets to have an effect.
+      // No box-shadow() mixin for focus accessibility.
+      &::-webkit-slider-thumb {
+        box-shadow: $form-range-thumb-focus-box-shadow;
+      }
+      &::-moz-range-thumb {
+        box-shadow: $form-range-thumb-focus-box-shadow;
+      }
     }
-  }
 
-  &::-webkit-slider-runnable-track {
-    width: $form-range-track-width;
-    height: $form-range-track-height;
-    color: transparent; // Why?
-    cursor: $form-range-track-cursor;
-    background-color: $form-range-track-bg;
-    border-color: transparent;
-    @include border-radius($form-range-track-border-radius);
-    @include box-shadow($form-range-track-box-shadow);
-  }
-
-  &::-moz-range-thumb {
-    width: $form-range-thumb-width;
-    height: $form-range-thumb-height;
-    appearance: none;
-    @include gradient-bg($form-range-thumb-bg);
-    border: $form-range-thumb-border;
-    @include border-radius($form-range-thumb-border-radius);
-    @include box-shadow($form-range-thumb-box-shadow);
-    @include transition($form-range-thumb-transition);
-
-    &:active {
-      @include gradient-bg($form-range-thumb-active-bg);
+    &::-moz-focus-outer {
+      border: 0;
     }
-  }
-
-  &::-moz-range-track {
-    width: $form-range-track-width;
-    height: $form-range-track-height;
-    color: transparent;
-    cursor: $form-range-track-cursor;
-    background-color: $form-range-track-bg;
-    border-color: transparent; // Firefox specific?
-    @include border-radius($form-range-track-border-radius);
-    @include box-shadow($form-range-track-box-shadow);
-  }
-
-  &:disabled {
-    pointer-events: none;
 
     &::-webkit-slider-thumb {
-      background-color: $form-range-thumb-disabled-bg;
+      width: $form-range-thumb-width;
+      height: $form-range-thumb-height;
+      margin-top: ($form-range-track-height - $form-range-thumb-height) * 0.5; // Webkit specific
+      appearance: none;
+      @include gradient-bg($form-range-thumb-bg);
+      border: $form-range-thumb-border;
+      @include border-radius($form-range-thumb-border-radius);
+      @include box-shadow($form-range-thumb-box-shadow);
+      @include transition($form-range-thumb-transition);
+
+      &:active {
+        @include gradient-bg($form-range-thumb-active-bg);
+      }
+    }
+
+    &::-webkit-slider-runnable-track {
+      width: $form-range-track-width;
+      height: $form-range-track-height;
+      color: transparent; // Why?
+      cursor: $form-range-track-cursor;
+      background-color: $form-range-track-bg;
+      border-color: transparent;
+      @include border-radius($form-range-track-border-radius);
+      @include box-shadow($form-range-track-box-shadow);
     }
 
     &::-moz-range-thumb {
-      background-color: $form-range-thumb-disabled-bg;
+      width: $form-range-thumb-width;
+      height: $form-range-thumb-height;
+      appearance: none;
+      @include gradient-bg($form-range-thumb-bg);
+      border: $form-range-thumb-border;
+      @include border-radius($form-range-thumb-border-radius);
+      @include box-shadow($form-range-thumb-box-shadow);
+      @include transition($form-range-thumb-transition);
+
+      &:active {
+        @include gradient-bg($form-range-thumb-active-bg);
+      }
+    }
+
+    &::-moz-range-track {
+      width: $form-range-track-width;
+      height: $form-range-track-height;
+      color: transparent;
+      cursor: $form-range-track-cursor;
+      background-color: $form-range-track-bg;
+      border-color: transparent; // Firefox specific?
+      @include border-radius($form-range-track-border-radius);
+      @include box-shadow($form-range-track-box-shadow);
+    }
+
+    &:disabled {
+      pointer-events: none;
+
+      &::-webkit-slider-thumb {
+        background-color: $form-range-thumb-disabled-bg;
+      }
+
+      &::-moz-range-thumb {
+        background-color: $form-range-thumb-disabled-bg;
+      }
     }
   }
 }

--- a/core/scss/bootstrap/forms/_form-select.scss
+++ b/core/scss/bootstrap/forms/_form-select.scss
@@ -3,78 +3,80 @@
 // Replaces the browser default select with a custom one, mostly pulled from
 // https://primer.github.io/.
 
-.form-select {
-  --#{$prefix}form-select-bg-img: #{escape-svg($form-select-indicator)};
+@layer forms {
+  .form-select {
+    --#{$prefix}form-select-bg-img: #{escape-svg($form-select-indicator)};
 
-  display: block;
-  width: 100%;
-  padding: $form-select-padding-y $form-select-indicator-padding $form-select-padding-y $form-select-padding-x;
-  font-family: $form-select-font-family;
-  @include font-size($form-select-font-size);
-  font-weight: $form-select-font-weight;
-  line-height: $form-select-line-height;
-  color: $form-select-color;
-  appearance: none;
-  background-color: $form-select-bg;
-  background-image: var(--#{$prefix}form-select-bg-img), var(--#{$prefix}form-select-bg-icon, none);
-  background-repeat: no-repeat;
-  background-position: $form-select-bg-position;
-  background-size: $form-select-bg-size;
-  border: $form-select-border-width solid $form-select-border-color;
-  @include border-radius($form-select-border-radius, 0);
-  @include box-shadow($form-select-box-shadow);
-  @include transition($form-select-transition);
+    display: block;
+    width: 100%;
+    padding: $form-select-padding-y $form-select-indicator-padding $form-select-padding-y $form-select-padding-x;
+    font-family: $form-select-font-family;
+    @include font-size($form-select-font-size);
+    font-weight: $form-select-font-weight;
+    line-height: $form-select-line-height;
+    color: $form-select-color;
+    appearance: none;
+    background-color: $form-select-bg;
+    background-image: var(--#{$prefix}form-select-bg-img), var(--#{$prefix}form-select-bg-icon, none);
+    background-repeat: no-repeat;
+    background-position: $form-select-bg-position;
+    background-size: $form-select-bg-size;
+    border: $form-select-border-width solid $form-select-border-color;
+    @include border-radius($form-select-border-radius, 0);
+    @include box-shadow($form-select-box-shadow);
+    @include transition($form-select-transition);
 
-  &:focus {
-    border-color: $form-select-focus-border-color;
-    outline: 0;
-    @if $enable-shadows {
-      @include box-shadow($form-select-box-shadow, $form-select-focus-box-shadow);
-    } @else {
-      // Avoid using mixin so we can pass custom focus shadow properly
-      box-shadow: $form-select-focus-box-shadow;
+    &:focus {
+      border-color: $form-select-focus-border-color;
+      outline: 0;
+      @if $enable-shadows {
+        @include box-shadow($form-select-box-shadow, $form-select-focus-box-shadow);
+      } @else {
+        // Avoid using mixin so we can pass custom focus shadow properly
+        box-shadow: $form-select-focus-box-shadow;
+      }
+    }
+
+    &[multiple],
+    &[size]:not([size='1']) {
+      padding-right: $form-select-padding-x;
+      background-image: none;
+    }
+
+    &:disabled {
+      color: $form-select-disabled-color;
+      background-color: $form-select-disabled-bg;
+      border-color: $form-select-disabled-border-color;
+    }
+
+    // Remove outline from select box in FF
+    &:-moz-focusring {
+      color: transparent;
+      text-shadow: 0 0 0 $form-select-color;
     }
   }
 
-  &[multiple],
-  &[size]:not([size="1"]) {
-    padding-right: $form-select-padding-x;
-    background-image: none;
+  .form-select-sm {
+    padding-top: $form-select-padding-y-sm;
+    padding-bottom: $form-select-padding-y-sm;
+    padding-left: $form-select-padding-x-sm;
+    @include font-size($form-select-font-size-sm);
+    @include border-radius($form-select-border-radius-sm);
   }
 
-  &:disabled {
-    color: $form-select-disabled-color;
-    background-color: $form-select-disabled-bg;
-    border-color: $form-select-disabled-border-color;
+  .form-select-lg {
+    padding-top: $form-select-padding-y-lg;
+    padding-bottom: $form-select-padding-y-lg;
+    padding-left: $form-select-padding-x-lg;
+    @include font-size($form-select-font-size-lg);
+    @include border-radius($form-select-border-radius-lg);
   }
 
-  // Remove outline from select box in FF
-  &:-moz-focusring {
-    color: transparent;
-    text-shadow: 0 0 0 $form-select-color;
-  }
-}
-
-.form-select-sm {
-  padding-top: $form-select-padding-y-sm;
-  padding-bottom: $form-select-padding-y-sm;
-  padding-left: $form-select-padding-x-sm;
-  @include font-size($form-select-font-size-sm);
-  @include border-radius($form-select-border-radius-sm);
-}
-
-.form-select-lg {
-  padding-top: $form-select-padding-y-lg;
-  padding-bottom: $form-select-padding-y-lg;
-  padding-left: $form-select-padding-x-lg;
-  @include font-size($form-select-font-size-lg);
-  @include border-radius($form-select-border-radius-lg);
-}
-
-@if $enable-dark-mode {
-  @include color-mode(dark) {
-    .form-select {
-      --#{$prefix}form-select-bg-img: #{escape-svg($form-select-indicator-dark)};
+  @if $enable-dark-mode {
+    @include color-mode(dark) {
+      .form-select {
+        --#{$prefix}form-select-bg-img: #{escape-svg($form-select-indicator-dark)};
+      }
     }
   }
 }

--- a/core/scss/bootstrap/forms/_form-text.scss
+++ b/core/scss/bootstrap/forms/_form-text.scss
@@ -2,10 +2,12 @@
 // Form text
 //
 
-.form-text {
-  margin-top: $form-text-margin-top;
-  @include font-size($form-text-font-size);
-  font-style: $form-text-font-style;
-  font-weight: $form-text-font-weight;
-  color: $form-text-color;
+@layer forms {
+  .form-text {
+    margin-top: $form-text-margin-top;
+    @include font-size($form-text-font-size);
+    font-style: $form-text-font-style;
+    font-weight: $form-text-font-weight;
+    color: $form-text-color;
+  }
 }

--- a/core/scss/bootstrap/forms/_input-group.scss
+++ b/core/scss/bootstrap/forms/_input-group.scss
@@ -1,135 +1,134 @@
-@use "sass:map";
-@use "sass:string";
+@use 'sass:map';
+@use 'sass:string';
 
 //
 // Base styles
 //
 
-.input-group {
-  position: relative;
-  display: flex;
-  flex-wrap: wrap; // For form validation feedback
-  align-items: stretch;
-  width: 100%;
-
-  > .form-control,
-  > .form-select,
-  > .form-floating {
-    position: relative; // For focus state's z-index
-    flex: 1 1 auto;
-    width: 1%;
-    min-width: 0; // https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size
-  }
-
-  // Bring the "active" form control to the top of surrounding elements
-  > .form-control:focus,
-  > .form-select:focus,
-  > .form-floating:focus-within {
-    z-index: 5;
-  }
-
-  // Ensure buttons are always above inputs for more visually pleasing borders.
-  // This isn't needed for `.input-group-text` since it shares the same border-color
-  // as our inputs.
-  .btn {
+@layer components {
+  .input-group {
     position: relative;
-    z-index: 2;
+    display: flex;
+    flex-wrap: wrap; // For form validation feedback
+    align-items: stretch;
+    width: 100%;
 
-    &:focus {
+    > .form-control,
+    > .form-select,
+    > .form-floating {
+      position: relative; // For focus state's z-index
+      flex: 1 1 auto;
+      width: 1%;
+      min-width: 0; // https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size
+    }
+
+    // Bring the "active" form control to the top of surrounding elements
+    > .form-control:focus,
+    > .form-select:focus,
+    > .form-floating:focus-within {
       z-index: 5;
     }
-  }
-}
 
+    // Ensure buttons are always above inputs for more visually pleasing borders.
+    // This isn't needed for `.input-group-text` since it shares the same border-color
+    // as our inputs.
+    .btn {
+      position: relative;
+      z-index: 2;
 
-// Textual addons
-//
-// Serves as a catch-all element for any text or radio/checkbox input you wish
-// to prepend or append to an input.
-
-.input-group-text {
-  display: flex;
-  align-items: center;
-  padding: $input-group-addon-padding-y $input-group-addon-padding-x;
-  @include font-size($input-font-size); // Match inputs
-  font-weight: $input-group-addon-font-weight;
-  line-height: $input-line-height;
-  color: $input-group-addon-color;
-  text-align: center;
-  white-space: nowrap;
-  background-color: $input-group-addon-bg;
-  border: $input-border-width solid $input-group-addon-border-color;
-  @include border-radius($input-border-radius);
-}
-
-
-// Sizing
-//
-// Remix the default form control sizing classes into new ones for easier
-// manipulation.
-
-.input-group-lg > .form-control,
-.input-group-lg > .form-select,
-.input-group-lg > .input-group-text,
-.input-group-lg > .btn {
-  padding: $input-padding-y-lg $input-padding-x-lg;
-  @include font-size($input-font-size-lg);
-  @include border-radius($input-border-radius-lg);
-}
-
-.input-group-sm > .form-control,
-.input-group-sm > .form-select,
-.input-group-sm > .input-group-text,
-.input-group-sm > .btn {
-  padding: $input-padding-y-sm $input-padding-x-sm;
-  @include font-size($input-font-size-sm);
-  @include border-radius($input-border-radius-sm);
-}
-
-.input-group-lg > .form-select,
-.input-group-sm > .form-select {
-  padding-right: $form-select-padding-x + $form-select-indicator-padding;
-}
-
-
-// Rounded corners
-//
-// These rulesets must come after the sizing ones to properly override sm and lg
-// border-radius values when extending. They're more specific than we'd like
-// with the `.input-group >` part, but without it, we cannot override the sizing.
-
-// stylelint-disable-next-line no-duplicate-selectors
-.input-group {
-  &:not(.has-validation) {
-    > :not(:last-child):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating),
-    > .dropdown-toggle:nth-last-child(n + 3),
-    > .form-floating:not(:last-child) > .form-control,
-    > .form-floating:not(:last-child) > .form-select {
-      @include border-end-radius(0);
+      &:focus {
+        z-index: 5;
+      }
     }
   }
 
-  &.has-validation {
-    > :nth-last-child(n + 3):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating),
-    > .dropdown-toggle:nth-last-child(n + 4),
-    > .form-floating:nth-last-child(n + 3) > .form-control,
-    > .form-floating:nth-last-child(n + 3) > .form-select {
-      @include border-end-radius(0);
+  // Textual addons
+  //
+  // Serves as a catch-all element for any text or radio/checkbox input you wish
+  // to prepend or append to an input.
+
+  .input-group-text {
+    display: flex;
+    align-items: center;
+    padding: $input-group-addon-padding-y $input-group-addon-padding-x;
+    @include font-size($input-font-size); // Match inputs
+    font-weight: $input-group-addon-font-weight;
+    line-height: $input-line-height;
+    color: $input-group-addon-color;
+    text-align: center;
+    white-space: nowrap;
+    background-color: $input-group-addon-bg;
+    border: $input-border-width solid $input-group-addon-border-color;
+    @include border-radius($input-border-radius);
+  }
+
+  // Sizing
+  //
+  // Remix the default form control sizing classes into new ones for easier
+  // manipulation.
+
+  .input-group-lg > .form-control,
+  .input-group-lg > .form-select,
+  .input-group-lg > .input-group-text,
+  .input-group-lg > .btn {
+    padding: $input-padding-y-lg $input-padding-x-lg;
+    @include font-size($input-font-size-lg);
+    @include border-radius($input-border-radius-lg);
+  }
+
+  .input-group-sm > .form-control,
+  .input-group-sm > .form-select,
+  .input-group-sm > .input-group-text,
+  .input-group-sm > .btn {
+    padding: $input-padding-y-sm $input-padding-x-sm;
+    @include font-size($input-font-size-sm);
+    @include border-radius($input-border-radius-sm);
+  }
+
+  .input-group-lg > .form-select,
+  .input-group-sm > .form-select {
+    padding-right: $form-select-padding-x + $form-select-indicator-padding;
+  }
+
+  // Rounded corners
+  //
+  // These rulesets must come after the sizing ones to properly override sm and lg
+  // border-radius values when extending. They're more specific than we'd like
+  // with the `.input-group >` part, but without it, we cannot override the sizing.
+
+  // stylelint-disable-next-line no-duplicate-selectors
+  .input-group {
+    &:not(.has-validation) {
+      > :not(:last-child):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating),
+      > .dropdown-toggle:nth-last-child(n + 3),
+      > .form-floating:not(:last-child) > .form-control,
+      > .form-floating:not(:last-child) > .form-select {
+        @include border-end-radius(0);
+      }
     }
-  }
 
-  $validation-messages: "";
-  @each $state in map.keys($form-validation-states) {
-    $validation-messages: $validation-messages + ":not(." + string.unquote($state) + "-tooltip)" + ":not(." + string.unquote($state) + "-feedback)";
-  }
+    &.has-validation {
+      > :nth-last-child(n + 3):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating),
+      > .dropdown-toggle:nth-last-child(n + 4),
+      > .form-floating:nth-last-child(n + 3) > .form-control,
+      > .form-floating:nth-last-child(n + 3) > .form-select {
+        @include border-end-radius(0);
+      }
+    }
 
-  > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
-    margin-left: calc(-1 * #{$input-border-width}); // stylelint-disable-line function-disallowed-list
-    @include border-start-radius(0);
-  }
+    $validation-messages: '';
+    @each $state in map.keys($form-validation-states) {
+      $validation-messages: $validation-messages + ':not(.' + string.unquote($state) + '-tooltip)' + ':not(.' + string.unquote($state) + '-feedback)';
+    }
 
-  > .form-floating:not(:first-child) > .form-control,
-  > .form-floating:not(:first-child) > .form-select {
-    @include border-start-radius(0);
+    > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
+      margin-left: calc(-1 * #{$input-border-width}); // stylelint-disable-line function-disallowed-list
+      @include border-start-radius(0);
+    }
+
+    > .form-floating:not(:first-child) > .form-control,
+    > .form-floating:not(:first-child) > .form-select {
+      @include border-start-radius(0);
+    }
   }
 }

--- a/core/scss/bootstrap/forms/_labels.scss
+++ b/core/scss/bootstrap/forms/_labels.scss
@@ -2,35 +2,37 @@
 // Labels
 //
 
-.form-label {
-  margin-bottom: $form-label-margin-bottom;
-  @include font-size($form-label-font-size);
-  font-style: $form-label-font-style;
-  font-weight: $form-label-font-weight;
-  color: $form-label-color;
-}
+@layer forms {
+  .form-label {
+    margin-bottom: $form-label-margin-bottom;
+    @include font-size($form-label-font-size);
+    font-style: $form-label-font-style;
+    font-weight: $form-label-font-weight;
+    color: $form-label-color;
+  }
 
-// For use with horizontal and inline forms, when you need the label (or legend)
-// text to align with the form controls.
-.col-form-label {
-  padding-top: add($input-padding-y, $input-border-width);
-  padding-bottom: add($input-padding-y, $input-border-width);
-  margin-bottom: 0; // Override the `<legend>` default
-  @include font-size(inherit); // Override the `<legend>` default
-  font-style: $form-label-font-style;
-  font-weight: $form-label-font-weight;
-  line-height: $input-line-height;
-  color: $form-label-color;
-}
+  // For use with horizontal and inline forms, when you need the label (or legend)
+  // text to align with the form controls.
+  .col-form-label {
+    padding-top: add($input-padding-y, $input-border-width);
+    padding-bottom: add($input-padding-y, $input-border-width);
+    margin-bottom: 0; // Override the `<legend>` default
+    @include font-size(inherit); // Override the `<legend>` default
+    font-style: $form-label-font-style;
+    font-weight: $form-label-font-weight;
+    line-height: $input-line-height;
+    color: $form-label-color;
+  }
 
-.col-form-label-lg {
-  padding-top: add($input-padding-y-lg, $input-border-width);
-  padding-bottom: add($input-padding-y-lg, $input-border-width);
-  @include font-size($input-font-size-lg);
-}
+  .col-form-label-lg {
+    padding-top: add($input-padding-y-lg, $input-border-width);
+    padding-bottom: add($input-padding-y-lg, $input-border-width);
+    @include font-size($input-font-size-lg);
+  }
 
-.col-form-label-sm {
-  padding-top: add($input-padding-y-sm, $input-border-width);
-  padding-bottom: add($input-padding-y-sm, $input-border-width);
-  @include font-size($input-font-size-sm);
+  .col-form-label-sm {
+    padding-top: add($input-padding-y-sm, $input-border-width);
+    padding-bottom: add($input-padding-y-sm, $input-border-width);
+    @include font-size($input-font-size-sm);
+  }
 }

--- a/core/scss/bootstrap/forms/_validation.scss
+++ b/core/scss/bootstrap/forms/_validation.scss
@@ -6,7 +6,10 @@
 // server-side validation.
 
 // scss-docs-start form-validation-states-loop
-@each $state, $data in $form-validation-states {
-  @include form-validation-state($state, $data...);
+
+@layer components {
+  @each $state, $data in $form-validation-states {
+    @include form-validation-state($state, $data...);
+  }
+  // scss-docs-end form-validation-states-loop
 }
-// scss-docs-end form-validation-states-loop

--- a/core/scss/bootstrap/utilities/_api.scss
+++ b/core/scss/bootstrap/utilities/_api.scss
@@ -1,50 +1,51 @@
-@use "sass:map";
-@use "sass:meta";
+@use 'sass:map';
+@use 'sass:meta';
 
 // Loop over each breakpoint
-@each $breakpoint in map.keys($grid-breakpoints) {
 
-  // Generate media query if needed
-  @include media-breakpoint-up($breakpoint) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
-
-    // Loop over each utility property
-    @each $key, $utility in $utilities {
-      // The utility can be disabled with `false`, thus check if the utility is a map first
-      // Only proceed if responsive media queries are enabled or if it's the base media query
-      @if meta.type-of($utility) == "map" and (map.get($utility, responsive) or $infix == "") {
-        @include generate-utility($utility, $infix);
-      }
-    }
-  }
-}
-
-// RFS rescaling
-@media (min-width: $rfs-mq-value) {
+@layer utilities {
   @each $breakpoint in map.keys($grid-breakpoints) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    // Generate media query if needed
+    @include media-breakpoint-up($breakpoint) {
+      $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
-    @if (map.get($grid-breakpoints, $breakpoint) < $rfs-breakpoint) {
       // Loop over each utility property
       @each $key, $utility in $utilities {
         // The utility can be disabled with `false`, thus check if the utility is a map first
         // Only proceed if responsive media queries are enabled or if it's the base media query
-        @if meta.type-of($utility) == "map" and map.get($utility, rfs) and (map.get($utility, responsive) or $infix == "") {
-          @include generate-utility($utility, $infix, true);
+        @if meta.type-of($utility) == 'map' and (map.get($utility, responsive) or $infix == '') {
+          @include generate-utility($utility, $infix);
         }
       }
     }
   }
-}
 
+  // RFS rescaling
+  @media (min-width: $rfs-mq-value) {
+    @each $breakpoint in map.keys($grid-breakpoints) {
+      $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
-// Print utilities
-@media print {
-  @each $key, $utility in $utilities {
-    // The utility can be disabled with `false`, thus check if the utility is a map first
-    // Then check if the utility needs print styles
-    @if meta.type-of($utility) == "map" and map.get($utility, print) == true {
-      @include generate-utility($utility, "-print");
+      @if (map.get($grid-breakpoints, $breakpoint) < $rfs-breakpoint) {
+        // Loop over each utility property
+        @each $key, $utility in $utilities {
+          // The utility can be disabled with `false`, thus check if the utility is a map first
+          // Only proceed if responsive media queries are enabled or if it's the base media query
+          @if meta.type-of($utility) == 'map' and map.get($utility, rfs) and (map.get($utility, responsive) or $infix == '') {
+            @include generate-utility($utility, $infix, true);
+          }
+        }
+      }
+    }
+  }
+
+  // Print utilities
+  @media print {
+    @each $key, $utility in $utilities {
+      // The utility can be disabled with `false`, thus check if the utility is a map first
+      // Then check if the utility needs print styles
+      @if meta.type-of($utility) == 'map' and map.get($utility, print) == true {
+        @include generate-utility($utility, '-print');
+      }
     }
   }
 }

--- a/core/scss/helpers/_index.scss
+++ b/core/scss/helpers/_index.scss
@@ -3,142 +3,145 @@
 //
 // Clearfix
 //
-.clearfix {
-  @include clearfix();
-}
 
-//
-// Text truncation
-//
-.text-truncate {
-  @include text-truncate();
-}
+@layer helpers {
+  .clearfix {
+    @include clearfix();
+  }
 
-//
-// Vertical rule
-//
-.vr {
-  display: inline-block;
-  align-self: stretch;
-  width: $vr-border-width;
-  min-height: 1em;
-  background-color: currentcolor;
-  opacity: $hr-opacity;
-}
+  //
+  // Text truncation
+  //
+  .text-truncate {
+    @include text-truncate();
+  }
 
-//
-// Stretched link
-//
-.stretched-link {
-  &::after {
-    position: absolute;
+  //
+  // Vertical rule
+  //
+  .vr {
+    display: inline-block;
+    align-self: stretch;
+    width: $vr-border-width;
+    min-height: 1em;
+    background-color: currentcolor;
+    opacity: $hr-opacity;
+  }
+
+  //
+  // Stretched link
+  //
+  .stretched-link {
+    &::after {
+      position: absolute;
+      top: 0;
+      inset-inline-end: 0;
+      bottom: 0;
+      inset-inline-start: 0;
+      z-index: 1;
+      content: '';
+    }
+  }
+
+  //
+  // Visually hidden
+  //
+  .visually-hidden,
+  .visually-hidden-focusable:not(:focus):not(:focus-within) {
+    @include visually-hidden();
+  }
+
+  //
+  // Stacks
+  //
+  .hstack {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    align-self: stretch;
+  }
+
+  .vstack {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    align-self: stretch;
+  }
+
+  //
+  // Position
+  //
+  // Shorthand
+
+  .fixed-top {
+    position: fixed;
     top: 0;
+    inset-inline-end: 0;
+    inset-inline-start: 0;
+    z-index: $zindex-fixed;
+  }
+
+  .fixed-bottom {
+    position: fixed;
     inset-inline-end: 0;
     bottom: 0;
     inset-inline-start: 0;
-    z-index: 1;
-    content: '';
+    z-index: $zindex-fixed;
   }
-}
 
-//
-// Visually hidden
-//
-.visually-hidden,
-.visually-hidden-focusable:not(:focus):not(:focus-within) {
-  @include visually-hidden();
-}
+  // Responsive sticky top and bottom
+  @each $breakpoint in map.keys($grid-breakpoints) {
+    @include media-breakpoint-up($breakpoint) {
+      $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
-//
-// Stacks
-//
-.hstack {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  align-self: stretch;
-}
+      .sticky#{$infix}-top {
+        position: sticky;
+        top: 0;
+        z-index: $zindex-sticky;
+      }
 
-.vstack {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  align-self: stretch;
-}
-
-//
-// Position
-//
-// Shorthand
-
-.fixed-top {
-  position: fixed;
-  top: 0;
-  inset-inline-end: 0;
-  inset-inline-start: 0;
-  z-index: $zindex-fixed;
-}
-
-.fixed-bottom {
-  position: fixed;
-  inset-inline-end: 0;
-  bottom: 0;
-  inset-inline-start: 0;
-  z-index: $zindex-fixed;
-}
-
-// Responsive sticky top and bottom
-@each $breakpoint in map.keys($grid-breakpoints) {
-  @include media-breakpoint-up($breakpoint) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
-
-    .sticky#{$infix}-top {
-      position: sticky;
-      top: 0;
-      z-index: $zindex-sticky;
-    }
-
-    .sticky#{$infix}-bottom {
-      position: sticky;
-      bottom: 0;
-      z-index: $zindex-sticky;
+      .sticky#{$infix}-bottom {
+        position: sticky;
+        bottom: 0;
+        z-index: $zindex-sticky;
+      }
     }
   }
-}
 
-//
-// Aspect ratio
-//
-.ratio {
-  position: relative;
-  width: 100%;
-
-  &::before {
-    display: block;
-    padding-top: var(--#{$prefix}aspect-ratio);
-    content: '';
-  }
-
-  > * {
-    position: absolute;
-    top: 0;
-    inset-inline-start: 0;
+  //
+  // Aspect ratio
+  //
+  .ratio {
+    position: relative;
     width: 100%;
-    height: 100%;
-  }
-}
 
-@each $key, $ratio in $aspect-ratios {
-  .ratio-#{$key} {
-    --#{$prefix}aspect-ratio: #{$ratio};
-  }
-}
+    &::before {
+      display: block;
+      padding-top: var(--#{$prefix}aspect-ratio);
+      content: '';
+    }
 
-//
-// Focus ring
-//
-.focus-ring:focus {
-  outline: 0;
-  // By default, there is no `--bs-focus-ring-x`, `--bs-focus-ring-y`, or `--bs-focus-ring-blur`, but we provide CSS variables with fallbacks to initial `0` values
-  box-shadow: var(--#{$prefix}focus-ring-x, 0) var(--#{$prefix}focus-ring-y, 0) var(--#{$prefix}focus-ring-blur, 0) var(--#{$prefix}focus-ring-width) var(--#{$prefix}focus-ring-color);
+    > * {
+      position: absolute;
+      top: 0;
+      inset-inline-start: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  @each $key, $ratio in $aspect-ratios {
+    .ratio-#{$key} {
+      --#{$prefix}aspect-ratio: #{$ratio};
+    }
+  }
+
+  //
+  // Focus ring
+  //
+  .focus-ring:focus {
+    outline: 0;
+    // By default, there is no `--bs-focus-ring-x`, `--bs-focus-ring-y`, or `--bs-focus-ring-blur`, but we provide CSS variables with fallbacks to initial `0` values
+    box-shadow: var(--#{$prefix}focus-ring-x, 0) var(--#{$prefix}focus-ring-y, 0) var(--#{$prefix}focus-ring-blur, 0) var(--#{$prefix}focus-ring-width) var(--#{$prefix}focus-ring-color);
+  }
 }

--- a/core/scss/layout/_animations.scss
+++ b/core/scss/layout/_animations.scss
@@ -1,98 +1,100 @@
-@keyframes pulse {
-  0% {
-    transform: scale(1);
+@layer components {
+  @keyframes pulse {
+    0% {
+      transform: scale(1);
+    }
+
+    14% {
+      transform: scale(1.25);
+    }
+
+    28% {
+      transform: scale(1);
+    }
+
+    42% {
+      transform: scale(1.25);
+    }
+
+    70% {
+      transform: scale(1);
+    }
   }
 
-  14% {
-    transform: scale(1.25);
+  @keyframes tada {
+    0% {
+      transform: scale3d(1, 1, 1);
+    }
+
+    10%,
+    5% {
+      transform: scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -5deg);
+    }
+
+    15%,
+    25%,
+    35%,
+    45% {
+      transform: scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 5deg);
+    }
+
+    20%,
+    30%,
+    40% {
+      transform: scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -5deg);
+    }
+
+    50% {
+      transform: scale3d(1, 1, 1);
+    }
   }
 
-  28% {
-    transform: scale(1);
+  @keyframes rotate-360 {
+    from {
+      transform: rotate(0deg);
+    }
+
+    to {
+      transform: rotate(360deg);
+    }
   }
 
-  42% {
-    transform: scale(1.25);
+  @keyframes blink {
+    from {
+      opacity: 0;
+    }
+
+    50% {
+      opacity: 1;
+    }
+
+    to {
+      opacity: 0;
+    }
   }
 
-  70% {
-    transform: scale(1);
-  }
-}
+  @keyframes shake {
+    0% {
+      transform: scaleX(1);
+    }
 
-@keyframes tada {
-  0% {
-    transform: scale3d(1, 1, 1);
-  }
+    20% {
+      transform: scale3d(0.9, 0.9, 0.9) rotate(-5deg);
+    }
 
-  10%,
-  5% {
-    transform: scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -5deg);
-  }
+    50%,
+    70%,
+    90% {
+      transform: scale3d(1.25, 1.25, 1.25) rotate(5deg);
+    }
 
-  15%,
-  25%,
-  35%,
-  45% {
-    transform: scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 5deg);
-  }
+    60%,
+    80% {
+      transform: scale3d(1.25, 1.25, 1.25) rotate(-5deg);
+    }
 
-  20%,
-  30%,
-  40% {
-    transform: scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -5deg);
-  }
-
-  50% {
-    transform: scale3d(1, 1, 1);
-  }
-}
-
-@keyframes rotate-360 {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@keyframes blink {
-  from {
-    opacity: 0;
-  }
-
-  50% {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
-  }
-}
-
-@keyframes shake {
-  0% {
-    transform: scaleX(1);
-  }
-
-  20% {
-    transform: scale3d(0.9, 0.9, 0.9) rotate(-5deg);
-  }
-
-  50%,
-  70%,
-  90% {
-    transform: scale3d(1.25, 1.25, 1.25) rotate(5deg);
-  }
-
-  60%,
-  80% {
-    transform: scale3d(1.25, 1.25, 1.25) rotate(-5deg);
-  }
-
-  to {
-    transform: scaleX(1);
+    to {
+      transform: scaleX(1);
+    }
   }
 }

--- a/core/scss/layout/_core.scss
+++ b/core/scss/layout/_core.scss
@@ -1,76 +1,78 @@
 @use 'sass:map';
 
-html {
-  scrollbar-gutter: stable;
+@layer components {
+  html {
+    scrollbar-gutter: stable;
 
-  @supports not (scrollbar-gutter: stable) {
-    overflow-y: scroll;
-  }
-}
-
-// stylelint-disable property-no-vendor-prefix
-body {
-  letter-spacing: $body-letter-spacing;
-  touch-action: manipulation;
-  text-rendering: optimizeLegibility;
-  font-feature-settings:
-    'liga' 0,
-    'cv03',
-    'cv04',
-    'cv11';
-  position: relative;
-  min-height: 100%;
-  height: 100%;
-  padding: 0;
-
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-
-  @include media-print {
-    background: transparent;
-  }
-}
-
-@include scrollbar;
-
-//
-// Fluid container
-//
-.layout-fluid {
-  .container,
-  [class^='container-'],
-  [class*=' container-'] {
-    max-width: 100%;
-  }
-}
-
-//
-// Boxed container
-//
-.layout-boxed {
-  --#{$prefix}theme-boxed-border-radius: 0;
-  --#{$prefix}theme-boxed-width: #{map.get($container-max-widths, xxl)};
-
-  @include media-breakpoint-up(md) {
-    background: $dark linear-gradient(to right, rgba(#fff, 0.1), transparent) fixed;
-    padding: 1rem;
-    --#{$prefix}theme-boxed-border-radius: #{$border-radius};
+    @supports not (scrollbar-gutter: stable) {
+      overflow-y: scroll;
+    }
   }
 
-  .page {
-    margin: 0 auto;
-    max-width: var(--#{$prefix}theme-boxed-width);
-    @include border-radius(var(--#{$prefix}theme-boxed-border-radius));
-    color: var(--#{$prefix}body-color);
+  // stylelint-disable property-no-vendor-prefix
+  body {
+    letter-spacing: $body-letter-spacing;
+    touch-action: manipulation;
+    text-rendering: optimizeLegibility;
+    font-feature-settings:
+      'liga' 0,
+      'cv03',
+      'cv04',
+      'cv11';
+    position: relative;
+    min-height: 100%;
+    height: 100%;
+    padding: 0;
+
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+
+    @include media-print {
+      background: transparent;
+    }
+  }
+
+  @include scrollbar;
+
+  //
+  // Fluid container
+  //
+  .layout-fluid {
+    .container,
+    [class^='container-'],
+    [class*=' container-'] {
+      max-width: 100%;
+    }
+  }
+
+  //
+  // Boxed container
+  //
+  .layout-boxed {
+    --#{$prefix}theme-boxed-border-radius: 0;
+    --#{$prefix}theme-boxed-width: #{map.get($container-max-widths, xxl)};
 
     @include media-breakpoint-up(md) {
-      border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-      background: var(--#{$prefix}body-bg);
+      background: $dark linear-gradient(to right, rgba(#fff, 0.1), transparent) fixed;
+      padding: 1rem;
+      --#{$prefix}theme-boxed-border-radius: #{$border-radius};
     }
 
-    > .navbar:first-child {
-      border-start-start-radius: var(--#{$prefix}theme-boxed-border-radius);
-      border-start-end-radius: var(--#{$prefix}theme-boxed-border-radius);
+    .page {
+      margin: 0 auto;
+      max-width: var(--#{$prefix}theme-boxed-width);
+      @include border-radius(var(--#{$prefix}theme-boxed-border-radius));
+      color: var(--#{$prefix}body-color);
+
+      @include media-breakpoint-up(md) {
+        border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+        background: var(--#{$prefix}body-bg);
+      }
+
+      > .navbar:first-child {
+        border-start-start-radius: var(--#{$prefix}theme-boxed-border-radius);
+        border-start-end-radius: var(--#{$prefix}theme-boxed-border-radius);
+      }
     }
   }
 }

--- a/core/scss/layout/_footer.scss
+++ b/core/scss/layout/_footer.scss
@@ -1,16 +1,18 @@
-.footer {
-  border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $footer-border-color;
-  background-color: $footer-bg;
-  padding: $footer-padding-y 0;
-  color: $footer-color;
-  margin-top: auto;
+@layer components {
+  .footer {
+    border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $footer-border-color;
+    background-color: $footer-bg;
+    padding: $footer-padding-y 0;
+    color: $footer-color;
+    margin-top: auto;
 
-  @include media-print {
-    display: none;
+    @include media-print {
+      display: none;
+    }
   }
-}
 
-.footer-transparent {
-  background-color: transparent;
-  border-top: 0;
+  .footer-transparent {
+    background-color: transparent;
+    border-top: 0;
+  }
 }

--- a/core/scss/layout/_navbar.scss
+++ b/core/scss/layout/_navbar.scss
@@ -1,395 +1,397 @@
 @use 'sass:map';
 
-@mixin navbar-vertical-nav {
-  .navbar-collapse {
-    flex-direction: column;
-
-    [class^='container'] {
+@layer components {
+  @mixin navbar-vertical-nav {
+    .navbar-collapse {
       flex-direction: column;
-      align-items: stretch;
-      padding: 0;
-    }
 
-    .navbar-nav {
-      margin-inline-start: 0;
-      margin-inline-end: 0;
+      [class^='container'] {
+        flex-direction: column;
+        align-items: stretch;
+        padding: 0;
+      }
 
-      .nav-link {
-        padding: 0.5rem calc(#{$container-padding-x} / 2);
-        justify-content: start;
+      .navbar-nav {
+        margin-inline-start: 0;
+        margin-inline-end: 0;
+
+        .nav-link {
+          padding: 0.5rem calc(#{$container-padding-x} / 2);
+          justify-content: start;
+        }
+      }
+
+      .dropdown-menu-columns {
+        flex-direction: column;
+      }
+
+      .dropdown-menu {
+        padding: 0;
+        background: transparent;
+        position: static;
+        color: inherit;
+        box-shadow: none;
+        border: none;
+        min-width: 0;
+        margin: 0;
+
+        .dropdown-item {
+          min-width: 0;
+          display: flex;
+          width: auto;
+          padding-inline-start: add(calc(#{$container-padding-x} / 2), 1.75rem);
+          color: inherit;
+
+          &.disabled {
+            color: var(--#{$prefix}disabled-color);
+            pointer-events: none;
+            background-color: transparent;
+          }
+
+          &.active,
+          &:active {
+            background: var(--#{$prefix}navbar-active-bg);
+          }
+        }
+
+        .dropdown-menu .dropdown-item {
+          padding-inline-start: add(calc(#{$container-padding-x} / 2), 3.25rem);
+        }
+
+        .dropdown-menu .dropdown-menu .dropdown-item {
+          padding-inline-start: add(calc(#{$container-padding-x} / 2), 4.75rem);
+        }
+      }
+
+      .dropdown-toggle:after {
+        margin-inline-start: auto;
+      }
+
+      .nav-item.active:after {
+        border-bottom-width: 0;
+        border-inline-start-width: 3px;
+        inset-inline-end: auto;
+        top: 0;
+        bottom: 0;
       }
     }
+  }
 
-    .dropdown-menu-columns {
-      flex-direction: column;
+  /**
+  Navbar
+   */
+  .navbar {
+    --#{$prefix}navbar-bg: var(--#{$prefix}bg-surface);
+    --#{$prefix}navbar-border-width: #{$navbar-border-width};
+    --#{$prefix}navbar-active-border-color: #{$navbar-active-border-color};
+    --#{$prefix}navbar-active-bg: #{$navbar-light-active-bg};
+    --#{$prefix}navbar-border-color: #{$navbar-border-color};
+    --#{$prefix}navbar-hover-color: #{$navbar-hover-color};
+    align-items: stretch;
+    min-height: $navbar-height;
+    box-shadow: inset 0 calc(-1 * var(--#{$prefix}navbar-border-width)) 0 0 var(--#{$prefix}navbar-border-color);
+    background: var(--#{$prefix}navbar-bg);
+    color: var(--#{$prefix}navbar-color);
+
+    .navbar-collapse & {
+      flex-grow: 1;
+    }
+
+    &.collapsing {
+      min-height: 0;
     }
 
     .dropdown-menu {
-      padding: 0;
-      background: transparent;
-      position: static;
-      color: inherit;
-      box-shadow: none;
-      border: none;
-      min-width: 0;
-      margin: 0;
+      position: absolute;
+      z-index: $zindex-fixed;
+    }
 
-      .dropdown-item {
-        min-width: 0;
-        display: flex;
-        width: auto;
-        padding-inline-start: add(calc(#{$container-padding-x} / 2), 1.75rem);
-        color: inherit;
+    .navbar-nav {
+      min-height: subtract($navbar-height, 2 * $navbar-padding-y);
 
-        &.disabled {
-          color: var(--#{$prefix}disabled-color);
-          pointer-events: none;
-          background-color: transparent;
-        }
+      .nav-link {
+        position: relative;
+        min-width: 2.5rem;
+        min-height: 2.5rem;
+        justify-content: center;
+        @include border-radius(var(--#{$prefix}border-radius));
 
-        &.active,
-        &:active {
-          background: var(--#{$prefix}navbar-active-bg);
+        .badge {
+          position: absolute;
+          top: 0.5rem;
+          inset-inline-end: 0.5rem;
+          transform: translate(50%, -50%);
         }
       }
-
-      .dropdown-menu .dropdown-item {
-        padding-inline-start: add(calc(#{$container-padding-x} / 2), 3.25rem);
-      }
-
-      .dropdown-menu .dropdown-menu .dropdown-item {
-        padding-inline-start: add(calc(#{$container-padding-x} / 2), 4.75rem);
-      }
-    }
-
-    .dropdown-toggle:after {
-      margin-inline-start: auto;
-    }
-
-    .nav-item.active:after {
-      border-bottom-width: 0;
-      border-inline-start-width: 3px;
-      inset-inline-end: auto;
-      top: 0;
-      bottom: 0;
     }
   }
-}
 
-/**
-Navbar
- */
-.navbar {
-  --#{$prefix}navbar-bg: var(--#{$prefix}bg-surface);
-  --#{$prefix}navbar-border-width: #{$navbar-border-width};
-  --#{$prefix}navbar-active-border-color: #{$navbar-active-border-color};
-  --#{$prefix}navbar-active-bg: #{$navbar-light-active-bg};
-  --#{$prefix}navbar-border-color: #{$navbar-border-color};
-  --#{$prefix}navbar-hover-color: #{$navbar-hover-color};
-  align-items: stretch;
-  min-height: $navbar-height;
-  box-shadow: inset 0 calc(-1 * var(--#{$prefix}navbar-border-width)) 0 0 var(--#{$prefix}navbar-border-color);
-  background: var(--#{$prefix}navbar-bg);
-  color: var(--#{$prefix}navbar-color);
+  .navbar-expand {
+    @each $breakpoint in map.keys($grid-breakpoints) {
+      $next: breakpoint-next($breakpoint, $grid-breakpoints);
+      $infix: breakpoint-infix($next, $grid-breakpoints);
 
-  .navbar-collapse & {
-    flex-grow: 1;
-  }
-
-  &.collapsing {
-    min-height: 0;
-  }
-
-  .dropdown-menu {
-    position: absolute;
-    z-index: $zindex-fixed;
-  }
-
-  .navbar-nav {
-    min-height: subtract($navbar-height, 2 * $navbar-padding-y);
-
-    .nav-link {
-      position: relative;
-      min-width: 2.5rem;
-      min-height: 2.5rem;
-      justify-content: center;
-      @include border-radius(var(--#{$prefix}border-radius));
-
-      .badge {
-        position: absolute;
-        top: 0.5rem;
-        inset-inline-end: 0.5rem;
-        transform: translate(50%, -50%);
-      }
-    }
-  }
-}
-
-.navbar-expand {
-  @each $breakpoint in map.keys($grid-breakpoints) {
-    $next: breakpoint-next($breakpoint, $grid-breakpoints);
-    $infix: breakpoint-infix($next, $grid-breakpoints);
-
-    &#{$infix} {
-      @include media-breakpoint-down(breakpoint-next($breakpoint)) {
-        @include navbar-vertical-nav;
-      }
-
-      @include media-breakpoint-up($next) {
-        .navbar-collapse {
-          width: auto;
-          flex: 1 1 auto;
+      &#{$infix} {
+        @include media-breakpoint-down(breakpoint-next($breakpoint)) {
+          @include navbar-vertical-nav;
         }
 
-        .nav-item.active {
-          position: relative;
-
-          .nav-link {
-            color: var(--#{$prefix}navbar-active-color);
+        @include media-breakpoint-up($next) {
+          .navbar-collapse {
+            width: auto;
+            flex: 1 1 auto;
           }
 
-          &:after {
-            content: '';
-            position: absolute;
-            inset-inline-start: 0;
-            inset-inline-end: 0;
-            bottom: -0.25rem;
-            border: 0 var(--#{$prefix}border-style) var(--#{$prefix}navbar-active-border-color);
-            border-bottom-width: 2px;
+          .nav-item.active {
+            position: relative;
+
+            .nav-link {
+              color: var(--#{$prefix}navbar-active-color);
+            }
+
+            &:after {
+              content: '';
+              position: absolute;
+              inset-inline-start: 0;
+              inset-inline-end: 0;
+              bottom: -0.25rem;
+              border: 0 var(--#{$prefix}border-style) var(--#{$prefix}navbar-active-border-color);
+              border-bottom-width: 2px;
+            }
           }
-        }
 
-        &.navbar-vertical {
-          box-shadow: inset calc(-1 * var(--#{$prefix}navbar-border-width)) 0 0 0 var(--#{$prefix}navbar-border-color);
-
-          &.navbar-right,
-          &.navbar-end {
-            box-shadow: inset calc(1 * var(--#{$prefix}navbar-border-width)) 0 0 0 var(--#{$prefix}navbar-border-color);
-          }
-        }
-
-        &.navbar-vertical {
-          ~ .navbar,
-          ~ .page-wrapper {
-            margin-inline-start: $sidebar-width;
-          }
-        }
-
-        &.navbar-vertical.navbar-right,
-        &.navbar-vertical.navbar-end {
-          ~ .navbar,
-          ~ .page-wrapper {
-            margin-inline-start: 0;
-            margin-inline-end: $sidebar-width;
-          }
-        }
-      }
-    }
-  }
-}
-
-/**
-Navbar brand
- */
-.navbar-brand {
-  display: inline-flex;
-  align-items: center;
-  font-weight: $navbar-brand-font-weight;
-  margin: 0;
-  line-height: 1;
-  gap: $spacer-2;
-}
-
-.navbar-brand-image {
-  height: $navbar-brand-image-height;
-  width: auto;
-}
-
-/**
-Navbar toggler
- */
-.navbar-toggler {
-  border: 0;
-  width: $navbar-brand-image-height;
-  height: $navbar-brand-image-height;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.navbar-toggler-icon {
-  height: 2px;
-  width: 1.25em;
-  background: currentColor;
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-  position: relative;
-  @include transition(top $navbar-toggler-animation-time $navbar-toggler-animation-time, bottom $navbar-toggler-animation-time $navbar-toggler-animation-time, transform $navbar-toggler-animation-time, opacity 0s $navbar-toggler-animation-time);
-
-  &:before,
-  &:after {
-    content: '';
-    display: block;
-    height: inherit;
-    width: inherit;
-    border-radius: inherit;
-    background: inherit;
-    position: absolute;
-    inset-inline-start: 0;
-    @include transition(inherit);
-  }
-
-  &:before {
-    top: -0.45em;
-  }
-
-  &:after {
-    bottom: -0.45em;
-  }
-
-  .navbar-toggler[aria-expanded='true'] & {
-    transform: rotate(45deg);
-    @include transition(top $transition-time, bottom $transition-time, transform $transition-time $transition-time, opacity 0s $transition-time);
-
-    &:before {
-      top: 0;
-      transform: rotate(-90deg);
-    }
-
-    &:after {
-      bottom: 0;
-      opacity: 0;
-    }
-  }
-}
-
-/**
-Navbar transparent
- */
-.navbar-transparent {
-  --#{$prefix}navbar-border-color: transparent !important;
-  background: transparent !important;
-}
-
-/**
-Navbar nav
- */
-.navbar-nav {
-  --#{$prefix}nav-link-hover-bg: #{$navbar-nav-link-hover-bg};
-  --#{$prefix}nav-link-icon-color: #{$nav-link-icon-color};
-  --#{$prefix}nav-link-hover-icon-color: #{$nav-link-hover-icon-color};
-  margin: 0;
-  padding: 0;
-  align-items: stretch;
-
-  .nav-item {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-  }
-}
-
-/**
-Navbar side
- */
-.navbar-side {
-  margin: 0;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-around;
-}
-
-/**
-Navbar vertical
- */
-@if $enable-navbar-vertical {
-  .navbar-vertical {
-    &.navbar-expand {
-      @each $breakpoint in map.keys($grid-breakpoints) {
-        $next: breakpoint-next($breakpoint, $grid-breakpoints);
-        $infix: breakpoint-infix($next, $grid-breakpoints);
-
-        &#{$infix} {
-          @include media-breakpoint-up($next) {
-            width: $sidebar-width;
-            position: fixed;
-            top: 0;
-            inset-inline-start: 0;
-            bottom: 0;
-            z-index: $zindex-fixed;
-            align-items: start;
-            overflow-y: scroll;
-            padding: 0;
-            @include transition(transform $transition-time);
+          &.navbar-vertical {
+            box-shadow: inset calc(-1 * var(--#{$prefix}navbar-border-width)) 0 0 0 var(--#{$prefix}navbar-border-color);
 
             &.navbar-right,
             &.navbar-end {
-              inset-inline-start: auto;
-              inset-inline-end: 0;
+              box-shadow: inset calc(1 * var(--#{$prefix}navbar-border-width)) 0 0 0 var(--#{$prefix}navbar-border-color);
             }
+          }
 
-            .navbar-brand {
-              padding: (($navbar-height - $navbar-brand-image-height) * 0.5) 0;
-              justify-content: center;
+          &.navbar-vertical {
+            ~ .navbar,
+            ~ .page-wrapper {
+              margin-inline-start: $sidebar-width;
             }
+          }
 
-            .navbar-collapse {
-              align-items: stretch;
+          &.navbar-vertical.navbar-right,
+          &.navbar-vertical.navbar-end {
+            ~ .navbar,
+            ~ .page-wrapper {
+              margin-inline-start: 0;
+              margin-inline-end: $sidebar-width;
             }
-
-            .navbar-nav {
-              flex-direction: column;
-              flex-grow: 1;
-              min-height: auto;
-
-              .nav-link {
-                padding-top: 0.5rem;
-                padding-bottom: 0.5rem;
-              }
-            }
-
-            > [class^='container'] {
-              flex-direction: column;
-              align-items: stretch;
-              min-height: 100%;
-              justify-content: start;
-              padding: 0;
-            }
-
-            ~ .page {
-              padding-inline-start: $sidebar-width;
-
-              [class^='container'] {
-                padding-inline-start: 1.5rem;
-                padding-inline-end: 1.5rem;
-              }
-            }
-
-            &.navbar-right ~ .page,
-            &.navbar-end ~ .page {
-              padding-inline-start: 0;
-              padding-inline-end: $sidebar-width;
-            }
-
-            @include navbar-vertical-nav;
           }
         }
       }
     }
   }
-}
 
-.navbar-overlap {
-  &:after {
-    content: '';
-    height: $navbar-overlap-height;
-    position: absolute;
-    top: 100%;
-    inset-inline-start: 0;
-    inset-inline-end: 0;
-    background: inherit;
-    z-index: -1;
-    box-shadow: inherit;
+  /**
+  Navbar brand
+   */
+  .navbar-brand {
+    display: inline-flex;
+    align-items: center;
+    font-weight: $navbar-brand-font-weight;
+    margin: 0;
+    line-height: 1;
+    gap: $spacer-2;
+  }
+
+  .navbar-brand-image {
+    height: $navbar-brand-image-height;
+    width: auto;
+  }
+
+  /**
+  Navbar toggler
+   */
+  .navbar-toggler {
+    border: 0;
+    width: $navbar-brand-image-height;
+    height: $navbar-brand-image-height;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .navbar-toggler-icon {
+    height: 2px;
+    width: 1.25em;
+    background: currentColor;
+    @include border-radius(var(--#{$prefix}border-radius-pill));
+    position: relative;
+    @include transition(top $navbar-toggler-animation-time $navbar-toggler-animation-time, bottom $navbar-toggler-animation-time $navbar-toggler-animation-time, transform $navbar-toggler-animation-time, opacity 0s $navbar-toggler-animation-time);
+
+    &:before,
+    &:after {
+      content: '';
+      display: block;
+      height: inherit;
+      width: inherit;
+      border-radius: inherit;
+      background: inherit;
+      position: absolute;
+      inset-inline-start: 0;
+      @include transition(inherit);
+    }
+
+    &:before {
+      top: -0.45em;
+    }
+
+    &:after {
+      bottom: -0.45em;
+    }
+
+    .navbar-toggler[aria-expanded='true'] & {
+      transform: rotate(45deg);
+      @include transition(top $transition-time, bottom $transition-time, transform $transition-time $transition-time, opacity 0s $transition-time);
+
+      &:before {
+        top: 0;
+        transform: rotate(-90deg);
+      }
+
+      &:after {
+        bottom: 0;
+        opacity: 0;
+      }
+    }
+  }
+
+  /**
+  Navbar transparent
+   */
+  .navbar-transparent {
+    --#{$prefix}navbar-border-color: transparent !important;
+    background: transparent !important;
+  }
+
+  /**
+  Navbar nav
+   */
+  .navbar-nav {
+    --#{$prefix}nav-link-hover-bg: #{$navbar-nav-link-hover-bg};
+    --#{$prefix}nav-link-icon-color: #{$nav-link-icon-color};
+    --#{$prefix}nav-link-hover-icon-color: #{$nav-link-hover-icon-color};
+    margin: 0;
+    padding: 0;
+    align-items: stretch;
+
+    .nav-item {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+  }
+
+  /**
+  Navbar side
+   */
+  .navbar-side {
+    margin: 0;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-around;
+  }
+
+  /**
+  Navbar vertical
+   */
+  @if $enable-navbar-vertical {
+    .navbar-vertical {
+      &.navbar-expand {
+        @each $breakpoint in map.keys($grid-breakpoints) {
+          $next: breakpoint-next($breakpoint, $grid-breakpoints);
+          $infix: breakpoint-infix($next, $grid-breakpoints);
+
+          &#{$infix} {
+            @include media-breakpoint-up($next) {
+              width: $sidebar-width;
+              position: fixed;
+              top: 0;
+              inset-inline-start: 0;
+              bottom: 0;
+              z-index: $zindex-fixed;
+              align-items: start;
+              overflow-y: scroll;
+              padding: 0;
+              @include transition(transform $transition-time);
+
+              &.navbar-right,
+              &.navbar-end {
+                inset-inline-start: auto;
+                inset-inline-end: 0;
+              }
+
+              .navbar-brand {
+                padding: (($navbar-height - $navbar-brand-image-height) * 0.5) 0;
+                justify-content: center;
+              }
+
+              .navbar-collapse {
+                align-items: stretch;
+              }
+
+              .navbar-nav {
+                flex-direction: column;
+                flex-grow: 1;
+                min-height: auto;
+
+                .nav-link {
+                  padding-top: 0.5rem;
+                  padding-bottom: 0.5rem;
+                }
+              }
+
+              > [class^='container'] {
+                flex-direction: column;
+                align-items: stretch;
+                min-height: 100%;
+                justify-content: start;
+                padding: 0;
+              }
+
+              ~ .page {
+                padding-inline-start: $sidebar-width;
+
+                [class^='container'] {
+                  padding-inline-start: 1.5rem;
+                  padding-inline-end: 1.5rem;
+                }
+              }
+
+              &.navbar-right ~ .page,
+              &.navbar-end ~ .page {
+                padding-inline-start: 0;
+                padding-inline-end: $sidebar-width;
+              }
+
+              @include navbar-vertical-nav;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  .navbar-overlap {
+    &:after {
+      content: '';
+      height: $navbar-overlap-height;
+      position: absolute;
+      top: 100%;
+      inset-inline-start: 0;
+      inset-inline-end: 0;
+      background: inherit;
+      z-index: -1;
+      box-shadow: inherit;
+    }
   }
 }

--- a/core/scss/layout/_page.scss
+++ b/core/scss/layout/_page.scss
@@ -1,169 +1,171 @@
-.page {
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  min-height: 100%;
-}
+@layer components {
+  .page {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    min-height: 100%;
+  }
 
-.page-center {
-  justify-content: center;
-}
+  .page-center {
+    justify-content: center;
+  }
 
-.page-wrapper {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
+  .page-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
 
-  @include media-print {
+    @include media-print {
+      margin: 0 !important;
+    }
+  }
+
+  .page-wrapper-full {
+    .page-body:first-child {
+      margin: 0;
+      border-top: 0;
+    }
+  }
+
+  // Content body
+  .page-body {
+    margin-top: var(--#{$prefix}page-padding-y);
+    margin-bottom: var(--#{$prefix}page-padding-y);
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+
+  .page-body-card {
+    background: var(--#{$prefix}bg-surface);
+    border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $card-border-color;
+    padding: var(--#{$prefix}page-padding) 0;
+    margin-bottom: 0;
+    flex: 1;
+
+    .page-body ~ & {
+      margin-top: 0;
+    }
+  }
+
+  .page-cover {
+    background: no-repeat center/cover;
+    min-height: 9rem;
+
+    @include media-breakpoint-up(md) {
+      min-height: 12rem;
+    }
+
+    @include media-breakpoint-up(lg) {
+      min-height: 15rem;
+    }
+  }
+
+  .page-cover-overlay {
+    position: relative;
+
+    &:after {
+      content: '';
+      position: absolute;
+      top: 0;
+      inset-inline-start: 0;
+      inset-inline-end: 0;
+      bottom: 0;
+      background-image: $overlay-gradient;
+    }
+  }
+
+  .page-header {
+    display: flex;
+    flex-wrap: wrap;
+    min-height: 2.25rem;
+    flex-direction: column;
+    justify-content: center;
+    max-width: 100%;
+
+    .page-wrapper & {
+      margin: var(--#{$prefix}page-padding-y) 0 0;
+    }
+  }
+
+  .page-header-border {
+    border-bottom: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+    padding: var(--#{$prefix}page-padding-y) 0;
     margin: 0 !important;
+    background-color: var(--#{$prefix}bg-surface);
   }
-}
 
-.page-wrapper-full {
-  .page-body:first-child {
+  .page-pretitle {
+    @include subheader;
+  }
+
+  .page-title {
     margin: 0;
-    border-top: 0;
-  }
-}
+    font-size: $page-title-font-size;
+    line-height: $page-title-line-height;
+    font-weight: $page-title-font-weight;
+    color: inherit;
+    display: flex;
+    align-items: center;
 
-// Content body
-.page-body {
-  margin-top: var(--#{$prefix}page-padding-y);
-  margin-bottom: var(--#{$prefix}page-padding-y);
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-}
-
-.page-body-card {
-  background: var(--#{$prefix}bg-surface);
-  border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $card-border-color;
-  padding: var(--#{$prefix}page-padding) 0;
-  margin-bottom: 0;
-  flex: 1;
-
-  .page-body ~ & {
-    margin-top: 0;
-  }
-}
-
-.page-cover {
-  background: no-repeat center/cover;
-  min-height: 9rem;
-
-  @include media-breakpoint-up(md) {
-    min-height: 12rem;
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+      margin-inline-end: 0.25rem;
+    }
   }
 
-  @include media-breakpoint-up(lg) {
-    min-height: 15rem;
+  .page-title-lg {
+    font-size: $h1-font-size;
+    line-height: $h1-line-height;
   }
-}
 
-.page-cover-overlay {
-  position: relative;
+  .page-subtitle {
+    margin-top: 0.25rem;
+    color: var(--#{$prefix}secondary);
+  }
 
-  &:after {
-    content: '';
+  //
+  // Page cover
+  //
+  .page-cover {
+    --#{$prefix}page-cover-blur: 20px;
+    --#{$prefix}page-cover-padding: 1rem;
+    min-height: 6rem;
+    padding: var(--#{$prefix}page-cover-padding) 0;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .page-cover-img {
     position: absolute;
-    top: 0;
-    inset-inline-start: 0;
-    inset-inline-end: 0;
-    bottom: 0;
-    background-image: $overlay-gradient;
-  }
-}
-
-.page-header {
-  display: flex;
-  flex-wrap: wrap;
-  min-height: 2.25rem;
-  flex-direction: column;
-  justify-content: center;
-  max-width: 100%;
-
-  .page-wrapper & {
-    margin: var(--#{$prefix}page-padding-y) 0 0;
-  }
-}
-
-.page-header-border {
-  border-bottom: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-  padding: var(--#{$prefix}page-padding-y) 0;
-  margin: 0 !important;
-  background-color: var(--#{$prefix}bg-surface);
-}
-
-.page-pretitle {
-  @include subheader;
-}
-
-.page-title {
-  margin: 0;
-  font-size: $page-title-font-size;
-  line-height: $page-title-line-height;
-  font-weight: $page-title-font-weight;
-  color: inherit;
-  display: flex;
-  align-items: center;
-
-  svg {
-    width: 1.5rem;
-    height: 1.5rem;
-    margin-inline-end: 0.25rem;
-  }
-}
-
-.page-title-lg {
-  font-size: $h1-font-size;
-  line-height: $h1-line-height;
-}
-
-.page-subtitle {
-  margin-top: 0.25rem;
-  color: var(--#{$prefix}secondary);
-}
-
-//
-// Page cover
-//
-.page-cover {
-  --#{$prefix}page-cover-blur: 20px;
-  --#{$prefix}page-cover-padding: 1rem;
-  min-height: 6rem;
-  padding: var(--#{$prefix}page-cover-padding) 0;
-  position: relative;
-  overflow: hidden;
-}
-
-.page-cover-img {
-  position: absolute;
-  top: calc(-2 * var(--#{$prefix}page-cover-blur, 0));
-  inset-inline-start: calc(-2 * var(--#{$prefix}page-cover-blur, 0));
-  inset-inline-end: calc(-2 * var(--#{$prefix}page-cover-blur, 0));
-  bottom: calc(-2 * var(--#{$prefix}page-cover-blur, 0));
-  pointer-events: none;
-  filter: blur(var(--#{$prefix}page-cover-blur));
-  object-fit: cover;
-  background-size: cover;
-  background-position: center;
-  z-index: -1;
-}
-
-//
-// Page tabs
-//
-.page-tabs {
-  margin-top: 0.5rem;
-  position: relative;
-}
-
-.page-header-tabs {
-  .nav-bordered {
-    border: 0;
+    top: calc(-2 * var(--#{$prefix}page-cover-blur, 0));
+    inset-inline-start: calc(-2 * var(--#{$prefix}page-cover-blur, 0));
+    inset-inline-end: calc(-2 * var(--#{$prefix}page-cover-blur, 0));
+    bottom: calc(-2 * var(--#{$prefix}page-cover-blur, 0));
+    pointer-events: none;
+    filter: blur(var(--#{$prefix}page-cover-blur));
+    object-fit: cover;
+    background-size: cover;
+    background-position: center;
+    z-index: -1;
   }
 
-  + .page-body-card {
-    margin-top: 0;
+  //
+  // Page tabs
+  //
+  .page-tabs {
+    margin-top: 0.5rem;
+    position: relative;
+  }
+
+  .page-header-tabs {
+    .nav-bordered {
+      border: 0;
+    }
+
+    + .page-body-card {
+      margin-top: 0;
+    }
   }
 }

--- a/core/scss/marketing/_browser.scss
+++ b/core/scss/marketing/_browser.scss
@@ -1,69 +1,72 @@
 //
 // Browser
 //
-.browser {
-  @include border-radius(var(--#{$prefix}border-radius-lg));
-  box-shadow: 0 0 0 1px var(--#{$prefix}border-color);
-  background: var(--#{$prefix}bg-surface-secondary);
-  overflow: hidden;
-}
 
-.browser-header {
-  padding: 0.25rem 1rem;
-  background: var(--#{$prefix}border-color-light) linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.03));
-  border-bottom: 1px solid var(--#{$prefix}border-color);
-  @include border-radius(calc(var(--#{$prefix}border-radius-lg) - 1px) calc(var(--#{$prefix}border-radius-lg) - 1px) 0 0);
-}
+@layer components {
+  .browser {
+    @include border-radius(var(--#{$prefix}border-radius-lg));
+    box-shadow: 0 0 0 1px var(--#{$prefix}border-color);
+    background: var(--#{$prefix}bg-surface-secondary);
+    overflow: hidden;
+  }
 
-.browser-dots {
-  margin-inline-end: 3rem;
-  display: flex;
-}
+  .browser-header {
+    padding: 0.25rem 1rem;
+    background: var(--#{$prefix}border-color-light) linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.03));
+    border-bottom: 1px solid var(--#{$prefix}border-color);
+    @include border-radius(calc(var(--#{$prefix}border-radius-lg) - 1px) calc(var(--#{$prefix}border-radius-lg) - 1px) 0 0);
+  }
 
-.browser-dots-colored {
-  .browser-dot {
-    &:nth-child(1) {
-      background: #fb6058;
-    }
+  .browser-dots {
+    margin-inline-end: 3rem;
+    display: flex;
+  }
 
-    &:nth-child(2) {
-      background: #fcbe3b;
-    }
+  .browser-dots-colored {
+    .browser-dot {
+      &:nth-child(1) {
+        background: #fb6058;
+      }
 
-    &:nth-child(3) {
-      background: #2ccb4c;
+      &:nth-child(2) {
+        background: #fcbe3b;
+      }
+
+      &:nth-child(3) {
+        background: #2ccb4c;
+      }
     }
   }
-}
 
-.browser-dot {
-  margin-inline-end: 0.5rem;
-  width: 0.75rem;
-  min-width: 0.75rem;
-  height: 0.75rem;
-  background: var(--#{$prefix}border-color);
-  @include border-radius(var(--#{$prefix}border-radius-circle));
-  border: 1px solid var(--#{$prefix}border-color-dark);
-}
+  .browser-dot {
+    margin-inline-end: 0.5rem;
+    width: 0.75rem;
+    min-width: 0.75rem;
+    height: 0.75rem;
+    background: var(--#{$prefix}border-color);
+    @include border-radius(var(--#{$prefix}border-radius-circle));
+    border: 1px solid var(--#{$prefix}border-color-dark);
+  }
 
-.browser-input {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-decoration: none;
-  padding: 0.25rem;
-  color: var(--#{$prefix}secondary);
-  font-size: var(--#{$prefix}font-size-h5);
-  @include border-radius(var(--#{$prefix}border-radius));
-  line-height: 1;
-  cursor: pointer;
-  box-shadow:
-    0 0 0 1px rgba(0, 0, 0, 0.05),
-    0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  background-image: linear-gradient(to bottom, var(--#{$prefix}bg-surface), var(--#{$prefix}bg-surface-secondary));
-
-  &:hover {
+  .browser-input {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     text-decoration: none;
+    padding: 0.25rem;
+    color: var(--#{$prefix}secondary);
+    font-size: var(--#{$prefix}font-size-h5);
+    @include border-radius(var(--#{$prefix}border-radius));
+    line-height: 1;
+    cursor: pointer;
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 0, 0.05),
+      0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    background-image: linear-gradient(to bottom, var(--#{$prefix}bg-surface), var(--#{$prefix}bg-surface-secondary));
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 }

--- a/core/scss/marketing/_core.scss
+++ b/core/scss/marketing/_core.scss
@@ -1,8 +1,10 @@
-.body-marketing {
-  --#{$prefix}body-font-size: 1rem;
-  --#{$prefix}body-line-height: 1.75;
-}
+@layer components {
+  .body-marketing {
+    --#{$prefix}body-font-size: 1rem;
+    --#{$prefix}body-line-height: 1.75;
+  }
 
-.body-gradient {
-  background: var(--#{$prefix}bg-surface) linear-gradient(to bottom, var(--#{$prefix}bg-surface-secondary) 12%, var(--#{$prefix}bg-surface) 99%) repeat-x top center/100% 100vh;
+  .body-gradient {
+    background: var(--#{$prefix}bg-surface) linear-gradient(to bottom, var(--#{$prefix}bg-surface-secondary) 12%, var(--#{$prefix}bg-surface) 99%) repeat-x top center/100% 100vh;
+  }
 }

--- a/core/scss/marketing/_hero.scss
+++ b/core/scss/marketing/_hero.scss
@@ -1,69 +1,72 @@
 //
 // Hero
 //
-.hero {
-  text-align: center;
-  padding: 6.5rem 0;
-}
 
-.hero-title {
-  font-size: 3rem;
-  font-weight: var(--#{$prefix}font-weight-black);
-  letter-spacing: $spacing-tight;
-  line-height: $headings-line-height;
-
-  @include media-breakpoint-down(md) {
-    font-size: 2rem;
+@layer components {
+  .hero {
+    text-align: center;
+    padding: 6.5rem 0;
   }
-}
 
-.hero-description {
-  color: var(--#{$prefix}secondary);
-  font-size: var(--#{$prefix}font-size-h2);
-  line-height: 1.5;
-  margin: 0 auto;
-  max-width: 45rem;
+  .hero-title {
+    font-size: 3rem;
+    font-weight: var(--#{$prefix}font-weight-black);
+    letter-spacing: $spacing-tight;
+    line-height: $headings-line-height;
 
-  @include media-breakpoint-down(sm) {
-    font-size: var(--#{$prefix}font-size-h3);
+    @include media-breakpoint-down(md) {
+      font-size: 2rem;
+    }
   }
-}
 
-.hero-description-wide {
-  max-width: 61.875rem;
-}
+  .hero-description {
+    color: var(--#{$prefix}secondary);
+    font-size: var(--#{$prefix}font-size-h2);
+    line-height: 1.5;
+    margin: 0 auto;
+    max-width: 45rem;
 
-//
-// Hero subheader
-//
-.hero-subheader {
-  @include subheader;
-  margin-bottom: 0.5rem;
-}
+    @include media-breakpoint-down(sm) {
+      font-size: var(--#{$prefix}font-size-h3);
+    }
+  }
 
-.hero-img {
-  margin: 4rem auto;
-  max-width: 65rem;
-  @include border-radius($border-radius-lg);
-  position: relative;
-  z-index: 1;
-  //box-shadow: 0 10px 15px -3px rgba($color-text, 0.1),
-  //  0 4px 6px -2px rgba($color-text, 0.05);
+  .hero-description-wide {
+    max-width: 61.875rem;
+  }
 
-  img,
-  svg {
-    max-width: 100%;
-    height: auto;
-    display: block;
+  //
+  // Hero subheader
+  //
+  .hero-subheader {
+    @include subheader;
+    margin-bottom: 0.5rem;
+  }
+
+  .hero-img {
+    margin: 4rem auto;
+    max-width: 65rem;
+    @include border-radius($border-radius-lg);
     position: relative;
+    z-index: 1;
+    //box-shadow: 0 10px 15px -3px rgba($color-text, 0.1),
+    //  0 4px 6px -2px rgba($color-text, 0.05);
+
+    img,
+    svg {
+      max-width: 100%;
+      height: auto;
+      display: block;
+      position: relative;
+    }
   }
+  //
+  //.hero-img-side {
+  //  img,
+  //  svg {
+  //    max-width: 100%;
+  //    height: auto;
+  //    display: block;
+  //  }
+  //}
 }
-//
-//.hero-img-side {
-//  img,
-//  svg {
-//    max-width: 100%;
-//    height: auto;
-//    display: block;
-//  }
-//}

--- a/core/scss/marketing/_pricing.scss
+++ b/core/scss/marketing/_pricing.scss
@@ -1,111 +1,113 @@
 $pricing-card-width: 22rem;
 
-.pricing {
-  display: flex;
-  flex-direction: column;
-  margin: 0 auto;
-  justify-content: center;
-
-  @include media-breakpoint-up(md) {
-    flex-direction: row;
-  }
-}
-
-.pricing-card {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  background: var(--#{$prefix}bg-surface);
-  border: 1px solid $border-color;
-  padding: 2rem;
-  margin: 0 0 1rem;
-  position: relative;
-  box-shadow: var(--#{$prefix}shadow-card);
-  text-align: center;
-  @include border-radius($border-radius-lg);
-
-  @include media-breakpoint-up(md) {
-    margin: 1rem -1px;
-    max-width: $pricing-card-width;
-
-    &:first-child {
-      @include border-radius($border-radius-lg 0 0 $border-radius-lg);
-    }
-
-    &:last-child {
-      @include border-radius(0 $border-radius-lg $border-radius-lg 0);
-    }
-  }
-
-  &.featured {
-    z-index: 1;
-    border: 2px solid var(--#{$prefix}primary);
-    order: -1;
+@layer components {
+  .pricing {
+    display: flex;
+    flex-direction: column;
+    margin: 0 auto;
+    justify-content: center;
 
     @include media-breakpoint-up(md) {
-      order: unset;
-      margin-top: 0;
-      margin-bottom: 0;
-      box-shadow: var(--#{$prefix}shadow-card);
-      @include border-radius($border-radius-lg);
+      flex-direction: row;
     }
   }
-}
 
-.pricing-title {
-  font-size: $h2-font-size;
-  line-height: $h2-line-height;
-}
+  .pricing-card {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background: var(--#{$prefix}bg-surface);
+    border: 1px solid $border-color;
+    padding: 2rem;
+    margin: 0 0 1rem;
+    position: relative;
+    box-shadow: var(--#{$prefix}shadow-card);
+    text-align: center;
+    @include border-radius($border-radius-lg);
 
-.pricing-label {
-  position: absolute;
-  top: 0;
-  inset-inline-start: 0;
-  transform: translateY(-50%);
-  vertical-align: bottom;
-  inset-inline-end: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
+    @include media-breakpoint-up(md) {
+      margin: 1rem -1px;
+      max-width: $pricing-card-width;
 
-.pricing-btn {
-  margin-top: auto;
-  padding-top: 2rem;
-}
+      &:first-child {
+        @include border-radius($border-radius-lg 0 0 $border-radius-lg);
+      }
 
-.pricing-price {
-  display: flex;
-  justify-content: center;
-  font-size: 2.5rem;
-  line-height: 1;
-  font-weight: $font-weight-semibold;
-  margin: 0.75rem 0;
-}
+      &:last-child {
+        @include border-radius(0 $border-radius-lg $border-radius-lg 0);
+      }
+    }
 
-.pricing-price-currency {
-  font-size: $h2-font-size;
-  line-height: 1.5;
-  margin-inline-end: 0.25rem;
-  font-weight: $font-weight-semibold;
-}
+    &.featured {
+      z-index: 1;
+      border: 2px solid var(--#{$prefix}primary);
+      order: -1;
 
-.pricing-price-description {
-  font-size: $h4-font-size;
-  line-height: $h4-line-height;
-  font-weight: $font-weight-normal;
-  color: $text-secondary;
-  align-self: center;
-  margin-inline-start: 0.5rem;
-}
+      @include media-breakpoint-up(md) {
+        order: unset;
+        margin-top: 0;
+        margin-bottom: 0;
+        box-shadow: var(--#{$prefix}shadow-card);
+        @include border-radius($border-radius-lg);
+      }
+    }
+  }
 
-.pricing-features {
-  margin: 1rem 0 0;
-  padding: 0;
-  list-style: none;
-  text-align: start;
+  .pricing-title {
+    font-size: $h2-font-size;
+    line-height: $h2-line-height;
+  }
 
-  > li:not(:first-child) {
-    margin-top: 0.25rem;
+  .pricing-label {
+    position: absolute;
+    top: 0;
+    inset-inline-start: 0;
+    transform: translateY(-50%);
+    vertical-align: bottom;
+    inset-inline-end: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .pricing-btn {
+    margin-top: auto;
+    padding-top: 2rem;
+  }
+
+  .pricing-price {
+    display: flex;
+    justify-content: center;
+    font-size: 2.5rem;
+    line-height: 1;
+    font-weight: $font-weight-semibold;
+    margin: 0.75rem 0;
+  }
+
+  .pricing-price-currency {
+    font-size: $h2-font-size;
+    line-height: 1.5;
+    margin-inline-end: 0.25rem;
+    font-weight: $font-weight-semibold;
+  }
+
+  .pricing-price-description {
+    font-size: $h4-font-size;
+    line-height: $h4-line-height;
+    font-weight: $font-weight-normal;
+    color: $text-secondary;
+    align-self: center;
+    margin-inline-start: 0.5rem;
+  }
+
+  .pricing-features {
+    margin: 1rem 0 0;
+    padding: 0;
+    list-style: none;
+    text-align: start;
+
+    > li:not(:first-child) {
+      margin-top: 0.25rem;
+    }
   }
 }

--- a/core/scss/marketing/_sections.scss
+++ b/core/scss/marketing/_sections.scss
@@ -1,124 +1,126 @@
-@keyframes move-forever1 {
-  0% {
-    transform: translate(85px, 0%);
+@layer components {
+  @keyframes move-forever1 {
+    0% {
+      transform: translate(85px, 0%);
+    }
+
+    100% {
+      transform: translate(-90px, 0%);
+    }
   }
 
-  100% {
-    transform: translate(-90px, 0%);
-  }
-}
+  @keyframes move-forever2 {
+    0% {
+      transform: translate(-90px, 0%);
+    }
 
-@keyframes move-forever2 {
-  0% {
-    transform: translate(-90px, 0%);
-  }
-
-  100% {
-    transform: translate(85px, 0%);
-  }
-}
-
-@keyframes move-forever3 {
-  0% {
-    transform: translate(-90px, 0%);
+    100% {
+      transform: translate(85px, 0%);
+    }
   }
 
-  100% {
-    transform: translate(85px, 0%);
-  }
-}
+  @keyframes move-forever3 {
+    0% {
+      transform: translate(-90px, 0%);
+    }
 
-//
-// Sections
-//
-.section {
-  --section-bg: transparent;
-  background: var(--section-bg);
-  position: relative;
-  padding: 5rem 0;
-}
-
-.section-sm {
-  padding: 4rem 0;
-}
-
-.section-white {
-  --section-bg: var(--#{$prefix}bg-surface);
-}
-
-.section-light {
-  --section-bg: var(--#{$prefix}bg-surface-secondary);
-}
-
-.section-primary {
-  --section-bg: var(--#{$prefix}primary);
-  color: $white;
-}
-
-.section-dark {
-  --section-bg: var(--#{$prefix}dark);
-  color: $white;
-}
-
-.section-header {
-  text-align: center;
-  max-width: 45rem;
-  margin: 0 auto 5rem;
-
-  @at-root .section-sm & {
-    margin-bottom: 4rem;
-  }
-}
-
-.section-title {
-  font-size: var(--#{$prefix}font-size-h1);
-  font-weight: var(--#{$prefix}font-weight-semibold);
-  line-height: 1.2;
-}
-
-.section-title-lg {
-  font-size: 2rem;
-}
-
-.section-description {
-  color: var(--#{$prefix}secondary);
-  font-size: var(--#{$prefix}font-size-h3);
-  line-height: var(--#{$prefix}line-height-h3);
-  margin-top: 1rem;
-}
-
-//
-// Section divider
-//
-.section-divider {
-  position: absolute;
-  bottom: 100%;
-  pointer-events: none;
-  height: 5rem;
-  width: 100%;
-
-  path {
-    fill: var(--section-bg);
+    100% {
+      transform: translate(85px, 0%);
+    }
   }
 
-  .wave-1 {
-    animation: move-forever1 30s linear infinite;
-    animation-delay: -2s;
+  //
+  // Sections
+  //
+  .section {
+    --section-bg: transparent;
+    background: var(--section-bg);
+    position: relative;
+    padding: 5rem 0;
   }
 
-  .wave-2 {
-    animation: move-forever2 24s linear infinite;
-    opacity: 0.5;
-    animation-delay: -2s;
+  .section-sm {
+    padding: 4rem 0;
   }
 
-  .wave-3 {
-    animation: move-forever3 18s linear infinite;
-    opacity: 0.3;
-    animation-delay: -2s;
+  .section-white {
+    --section-bg: var(--#{$prefix}bg-surface);
   }
-}
 
-.section-divider-auto {
-  height: auto;
+  .section-light {
+    --section-bg: var(--#{$prefix}bg-surface-secondary);
+  }
+
+  .section-primary {
+    --section-bg: var(--#{$prefix}primary);
+    color: $white;
+  }
+
+  .section-dark {
+    --section-bg: var(--#{$prefix}dark);
+    color: $white;
+  }
+
+  .section-header {
+    text-align: center;
+    max-width: 45rem;
+    margin: 0 auto 5rem;
+
+    @at-root .section-sm & {
+      margin-bottom: 4rem;
+    }
+  }
+
+  .section-title {
+    font-size: var(--#{$prefix}font-size-h1);
+    font-weight: var(--#{$prefix}font-weight-semibold);
+    line-height: 1.2;
+  }
+
+  .section-title-lg {
+    font-size: 2rem;
+  }
+
+  .section-description {
+    color: var(--#{$prefix}secondary);
+    font-size: var(--#{$prefix}font-size-h3);
+    line-height: var(--#{$prefix}line-height-h3);
+    margin-top: 1rem;
+  }
+
+  //
+  // Section divider
+  //
+  .section-divider {
+    position: absolute;
+    bottom: 100%;
+    pointer-events: none;
+    height: 5rem;
+    width: 100%;
+
+    path {
+      fill: var(--section-bg);
+    }
+
+    .wave-1 {
+      animation: move-forever1 30s linear infinite;
+      animation-delay: -2s;
+    }
+
+    .wave-2 {
+      animation: move-forever2 24s linear infinite;
+      opacity: 0.5;
+      animation-delay: -2s;
+    }
+
+    .wave-3 {
+      animation: move-forever3 18s linear infinite;
+      opacity: 0.3;
+      animation-delay: -2s;
+    }
+  }
+
+  .section-divider-auto {
+    height: auto;
+  }
 }

--- a/core/scss/marketing/_shape.scss
+++ b/core/scss/marketing/_shape.scss
@@ -1,34 +1,36 @@
 @use 'sass:map';
 
-.shape {
-  --#{$prefix}shape-size: #{$avatar-size};
-  --#{$prefix}shape-icon-size: #{$avatar-icon-size};
-  --#{$prefix}shape-border-radius: 35%;
-  background-color: var(--#{$prefix}primary-lt);
-  color: var(--#{$prefix}primary);
-  @include border-radius(var(--#{$prefix}shape-border-radius));
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: var(--#{$prefix}shape-size);
-  width: var(--#{$prefix}shape-size);
+@layer components {
+  .shape {
+    --#{$prefix}shape-size: #{$avatar-size};
+    --#{$prefix}shape-icon-size: #{$avatar-icon-size};
+    --#{$prefix}shape-border-radius: 35%;
+    background-color: var(--#{$prefix}primary-lt);
+    color: var(--#{$prefix}primary);
+    @include border-radius(var(--#{$prefix}shape-border-radius));
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: var(--#{$prefix}shape-size);
+    width: var(--#{$prefix}shape-size);
 
-  .icon {
-    width: var(--#{$prefix}shape-icon-size);
-    height: var(--#{$prefix}shape-icon-size);
+    .icon {
+      width: var(--#{$prefix}shape-icon-size);
+      height: var(--#{$prefix}shape-icon-size);
+    }
   }
-}
 
-@each $avatar-size, $size in $avatar-sizes {
-  .shape-#{$avatar-size} {
-    --#{$prefix}shape-size: #{map.get($size, size)};
-    --#{$prefix}shape-icon-size: #{map.get($size, icon-size)};
+  @each $avatar-size, $size in $avatar-sizes {
+    .shape-#{$avatar-size} {
+      --#{$prefix}shape-size: #{map.get($size, size)};
+      --#{$prefix}shape-icon-size: #{map.get($size, icon-size)};
+    }
   }
-}
 
-@each $name, $color in $colors {
-  .shape-#{$name} {
-    background: var(--#{$prefix}#{$name}-lt);
-    color: var(--#{$prefix}#{$name});
+  @each $name, $color in $colors {
+    .shape-#{$name} {
+      background: var(--#{$prefix}#{$name}-lt);
+      color: var(--#{$prefix}#{$name});
+    }
   }
 }

--- a/core/scss/tabler-marketing.scss
+++ b/core/scss/tabler-marketing.scss
@@ -1,4 +1,5 @@
 @import 'config';
+@import 'layers';
 @import 'utilities-marketing';
 
 @import 'marketing/core';

--- a/core/scss/ui/_accordion.scss
+++ b/core/scss/ui/_accordion.scss
@@ -1,177 +1,179 @@
-.accordion {
-  --#{$prefix}accordion-color: var(--#{$prefix}body-color);
-  --#{$prefix}accordion-border-color: var(--#{$prefix}border-color);
-  --#{$prefix}accordion-border-radius: #{$accordion-border-radius};
-  --#{$prefix}accordion-inner-border-radius: #{$accordion-inner-border-radius};
-  --#{$prefix}accordion-padding-x: #{$accordion-body-padding-x};
-  --#{$prefix}accordion-gap: 0;
-  --#{$prefix}accordion-active-color: #{$accordion-button-active-color};
-  --#{$prefix}accordion-btn-color: var(--#{$prefix}accordion-color);
-  --#{$prefix}accordion-btn-bg: #{$accordion-button-bg};
-  --#{$prefix}accordion-btn-toggle-width: 1.25rem;
-  --#{$prefix}accordion-btn-padding-x: var(--#{$prefix}accordion-padding-x);
-  --#{$prefix}accordion-btn-padding-y: #{$accordion-button-padding-y};
-  --#{$prefix}accordion-btn-font-weight: var(--#{$prefix}font-weight-medium);
-  --#{$prefix}accordion-body-padding-x: var(--#{$prefix}accordion-padding-x);
-  --#{$prefix}accordion-body-padding-y: #{$accordion-body-padding-y};
+@layer components {
+  .accordion {
+    --#{$prefix}accordion-color: var(--#{$prefix}body-color);
+    --#{$prefix}accordion-border-color: var(--#{$prefix}border-color);
+    --#{$prefix}accordion-border-radius: #{$accordion-border-radius};
+    --#{$prefix}accordion-inner-border-radius: #{$accordion-inner-border-radius};
+    --#{$prefix}accordion-padding-x: #{$accordion-body-padding-x};
+    --#{$prefix}accordion-gap: 0;
+    --#{$prefix}accordion-active-color: #{$accordion-button-active-color};
+    --#{$prefix}accordion-btn-color: var(--#{$prefix}accordion-color);
+    --#{$prefix}accordion-btn-bg: #{$accordion-button-bg};
+    --#{$prefix}accordion-btn-toggle-width: 1.25rem;
+    --#{$prefix}accordion-btn-padding-x: var(--#{$prefix}accordion-padding-x);
+    --#{$prefix}accordion-btn-padding-y: #{$accordion-button-padding-y};
+    --#{$prefix}accordion-btn-font-weight: var(--#{$prefix}font-weight-medium);
+    --#{$prefix}accordion-body-padding-x: var(--#{$prefix}accordion-padding-x);
+    --#{$prefix}accordion-body-padding-y: #{$accordion-body-padding-y};
 
-  display: flex;
-  flex-direction: column;
-  gap: var(--#{$prefix}accordion-gap);
-}
-
-.accordion-button {
-  position: relative;
-  display: flex;
-  align-items: center;
-  width: 100%;
-  padding: var(--#{$prefix}accordion-btn-padding-y) var(--#{$prefix}accordion-padding-x);
-  color: inherit;
-  text-align: inherit;
-  background-color: transparent;
-  border: 0;
-  font-size: inherit;
-  font-weight: var(--#{$prefix}accordion-btn-font-weight);
-  gap: 0.75rem;
-
-  &:not(.collapsed) {
-    border-bottom-color: transparent;
-    box-shadow: none;
-    color: var(--#{$prefix}accordion-active-color);
-  }
-}
-
-.accordion-header {
-  margin: 0;
-  position: relative;
-  display: flex;
-  gap: 1rem;
-  align-items: center;
-  width: 100%;
-  color: var(--#{$prefix}accordion-btn-color);
-  text-align: start;
-  background-color: transparent;
-  border: 0;
-  overflow-anchor: none;
-  transition: transform $transition-time;
-
-  &:hover {
-    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    gap: var(--#{$prefix}accordion-gap);
   }
 
-  &:focus {
-    z-index: 3;
-    outline: 0;
-    box-shadow: var(--#{$prefix}accordion-btn-focus-box-shadow);
+  .accordion-button {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: var(--#{$prefix}accordion-btn-padding-y) var(--#{$prefix}accordion-padding-x);
+    color: inherit;
+    text-align: inherit;
+    background-color: transparent;
+    border: 0;
+    font-size: inherit;
+    font-weight: var(--#{$prefix}accordion-btn-font-weight);
+    gap: 0.75rem;
 
-    &:not(:focus-visible) {
-      outline: none;
+    &:not(.collapsed) {
+      border-bottom-color: transparent;
       box-shadow: none;
-    }
-  }
-}
-
-.accordion-button-icon {
-  color: var(--#{$prefix}secondary);
-}
-
-.accordion-button-toggle {
-  display: flex;
-  line-height: 1;
-  transition: $transition-time transform;
-  margin-inline-start: auto;
-  margin-inline-end: 0;
-  color: var(--#{$prefix}secondary);
-  width: var(--#{$prefix}accordion-btn-toggle-width);
-  height: var(--#{$prefix}accordion-btn-toggle-width);
-
-  .accordion-button:not(.collapsed) & {
-    transform: rotate(-180deg);
-    color: var(--#{$prefix}accordion-active-color);
-  }
-
-  path {
-    transition: $transition-time opacity;
-  }
-}
-
-.accordion-button-toggle-plus {
-  .accordion-button:not(.collapsed) & {
-    path:first-child {
-      opacity: 0;
-    }
-  }
-}
-
-.accordion-item {
-  color: var(--#{$prefix}accordion-color);
-  border: var(--#{$prefix}border-width) solid var(--#{$prefix}accordion-border-color);
-
-  &:first-of-type {
-    @include border-top-radius(var(--#{$prefix}accordion-border-radius));
-
-    > .accordion-header {
-      @include border-top-radius(var(--#{$prefix}accordion-inner-border-radius));
+      color: var(--#{$prefix}accordion-active-color);
     }
   }
 
-  &:not(:first-of-type) {
-    border-top: 0;
+  .accordion-header {
+    margin: 0;
+    position: relative;
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    width: 100%;
+    color: var(--#{$prefix}accordion-btn-color);
+    text-align: start;
+    background-color: transparent;
+    border: 0;
+    overflow-anchor: none;
+    transition: transform $transition-time;
+
+    &:hover {
+      z-index: 2;
+    }
+
+    &:focus {
+      z-index: 3;
+      outline: 0;
+      box-shadow: var(--#{$prefix}accordion-btn-focus-box-shadow);
+
+      &:not(:focus-visible) {
+        outline: none;
+        box-shadow: none;
+      }
+    }
   }
 
-  &:last-of-type {
-    @include border-bottom-radius(var(--#{$prefix}accordion-border-radius));
+  .accordion-button-icon {
+    color: var(--#{$prefix}secondary);
+  }
 
-    > .accordion-header {
-      &.collapsed {
-        @include border-bottom-radius(var(--#{$prefix}accordion-inner-border-radius));
+  .accordion-button-toggle {
+    display: flex;
+    line-height: 1;
+    transition: $transition-time transform;
+    margin-inline-start: auto;
+    margin-inline-end: 0;
+    color: var(--#{$prefix}secondary);
+    width: var(--#{$prefix}accordion-btn-toggle-width);
+    height: var(--#{$prefix}accordion-btn-toggle-width);
+
+    .accordion-button:not(.collapsed) & {
+      transform: rotate(-180deg);
+      color: var(--#{$prefix}accordion-active-color);
+    }
+
+    path {
+      transition: $transition-time opacity;
+    }
+  }
+
+  .accordion-button-toggle-plus {
+    .accordion-button:not(.collapsed) & {
+      path:first-child {
+        opacity: 0;
+      }
+    }
+  }
+
+  .accordion-item {
+    color: var(--#{$prefix}accordion-color);
+    border: var(--#{$prefix}border-width) solid var(--#{$prefix}accordion-border-color);
+
+    &:first-of-type {
+      @include border-top-radius(var(--#{$prefix}accordion-border-radius));
+
+      > .accordion-header {
+        @include border-top-radius(var(--#{$prefix}accordion-inner-border-radius));
       }
     }
 
-    > .accordion-collapse {
-      @include border-bottom-radius(var(--#{$prefix}accordion-border-radius));
-    }
-  }
-}
-
-.accordion-body {
-  color: var(--#{$prefix}secondary);
-  padding: 0 var(--#{$prefix}accordion-body-padding-x) var(--#{$prefix}accordion-body-padding-y);
-}
-
-.accordion-flush {
-  > .accordion-item {
-    border-inline-end: 0;
-    border-inline-start: 0;
-    @include border-radius(0);
-
-    &:first-child {
+    &:not(:first-of-type) {
       border-top: 0;
     }
-    &:last-child {
-      border-bottom: 0;
-    }
 
-    > .accordion-collapse,
-    > .accordion-header .accordion-button,
-    > .accordion-header .accordion-button.collapsed {
+    &:last-of-type {
+      @include border-bottom-radius(var(--#{$prefix}accordion-border-radius));
+
+      > .accordion-header {
+        &.collapsed {
+          @include border-bottom-radius(var(--#{$prefix}accordion-inner-border-radius));
+        }
+      }
+
+      > .accordion-collapse {
+        @include border-bottom-radius(var(--#{$prefix}accordion-border-radius));
+      }
+    }
+  }
+
+  .accordion-body {
+    color: var(--#{$prefix}secondary);
+    padding: 0 var(--#{$prefix}accordion-body-padding-x) var(--#{$prefix}accordion-body-padding-y);
+  }
+
+  .accordion-flush {
+    > .accordion-item {
+      border-inline-end: 0;
+      border-inline-start: 0;
       @include border-radius(0);
+
+      &:first-child {
+        border-top: 0;
+      }
+      &:last-child {
+        border-bottom: 0;
+      }
+
+      > .accordion-collapse,
+      > .accordion-header .accordion-button,
+      > .accordion-header .accordion-button.collapsed {
+        @include border-radius(0);
+      }
     }
   }
-}
 
-.accordion-tabs {
-  --#{$prefix}accordion-gap: 0.75rem;
+  .accordion-tabs {
+    --#{$prefix}accordion-gap: 0.75rem;
 
-  > .accordion-item {
-    border: var(--#{$prefix}border-width) solid var(--#{$prefix}accordion-border-color);
-    @include border-radius(var(--#{$prefix}accordion-border-radius));
+    > .accordion-item {
+      border: var(--#{$prefix}border-width) solid var(--#{$prefix}accordion-border-color);
+      @include border-radius(var(--#{$prefix}accordion-border-radius));
+    }
   }
-}
 
-.accordion-inverted {
-  .accordion-button-toggle {
-    order: -1;
-    margin-inline-start: 0;
+  .accordion-inverted {
+    .accordion-button-toggle {
+      order: -1;
+      margin-inline-start: 0;
+    }
   }
 }

--- a/core/scss/ui/_alerts.scss
+++ b/core/scss/ui/_alerts.scss
@@ -1,101 +1,103 @@
-.alert {
-  --#{$prefix}alert-variant-color: var(--#{$prefix}body-color);
-  --#{$prefix}alert-color: var(--#{$prefix}alert-variant-color);
-  --#{$prefix}alert-bg: #{color-transparent(var(--#{$prefix}alert-variant-color), 0.16, var(--#{$prefix}bg-surface))};
-  --#{$prefix}alert-padding-x: #{$alert-padding-x};
-  --#{$prefix}alert-padding-y: #{$alert-padding-y};
-  --#{$prefix}alert-margin-bottom: #{$alert-margin-bottom};
-  --#{$prefix}alert-border-color: #{color-transparent(var(--#{$prefix}alert-variant-color), 0.2, var(--#{$prefix}bg-surface))};
-  --#{$prefix}alert-border-color: var(--#{$prefix}border-color);
-  --#{$prefix}alert-border: var(--#{$prefix}border-width) solid var(--#{$prefix}alert-border-color);
-  --#{$prefix}alert-border-radius: var(--#{$prefix}border-radius);
-  --#{$prefix}alert-link-color: inherit;
-  --#{$prefix}alert-heading-font-weight: var(--#{$prefix}font-weight-medium);
+@layer components {
+  .alert {
+    --#{$prefix}alert-variant-color: var(--#{$prefix}body-color);
+    --#{$prefix}alert-color: var(--#{$prefix}alert-variant-color);
+    --#{$prefix}alert-bg: #{color-transparent(var(--#{$prefix}alert-variant-color), 0.16, var(--#{$prefix}bg-surface))};
+    --#{$prefix}alert-padding-x: #{$alert-padding-x};
+    --#{$prefix}alert-padding-y: #{$alert-padding-y};
+    --#{$prefix}alert-margin-bottom: #{$alert-margin-bottom};
+    --#{$prefix}alert-border-color: #{color-transparent(var(--#{$prefix}alert-variant-color), 0.2, var(--#{$prefix}bg-surface))};
+    --#{$prefix}alert-border-color: var(--#{$prefix}border-color);
+    --#{$prefix}alert-border: var(--#{$prefix}border-width) solid var(--#{$prefix}alert-border-color);
+    --#{$prefix}alert-border-radius: var(--#{$prefix}border-radius);
+    --#{$prefix}alert-link-color: inherit;
+    --#{$prefix}alert-heading-font-weight: var(--#{$prefix}font-weight-medium);
 
-  position: relative;
-  padding: var(--#{$prefix}alert-padding-y) var(--#{$prefix}alert-padding-x);
-  margin-bottom: var(--#{$prefix}alert-margin-bottom);
-  background-color: color-mix(in srgb, var(--#{$prefix}alert-bg), var(--#{$prefix}bg-surface));
-  @include border-radius(var(--#{$prefix}alert-border-radius));
-  border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}alert-border-color);
-  box-shadow: var(--#{$prefix}box-shadow);
-  color: var(--#{$prefix}alert-color);
-  display: flex;
-  flex-direction: row;
-  gap: 1rem;
-}
-
-.alert-heading {
-  color: inherit;
-  margin-bottom: 0.25rem; // todo: use variable
-  font-weight: var(--#{$prefix}alert-heading-font-weight);
-}
-
-.alert-description {
-  color: var(--#{$prefix}secondary);
-}
-
-.alert-icon {
-  color: var(--#{$prefix}alert-color);
-  width: 1.25rem !important; // todo: use variable
-  height: 1.25rem !important;
-}
-
-.alert-action {
-  color: var(--#{$prefix}alert-color);
-  text-decoration: underline;
-
-  &:hover {
-    text-decoration: none;
-  }
-}
-
-.alert-list {
-  margin: 0;
-}
-
-.alert-link {
-  font-weight: $alert-link-font-weight;
-  color: var(--#{$prefix}alert-link-color);
-
-  &,
-  &:hover {
+    position: relative;
+    padding: var(--#{$prefix}alert-padding-y) var(--#{$prefix}alert-padding-x);
+    margin-bottom: var(--#{$prefix}alert-margin-bottom);
+    background-color: color-mix(in srgb, var(--#{$prefix}alert-bg), var(--#{$prefix}bg-surface));
+    @include border-radius(var(--#{$prefix}alert-border-radius));
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}alert-border-color);
+    box-shadow: var(--#{$prefix}box-shadow);
     color: var(--#{$prefix}alert-color);
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
   }
-}
 
-.alert-dismissible {
-  padding-inline-end: 3rem; //todo: use variable
-
-  .btn-close {
-    position: absolute;
-    top: calc(var(--#{$prefix}alert-padding-x) / 2 - 1px);
-    inset-inline-end: calc(var(--#{$prefix}alert-padding-y) / 2 - 1px);
-    z-index: 1;
-    padding: calc(var(--#{$prefix}alert-padding-y) * 1.25) var(--#{$prefix}alert-padding-x);
+  .alert-heading {
+    color: inherit;
+    margin-bottom: 0.25rem; // todo: use variable
+    font-weight: var(--#{$prefix}alert-heading-font-weight);
   }
-}
-
-.alert-important {
-  background-color: var(--#{$prefix}alert-variant-color);
-  color: var(--#{$prefix}white);
 
   .alert-description {
-    color: inherit;
+    color: var(--#{$prefix}secondary);
   }
 
   .alert-icon {
-    color: inherit;
+    color: var(--#{$prefix}alert-color);
+    width: 1.25rem !important; // todo: use variable
+    height: 1.25rem !important;
   }
-}
 
-.alert-minor {
-  background: transparent;
-  border-color: var(--tblr-border-color);
-}
+  .alert-action {
+    color: var(--#{$prefix}alert-color);
+    text-decoration: underline;
 
-@each $name, $color in $theme-colors {
-  .alert-#{$name} {
-    --#{$prefix}alert-variant-color: var(--#{$prefix}#{$name});
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .alert-list {
+    margin: 0;
+  }
+
+  .alert-link {
+    font-weight: $alert-link-font-weight;
+    color: var(--#{$prefix}alert-link-color);
+
+    &,
+    &:hover {
+      color: var(--#{$prefix}alert-color);
+    }
+  }
+
+  .alert-dismissible {
+    padding-inline-end: 3rem; //todo: use variable
+
+    .btn-close {
+      position: absolute;
+      top: calc(var(--#{$prefix}alert-padding-x) / 2 - 1px);
+      inset-inline-end: calc(var(--#{$prefix}alert-padding-y) / 2 - 1px);
+      z-index: 1;
+      padding: calc(var(--#{$prefix}alert-padding-y) * 1.25) var(--#{$prefix}alert-padding-x);
+    }
+  }
+
+  .alert-important {
+    background-color: var(--#{$prefix}alert-variant-color);
+    color: var(--#{$prefix}white);
+
+    .alert-description {
+      color: inherit;
+    }
+
+    .alert-icon {
+      color: inherit;
+    }
+  }
+
+  .alert-minor {
+    background: transparent;
+    border-color: var(--tblr-border-color);
+  }
+
+  @each $name, $color in $theme-colors {
+    .alert-#{$name} {
+      --#{$prefix}alert-variant-color: var(--#{$prefix}#{$name});
+    }
   }
 }

--- a/core/scss/ui/_avatars.scss
+++ b/core/scss/ui/_avatars.scss
@@ -1,164 +1,166 @@
 @use 'sass:map';
 
-.avatar {
-  --#{$prefix}avatar-size: var(--#{$prefix}avatar-list-size, #{$avatar-size});
-  --#{$prefix}avatar-status-size: #{$avatar-status-size};
-  --#{$prefix}avatar-bg: #{$avatar-bg};
-  --#{$prefix}avatar-box-shadow-color: var(--#{$prefix}border-color-translucent);
-  --#{$prefix}avatar-box-shadow: inset 0 0 0 1px var(--#{$prefix}avatar-box-shadow-color);
-  --#{$prefix}avatar-font-size: #{$avatar-font-size};
-  --#{$prefix}avatar-icon-size: #{$avatar-icon-size};
-  --#{$prefix}avatar-brand-size: #{$avatar-brand-size};
-  --#{$prefix}avatar-border-radius: #{$avatar-border-radius};
-  position: relative;
-  width: var(--#{$prefix}avatar-size);
-  height: var(--#{$prefix}avatar-size);
-  font-size: var(--#{$prefix}avatar-font-size);
-  font-weight: var(--#{$prefix}font-weight-medium);
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--#{$prefix}secondary);
-  text-align: center;
-  text-transform: uppercase;
-  vertical-align: bottom;
-  user-select: none;
-  background: var(--#{$prefix}avatar-bg) no-repeat center/cover;
-  @include border-radius(var(--#{$prefix}avatar-border-radius));
-  box-shadow: var(--#{$prefix}avatar-box-shadow);
-  transition:
-    color $transition-time,
-    background-color $transition-time,
-    box-shadow $transition-time;
-
-  .icon {
-    width: var(--#{$prefix}avatar-icon-size);
-    height: var(--#{$prefix}avatar-icon-size);
-  }
-
-  .badge {
-    position: absolute;
-    inset-inline-end: 0;
-    bottom: 0;
-    @include border-radius(var(--#{$prefix}border-radius-pill));
-    box-shadow: 0 0 0 calc(var(--#{$prefix}avatar-status-size) / 4) $card-bg;
-  }
-
-  @at-root a#{&} {
-    cursor: pointer;
-
-    &:hover {
-      color: var(--#{$prefix}primary);
-      --#{$prefix}avatar-box-shadow-color: var(--#{$prefix}primary);
-    }
-  }
-}
-
-.avatar-rounded {
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-}
-
-.avatar-square {
-  @include border-radius(var(--#{$prefix}border-radius));
-}
-
-@each $avatar-size, $size in $avatar-sizes {
-  .avatar-#{$avatar-size} {
-    --#{$prefix}avatar-size: #{map.get($size, size)};
-    --#{$prefix}avatar-status-size: #{map.get($size, status-size)};
-    --#{$prefix}avatar-font-size: #{map.get($size, font-size)};
-    --#{$prefix}avatar-icon-size: #{map.get($size, icon-size)};
-    --#{$prefix}avatar-brand-size: #{map.get($size, brand-size)};
-
-    .badge:empty {
-      width: map.get($size, status-size);
-      height: map.get($size, status-size);
-    }
-
-    &.avatar-square {
-      @include border-radius(map.get($size, border-radius));
-    }
-  }
-}
-
-//
-// Avatar list
-//
-.avatar-list {
-  --#{$prefix}avatar-list-size: #{$avatar-size};
-  @include elements-list;
-
-  a.avatar {
-    &:hover {
-      z-index: 1;
-    }
-  }
-}
-
-.avatar-list-stacked {
-  display: block;
-  --#{$prefix}list-gap: 0;
-
+@layer components {
   .avatar {
-    box-shadow:
-      var(--#{$prefix}avatar-box-shadow),
-      0 0 0 2px var(--#{$prefix}card-bg, var(--#{$prefix}bg-surface));
+    --#{$prefix}avatar-size: var(--#{$prefix}avatar-list-size, #{$avatar-size});
+    --#{$prefix}avatar-status-size: #{$avatar-status-size};
+    --#{$prefix}avatar-bg: #{$avatar-bg};
+    --#{$prefix}avatar-box-shadow-color: var(--#{$prefix}border-color-translucent);
+    --#{$prefix}avatar-box-shadow: inset 0 0 0 1px var(--#{$prefix}avatar-box-shadow-color);
+    --#{$prefix}avatar-font-size: #{$avatar-font-size};
+    --#{$prefix}avatar-icon-size: #{$avatar-icon-size};
+    --#{$prefix}avatar-brand-size: #{$avatar-brand-size};
+    --#{$prefix}avatar-border-radius: #{$avatar-border-radius};
+    position: relative;
+    width: var(--#{$prefix}avatar-size);
+    height: var(--#{$prefix}avatar-size);
+    font-size: var(--#{$prefix}avatar-font-size);
+    font-weight: var(--#{$prefix}font-weight-medium);
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--#{$prefix}secondary);
+    text-align: center;
+    text-transform: uppercase;
+    vertical-align: bottom;
+    user-select: none;
+    background: var(--#{$prefix}avatar-bg) no-repeat center/cover;
+    @include border-radius(var(--#{$prefix}avatar-border-radius));
+    box-shadow: var(--#{$prefix}avatar-box-shadow);
+    transition:
+      color $transition-time,
+      background-color $transition-time,
+      box-shadow $transition-time;
 
-    &:not(:first-child) {
-      margin-inline-start: calc(#{$avatar-list-spacing} * var(--#{$prefix}avatar-size)) !important;
+    .icon {
+      width: var(--#{$prefix}avatar-icon-size);
+      height: var(--#{$prefix}avatar-icon-size);
+    }
+
+    .badge {
+      position: absolute;
+      inset-inline-end: 0;
+      bottom: 0;
+      @include border-radius(var(--#{$prefix}border-radius-pill));
+      box-shadow: 0 0 0 calc(var(--#{$prefix}avatar-status-size) / 4) $card-bg;
+    }
+
+    @at-root a#{&} {
+      cursor: pointer;
+
+      &:hover {
+        color: var(--#{$prefix}primary);
+        --#{$prefix}avatar-box-shadow-color: var(--#{$prefix}primary);
+      }
     }
   }
-}
 
-@each $avatar-size, $size in $avatar-sizes {
-  .avatar-list-#{$avatar-size} {
-    --#{$prefix}avatar-list-size: #{map.get($size, size)};
-  }
-}
-
-//
-// Avatar upload
-//
-.avatar-upload {
-  border: var(--#{$prefix}border-width) dashed var(--#{$prefix}border-color);
-  background: $form-check-input-bg;
-  box-shadow: none;
-  flex-direction: column;
-  @include transition(color $transition-time, background-color $transition-time);
-
-  svg {
-    width: 1.5rem;
-    height: 1.5rem;
-    stroke-width: 1;
+  .avatar-rounded {
+    @include border-radius(var(--#{$prefix}border-radius-pill));
   }
 
-  &:hover {
-    border-color: var(--#{$prefix}primary);
-    color: var(--#{$prefix}primary);
-    text-decoration: none;
+  .avatar-square {
+    @include border-radius(var(--#{$prefix}border-radius));
   }
-}
 
-.avatar-upload-text {
-  font-size: $h6-font-size;
-  line-height: 1;
-  margin-top: 0.25rem;
-}
+  @each $avatar-size, $size in $avatar-sizes {
+    .avatar-#{$avatar-size} {
+      --#{$prefix}avatar-size: #{map.get($size, size)};
+      --#{$prefix}avatar-status-size: #{map.get($size, status-size)};
+      --#{$prefix}avatar-font-size: #{map.get($size, font-size)};
+      --#{$prefix}avatar-icon-size: #{map.get($size, icon-size)};
+      --#{$prefix}avatar-brand-size: #{map.get($size, brand-size)};
 
-.avatar-cover {
-  margin-top: calc(-0.5 * var(--#{$prefix}avatar-size));
-  box-shadow: 0 0 0 0.25rem var(--#{$prefix}card-bg, var(--#{$prefix}body-bg));
-}
+      .badge:empty {
+        width: map.get($size, status-size);
+        height: map.get($size, status-size);
+      }
 
-.avatar-brand {
-  width: var(--#{$prefix}avatar-brand-size);
-  height: var(--#{$prefix}avatar-brand-size);
-  position: absolute;
-  inset-inline-end: -2px;
-  bottom: -2px;
-  z-index: 1000;
-  background: var(--#{$prefix}bg-surface);
-  @include border-radius(var(--#{$prefix}border-radius));
-  border: 1px solid var(--#{$prefix}border-color);
+      &.avatar-square {
+        @include border-radius(map.get($size, border-radius));
+      }
+    }
+  }
+
+  //
+  // Avatar list
+  //
+  .avatar-list {
+    --#{$prefix}avatar-list-size: #{$avatar-size};
+    @include elements-list;
+
+    a.avatar {
+      &:hover {
+        z-index: 1;
+      }
+    }
+  }
+
+  .avatar-list-stacked {
+    display: block;
+    --#{$prefix}list-gap: 0;
+
+    .avatar {
+      box-shadow:
+        var(--#{$prefix}avatar-box-shadow),
+        0 0 0 2px var(--#{$prefix}card-bg, var(--#{$prefix}bg-surface));
+
+      &:not(:first-child) {
+        margin-inline-start: calc(#{$avatar-list-spacing} * var(--#{$prefix}avatar-size)) !important;
+      }
+    }
+  }
+
+  @each $avatar-size, $size in $avatar-sizes {
+    .avatar-list-#{$avatar-size} {
+      --#{$prefix}avatar-list-size: #{map.get($size, size)};
+    }
+  }
+
+  //
+  // Avatar upload
+  //
+  .avatar-upload {
+    border: var(--#{$prefix}border-width) dashed var(--#{$prefix}border-color);
+    background: $form-check-input-bg;
+    box-shadow: none;
+    flex-direction: column;
+    @include transition(color $transition-time, background-color $transition-time);
+
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+      stroke-width: 1;
+    }
+
+    &:hover {
+      border-color: var(--#{$prefix}primary);
+      color: var(--#{$prefix}primary);
+      text-decoration: none;
+    }
+  }
+
+  .avatar-upload-text {
+    font-size: $h6-font-size;
+    line-height: 1;
+    margin-top: 0.25rem;
+  }
+
+  .avatar-cover {
+    margin-top: calc(-0.5 * var(--#{$prefix}avatar-size));
+    box-shadow: 0 0 0 0.25rem var(--#{$prefix}card-bg, var(--#{$prefix}body-bg));
+  }
+
+  .avatar-brand {
+    width: var(--#{$prefix}avatar-brand-size);
+    height: var(--#{$prefix}avatar-brand-size);
+    position: absolute;
+    inset-inline-end: -2px;
+    bottom: -2px;
+    z-index: 1000;
+    background: var(--#{$prefix}bg-surface);
+    @include border-radius(var(--#{$prefix}border-radius));
+    border: 1px solid var(--#{$prefix}border-color);
+  }
 }

--- a/core/scss/ui/_badges.scss
+++ b/core/scss/ui/_badges.scss
@@ -1,113 +1,115 @@
-.badge {
-  --#{$prefix}badge-padding-x: #{$badge-padding-x};
-  --#{$prefix}badge-padding-y: #{$badge-padding-y};
-  --#{$prefix}badge-font-size: #{$badge-font-size};
-  --#{$prefix}badge-font-weight: #{$badge-font-weight};
-  --#{$prefix}badge-color: #{$badge-color};
-  --#{$prefix}badge-border-radius: #{$badge-border-radius};
-  --#{$prefix}badge-icon-size: 1em;
-  --#{$prefix}badge-line-height: 1;
-  display: inline-flex;
-  padding: var(--#{$prefix}badge-padding-y) var(--#{$prefix}badge-padding-x);
-  font-weight: var(--#{$prefix}badge-font-weight);
-  font-size: var(--#{$prefix}badge-font-size);
-  color: var(--#{$prefix}badge-color);
-  text-align: center;
-  white-space: nowrap;
-  justify-content: center;
-  align-items: center;
-  gap: 0.25rem;
-  background: $badge-bg-color;
-  overflow: hidden;
-  user-select: none;
-  border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) transparent;
-  @include border-radius(var(--#{$prefix}badge-border-radius));
-  min-width: calc(1em + var(--#{$prefix}badge-padding-y) * 2 + 2px);
-  letter-spacing: 0.04em;
-  vertical-align: bottom;
-  line-height: var(--#{$prefix}badge-line-height);
+@layer components {
+  .badge {
+    --#{$prefix}badge-padding-x: #{$badge-padding-x};
+    --#{$prefix}badge-padding-y: #{$badge-padding-y};
+    --#{$prefix}badge-font-size: #{$badge-font-size};
+    --#{$prefix}badge-font-weight: #{$badge-font-weight};
+    --#{$prefix}badge-color: #{$badge-color};
+    --#{$prefix}badge-border-radius: #{$badge-border-radius};
+    --#{$prefix}badge-icon-size: 1em;
+    --#{$prefix}badge-line-height: 1;
+    display: inline-flex;
+    padding: var(--#{$prefix}badge-padding-y) var(--#{$prefix}badge-padding-x);
+    font-weight: var(--#{$prefix}badge-font-weight);
+    font-size: var(--#{$prefix}badge-font-size);
+    color: var(--#{$prefix}badge-color);
+    text-align: center;
+    white-space: nowrap;
+    justify-content: center;
+    align-items: center;
+    gap: 0.25rem;
+    background: $badge-bg-color;
+    overflow: hidden;
+    user-select: none;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) transparent;
+    @include border-radius(var(--#{$prefix}badge-border-radius));
+    min-width: calc(1em + var(--#{$prefix}badge-padding-y) * 2 + 2px);
+    letter-spacing: 0.04em;
+    vertical-align: bottom;
+    line-height: var(--#{$prefix}badge-line-height);
 
-  @at-root a#{&} {
-    background: var(--#{$prefix}bg-surface-secondary);
+    @at-root a#{&} {
+      background: var(--#{$prefix}bg-surface-secondary);
+    }
+
+    .icon {
+      width: 1em;
+      height: 1em;
+      font-size: var(--#{$prefix}badge-icon-size);
+      stroke-width: 2;
+    }
   }
 
-  .icon {
-    width: 1em;
-    height: 1em;
-    font-size: var(--#{$prefix}badge-icon-size);
-    stroke-width: 2;
+  .badge:empty,
+  .badge-dot {
+    display: inline-block;
+    width: $badge-empty-size;
+    height: $badge-empty-size;
+    min-width: 0;
+    min-height: auto;
+    padding: 0;
+    @include border-radius(var(--#{$prefix}border-radius-pill));
+    vertical-align: baseline;
   }
-}
 
-.badge:empty,
-.badge-dot {
-  display: inline-block;
-  width: $badge-empty-size;
-  height: $badge-empty-size;
-  min-width: 0;
-  min-height: auto;
-  padding: 0;
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-  vertical-align: baseline;
-}
+  //
+  // Outline badge
+  //
+  .badge-outline {
+    background-color: transparent;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) currentColor;
+  }
 
-//
-// Outline badge
-//
-.badge-outline {
-  background-color: transparent;
-  border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) currentColor;
-}
+  //
+  // Pill badge
+  //
+  .badge-pill {
+    @include border-radius(var(--#{$prefix}border-radius-pill));
+  }
 
-//
-// Pill badge
-//
-.badge-pill {
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-}
+  //
+  // Badges list
+  //
+  .badges-list {
+    @include elements-list;
+  }
 
-//
-// Badges list
-//
-.badges-list {
-  @include elements-list;
-}
+  //
+  // Notification badge
+  //
+  .badge-notification {
+    position: absolute !important;
+    top: 0 !important;
+    inset-inline-end: 0 !important;
+    transform: translate(50%, -50%);
+    z-index: 1;
+  }
 
-//
-// Notification badge
-//
-.badge-notification {
-  position: absolute !important;
-  top: 0 !important;
-  inset-inline-end: 0 !important;
-  transform: translate(50%, -50%);
-  z-index: 1;
-}
+  .badge-blink {
+    animation: blink 2s infinite;
+  }
 
-.badge-blink {
-  animation: blink 2s infinite;
-}
+  //
+  // Badge sizes
+  //
+  .badge-sm {
+    --#{$prefix}badge-font-size: #{$badge-font-size-sm};
+    --#{$prefix}badge-icon-size: 1em;
+    --#{$prefix}badge-padding-y: 2px;
+    --#{$prefix}badge-padding-x: 0.25rem;
+  }
 
-//
-// Badge sizes
-//
-.badge-sm {
-  --#{$prefix}badge-font-size: #{$badge-font-size-sm};
-  --#{$prefix}badge-icon-size: 1em;
-  --#{$prefix}badge-padding-y: 2px;
-  --#{$prefix}badge-padding-x: 0.25rem;
-}
+  .badge-lg {
+    --#{$prefix}badge-font-size: #{$badge-font-size-lg};
+    --#{$prefix}badge-icon-size: 1em;
+    --#{$prefix}badge-padding-y: 0.25rem;
+    --#{$prefix}badge-padding-x: 0.5rem;
+  }
 
-.badge-lg {
-  --#{$prefix}badge-font-size: #{$badge-font-size-lg};
-  --#{$prefix}badge-icon-size: 1em;
-  --#{$prefix}badge-padding-y: 0.25rem;
-  --#{$prefix}badge-padding-x: 0.5rem;
-}
-
-//
-// Badge with only icon
-//
-.badge-icononly {
-  --#{$prefix}badge-padding-x: 0;
+  //
+  // Badge with only icon
+  //
+  .badge-icononly {
+    --#{$prefix}badge-padding-x: 0;
+  }
 }

--- a/core/scss/ui/_breadcrumbs.scss
+++ b/core/scss/ui/_breadcrumbs.scss
@@ -1,83 +1,85 @@
-@use "sass:string";
+@use 'sass:string';
 
-.breadcrumb {
-  --#{$prefix}breadcrumb-padding-x: #{$breadcrumb-padding-x};
-  --#{$prefix}breadcrumb-padding-y: #{$breadcrumb-padding-y};
-  --#{$prefix}breadcrumb-margin-bottom: #{$breadcrumb-margin-bottom};
-  --#{$prefix}breadcrumb-font-size: #{$breadcrumb-font-size};
-  --#{$prefix}breadcrumb-bg: #{$breadcrumb-bg};
-  --#{$prefix}breadcrumb-border-radius: #{$breadcrumb-border-radius};
-  --#{$prefix}breadcrumb-divider-color: #{$breadcrumb-divider-color};
-  --#{$prefix}breadcrumb-item-padding-x: #{$breadcrumb-item-padding-x};
-  --#{$prefix}breadcrumb-item-active-color: #{$breadcrumb-active-color};
-  --#{$prefix}breadcrumb-item-active-font-weight: #{$breadcrumb-active-font-weight};
-  --#{$prefix}breadcrumb-item-disabled-color: #{$breadcrumb-disabled-color};
-  --#{$prefix}breadcrumb-link-color: #{$breadcrumb-link-color};
+@layer components {
+  .breadcrumb {
+    --#{$prefix}breadcrumb-padding-x: #{$breadcrumb-padding-x};
+    --#{$prefix}breadcrumb-padding-y: #{$breadcrumb-padding-y};
+    --#{$prefix}breadcrumb-margin-bottom: #{$breadcrumb-margin-bottom};
+    --#{$prefix}breadcrumb-font-size: #{$breadcrumb-font-size};
+    --#{$prefix}breadcrumb-bg: #{$breadcrumb-bg};
+    --#{$prefix}breadcrumb-border-radius: #{$breadcrumb-border-radius};
+    --#{$prefix}breadcrumb-divider-color: #{$breadcrumb-divider-color};
+    --#{$prefix}breadcrumb-item-padding-x: #{$breadcrumb-item-padding-x};
+    --#{$prefix}breadcrumb-item-active-color: #{$breadcrumb-active-color};
+    --#{$prefix}breadcrumb-item-active-font-weight: #{$breadcrumb-active-font-weight};
+    --#{$prefix}breadcrumb-item-disabled-color: #{$breadcrumb-disabled-color};
+    --#{$prefix}breadcrumb-link-color: #{$breadcrumb-link-color};
 
-  display: flex;
-  flex-wrap: wrap;
-  @include font-size(var(--#{$prefix}breadcrumb-font-size));
-  list-style: none;
-  background-color: var(--#{$prefix}breadcrumb-bg);
-  @include border-radius(var(--#{$prefix}breadcrumb-border-radius));
-  padding: 0;
-  margin: 0;
-  background: transparent;
-
-  a {
-    color: var(--#{$prefix}breadcrumb-link-color);
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-}
-
-.breadcrumb-muted {
-  --#{$prefix}breadcrumb-link-color: var(--#{$prefix}secondary);
-}
-
-.breadcrumb-item {
-  &.active {
-    color: var(--#{$prefix}breadcrumb-item-active-color);
-    font-weight: var(--#{$prefix}breadcrumb-item-active-font-weight);
+    display: flex;
+    flex-wrap: wrap;
+    @include font-size(var(--#{$prefix}breadcrumb-font-size));
+    list-style: none;
+    background-color: var(--#{$prefix}breadcrumb-bg);
+    @include border-radius(var(--#{$prefix}breadcrumb-border-radius));
+    padding: 0;
+    margin: 0;
+    background: transparent;
 
     a {
-      color: inherit;
-      pointer-events: none;
+      color: var(--#{$prefix}breadcrumb-link-color);
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 
-  &.disabled {
-    color: var(--#{$prefix}breadcrumb-item-disabled-color);
+  .breadcrumb-muted {
+    --#{$prefix}breadcrumb-link-color: var(--#{$prefix}secondary);
+  }
 
-    &:before {
-      color: inherit;
+  .breadcrumb-item {
+    &.active {
+      color: var(--#{$prefix}breadcrumb-item-active-color);
+      font-weight: var(--#{$prefix}breadcrumb-item-active-font-weight);
+
+      a {
+        color: inherit;
+        pointer-events: none;
+      }
     }
 
-    a {
-      color: inherit;
-      pointer-events: none;
+    &.disabled {
+      color: var(--#{$prefix}breadcrumb-item-disabled-color);
+
+      &:before {
+        color: inherit;
+      }
+
+      a {
+        color: inherit;
+        pointer-events: none;
+      }
+    }
+
+    & + & {
+      padding-inline-start: var(--#{$prefix}breadcrumb-item-padding-x);
+
+      &::before {
+        float: inline-start;
+        padding-inline-end: var(--#{$prefix}breadcrumb-item-padding-x);
+        color: var(--#{$prefix}breadcrumb-divider-color);
+        content: var(--#{$prefix}breadcrumb-divider, escape-svg($breadcrumb-divider));
+        /*rtl:raw:
+        transform: scaleX(-1);
+        */
+      }
     }
   }
 
-  & + & {
-    padding-inline-start: var(--#{$prefix}breadcrumb-item-padding-x);
-
-    &::before {
-      float: inline-start;
-      padding-inline-end: var(--#{$prefix}breadcrumb-item-padding-x);
-      color: var(--#{$prefix}breadcrumb-divider-color);
-      content: var(--#{$prefix}breadcrumb-divider, escape-svg($breadcrumb-divider));
-      /*rtl:raw:
-      transform: scaleX(-1);
-      */
+  @each $name, $symbol in $breadcrumb-variants {
+    .breadcrumb-#{$name} {
+      --#{$prefix}breadcrumb-divider: '#{string.quote($symbol)}';
     }
-  }
-}
-
-@each $name, $symbol in $breadcrumb-variants {
-  .breadcrumb-#{$name} {
-    --#{$prefix}breadcrumb-divider: '#{string.quote($symbol)}';
   }
 }

--- a/core/scss/ui/_button-group.scss
+++ b/core/scss/ui/_button-group.scss
@@ -1,16 +1,18 @@
-.btn-group,
-.btn-group-vertical {
-  box-shadow: $input-box-shadow;
+@layer components {
+  .btn-group,
+  .btn-group-vertical {
+    box-shadow: $input-box-shadow;
 
-  > .btn-check:checked + .btn,
-  > .btn:active,
-  > .btn.active {
-    z-index: 5;
-  }
+    > .btn-check:checked + .btn,
+    > .btn:active,
+    > .btn.active {
+      z-index: 5;
+    }
 
-  > .btn-check:focus + .btn,
-  > .btn:hover,
-  > .btn:focus {
-    z-index: 1;
+    > .btn-check:focus + .btn,
+    > .btn:hover,
+    > .btn:focus {
+      z-index: 1;
+    }
   }
 }

--- a/core/scss/ui/_buttons.scss
+++ b/core/scss/ui/_buttons.scss
@@ -4,359 +4,362 @@
 //
 // Button
 //
-.btn {
-  --#{$prefix}btn-icon-size: #{$input-btn-icon-size};
-  --#{$prefix}btn-icon-color: inherit;
-  --#{$prefix}btn-bg: var(--#{$prefix}bg-surface);
-  --#{$prefix}btn-color: var(--#{$prefix}body-color);
-  --#{$prefix}btn-border-color: #{$btn-border-color};
-  --#{$prefix}btn-hover-bg: var(--#{$prefix}btn-bg);
-  --#{$prefix}btn-hover-border-color: var(--#{$prefix}border-active-color);
-  --#{$prefix}btn-active-color: #{$active-color};
-  --#{$prefix}btn-active-bg: #{$active-bg};
-  --#{$prefix}btn-active-border-color: #{$active-border-color};
 
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  white-space: nowrap;
-  box-shadow: var(--#{$prefix}btn-box-shadow);
-  position: relative;
-  min-width: calc((var(--#{$prefix}btn-line-height) * 1) + (var(--#{$prefix}btn-padding-y) * 2) + (var(--#{$prefix}btn-border-width) * 2));
-  min-height: calc((var(--#{$prefix}btn-line-height) * 1) + (var(--#{$prefix}btn-padding-y) * 2) + (var(--#{$prefix}btn-border-width) * 2));
+@layer components {
+  .btn {
+    --#{$prefix}btn-icon-size: #{$input-btn-icon-size};
+    --#{$prefix}btn-icon-color: inherit;
+    --#{$prefix}btn-bg: var(--#{$prefix}bg-surface);
+    --#{$prefix}btn-color: var(--#{$prefix}body-color);
+    --#{$prefix}btn-border-color: #{$btn-border-color};
+    --#{$prefix}btn-hover-bg: var(--#{$prefix}btn-bg);
+    --#{$prefix}btn-hover-border-color: var(--#{$prefix}border-active-color);
+    --#{$prefix}btn-active-color: #{$active-color};
+    --#{$prefix}btn-active-bg: #{$active-bg};
+    --#{$prefix}btn-active-border-color: #{$active-border-color};
 
-  @include border-radius(var(--#{$prefix}btn-border-radius));
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    box-shadow: var(--#{$prefix}btn-box-shadow);
+    position: relative;
+    min-width: calc((var(--#{$prefix}btn-line-height) * 1) + (var(--#{$prefix}btn-padding-y) * 2) + (var(--#{$prefix}btn-border-width) * 2));
+    min-height: calc((var(--#{$prefix}btn-line-height) * 1) + (var(--#{$prefix}btn-padding-y) * 2) + (var(--#{$prefix}btn-border-width) * 2));
 
-  .icon {
-    width: var(--#{$prefix}btn-icon-size);
-    height: var(--#{$prefix}btn-icon-size);
-    min-width: var(--#{$prefix}btn-icon-size);
-    font-size: var(--#{$prefix}btn-icon-size);
-    margin: 0 calc(var(--#{$prefix}btn-padding-x) / 2) 0 calc(var(--#{$prefix}btn-padding-x) / -4);
-    vertical-align: bottom;
-    color: var(--#{$prefix}btn-icon-color);
-  }
+    @include border-radius(var(--#{$prefix}btn-border-radius));
 
-  .avatar {
-    width: var(--#{$prefix}btn-icon-size);
-    height: var(--#{$prefix}btn-icon-size);
-    margin: 0 calc(var(--#{$prefix}btn-padding-x) / 2) 0 calc(var(--#{$prefix}btn-padding-x) / -4);
-  }
-
-  .icon-right,
-  .icon-end {
-    margin: 0 calc(var(--#{$prefix}btn-padding-x) / -4) 0 calc(var(--#{$prefix}btn-padding-x) / 2);
-  }
-
-  .badge {
-    top: auto;
-  }
-
-  .btn-check + &:hover {
-    color: var(--#{$prefix}btn-hover-color);
-    background-color: var(--#{$prefix}btn-hover-bg);
-    border-color: var(--#{$prefix}btn-hover-border-color);
-  }
-}
-
-.btn-link {
-  color: #{color.adjust($primary, $lightness: 5%)};
-  background-color: transparent;
-  border-color: transparent;
-  box-shadow: none;
-
-  .icon {
-    color: inherit;
-  }
-
-  &:hover {
-    color: $link-hover-color;
-    border-color: transparent;
-  }
-}
-
-//
-// Button color variations
-//
-.btn-ghost {
-  --#{$prefix}btn-bg: transparent;
-  --#{$prefix}btn-border-color: transparent;
-  --#{$prefix}btn-box-shadow: none;
-  --#{$prefix}btn-hover-bg: var(--#{$prefix}bg-surface-secondary);
-  --#{$prefix}btn-hover-border-color: transparent;
-  --#{$prefix}btn-hover-color: var(--#{$prefix}body-color);
-}
-
-@each $color, $value in map.merge($theme-colors, $social-colors) {
-  .btn-#{$color} {
-    @if $color == 'dark' {
-      --#{$prefix}btn-border-color: var(--#{$prefix}dark-mode-border-color);
-      --#{$prefix}btn-hover-border-color: var(--#{$prefix}dark-mode-border-active-color);
-      --#{$prefix}btn-active-border-color: var(--#{$prefix}dark-mode-border-active-color);
-    } @else {
-      --#{$prefix}btn-border-color: transparent;
-      --#{$prefix}btn-hover-border-color: transparent;
-      --#{$prefix}btn-active-border-color: transparent;
+    .icon {
+      width: var(--#{$prefix}btn-icon-size);
+      height: var(--#{$prefix}btn-icon-size);
+      min-width: var(--#{$prefix}btn-icon-size);
+      font-size: var(--#{$prefix}btn-icon-size);
+      margin: 0 calc(var(--#{$prefix}btn-padding-x) / 2) 0 calc(var(--#{$prefix}btn-padding-x) / -4);
+      vertical-align: bottom;
+      color: var(--#{$prefix}btn-icon-color);
     }
 
-    --#{$prefix}btn-color: var(--#{$prefix}#{$color}-fg, #{$white});
-    --#{$prefix}btn-bg: var(--#{$prefix}#{$color});
-    --#{$prefix}btn-hover-color: var(--#{$prefix}#{$color}-fg);
-    --#{$prefix}btn-hover-bg: var(--#{$prefix}#{$color}-darken);
-    --#{$prefix}btn-active-color: var(--#{$prefix}#{$color}-fg);
-    --#{$prefix}btn-active-bg: var(--#{$prefix}#{$color}-darken);
-    --#{$prefix}btn-disabled-bg: var(--#{$prefix}#{$color});
-    --#{$prefix}btn-disabled-color: var(--#{$prefix}#{$color}-fg);
-    --#{$prefix}btn-box-shadow: var(--#{$prefix}shadow-input);
+    .avatar {
+      width: var(--#{$prefix}btn-icon-size);
+      height: var(--#{$prefix}btn-icon-size);
+      margin: 0 calc(var(--#{$prefix}btn-padding-x) / 2) 0 calc(var(--#{$prefix}btn-padding-x) / -4);
+    }
+
+    .icon-right,
+    .icon-end {
+      margin: 0 calc(var(--#{$prefix}btn-padding-x) / -4) 0 calc(var(--#{$prefix}btn-padding-x) / 2);
+    }
+
+    .badge {
+      top: auto;
+    }
+
+    .btn-check + &:hover {
+      color: var(--#{$prefix}btn-hover-color);
+      background-color: var(--#{$prefix}btn-hover-bg);
+      border-color: var(--#{$prefix}btn-hover-border-color);
+    }
   }
 
-  .btn-outline-#{$color},
-  .btn-outline.btn-#{$color} {
-    --#{$prefix}btn-color: var(--#{$prefix}#{$color});
-    --#{$prefix}btn-bg: transparent;
-    --#{$prefix}btn-border-color: var(--#{$prefix}#{$color});
-    --#{$prefix}btn-hover-color: var(--#{$prefix}#{$color}-fg);
-    --#{$prefix}btn-hover-border-color: transparent;
-    --#{$prefix}btn-hover-bg: var(--#{$prefix}#{$color});
-    --#{$prefix}btn-active-color: var(--#{$prefix}#{$color}-fg);
-    --#{$prefix}btn-active-bg: var(--#{$prefix}#{$color});
-    --#{$prefix}btn-active-border-color: var(--#{$prefix}#{$color});
-    --#{$prefix}btn-disabled-color: var(--#{$prefix}#{$color});
-    --#{$prefix}btn-disabled-border-color: var(--#{$prefix}#{$color});
+  .btn-link {
+    color: #{color.adjust($primary, $lightness: 5%)};
+    background-color: transparent;
+    border-color: transparent;
+    box-shadow: none;
+
+    .icon {
+      color: inherit;
+    }
+
+    &:hover {
+      color: $link-hover-color;
+      border-color: transparent;
+    }
   }
 
-  .btn-ghost-#{$color},
-  .btn-ghost.btn-#{$color} {
-    --#{$prefix}btn-color: var(--#{$prefix}#{$color});
+  //
+  // Button color variations
+  //
+  .btn-ghost {
     --#{$prefix}btn-bg: transparent;
     --#{$prefix}btn-border-color: transparent;
-    --#{$prefix}btn-hover-color: var(--#{$prefix}#{$color}-fg);
-    --#{$prefix}btn-hover-bg: var(--#{$prefix}#{$color});
-    --#{$prefix}btn-hover-border-color: var(--#{$prefix}#{$color});
-    --#{$prefix}btn-active-color: var(--#{$prefix}#{$color}-fg);
-    --#{$prefix}btn-active-bg: var(--#{$prefix}#{$color});
-    --#{$prefix}btn-active-border-color: transparent;
-    --#{$prefix}btn-active-shadow: #{$btn-active-box-shadow};
-    --#{$prefix}btn-disabled-color: var(--#{$prefix}#{$color});
-    --#{$prefix}btn-disabled-bg: transparent;
-    --#{$prefix}btn-disabled-border-color: transparent;
-    --#{$prefix}gradient: none;
     --#{$prefix}btn-box-shadow: none;
-  }
-}
-
-//
-// Button sizes
-//
-.btn-sm,
-.btn-group-sm > .btn {
-  --#{$prefix}btn-line-height: #{$input-btn-line-height-sm};
-  --#{$prefix}btn-icon-size: #{$input-btn-icon-size-sm};
-}
-
-.btn-lg,
-.btn-group-lg > .btn {
-  --#{$prefix}btn-line-height: #{$input-btn-line-height-lg};
-  --#{$prefix}btn-icon-size: #{$input-btn-icon-size-lg};
-}
-
-.btn-xl,
-.btn-group-xl > .btn {
-  --#{$prefix}btn-line-height: #{$input-btn-line-height-xl};
-  --#{$prefix}btn-icon-size: #{$input-btn-icon-size-xl};
-  --#{$prefix}btn-padding-y: #{$input-btn-padding-y-xl};
-  --#{$prefix}btn-padding-x: #{$input-btn-padding-x-xl};
-  --#{$prefix}btn-font-size: #{$input-btn-font-size-xl};
-}
-
-//
-// Button shapes
-//
-.btn-pill {
-  padding-inline-end: 1.5em;
-  padding-inline-start: 1.5em;
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-
-  &[class*='btn-icon'] {
-    padding: 0.375rem 15px;
-  }
-}
-
-.btn-square {
-  border-radius: 0;
-}
-
-//
-// Icon button
-//
-.btn-icon,
-.btn-action {
-  padding-inline-start: 0;
-  padding-inline-end: 0;
-
-  .icon {
-    margin: calc(-1 * var(--#{$prefix}btn-padding-x));
-  }
-  //[BUG] btn-sm and btn-xl with an icon looks broken
-  //issue #2470 fixed
-  min-width: calc(var(--#{$prefix}btn-line-height) + (var(--#{$prefix}btn-padding-y) * 2) + (var(--#{$prefix}btn-border-width) * 2));
-}
-
-//
-// Button list
-//
-.btn-list {
-  @include elements-list;
-}
-
-.btn-list-center {
-  justify-content: center;
-}
-
-//
-// Button floating
-//
-.btn-floating {
-  position: fixed;
-  z-index: $zindex-fixed;
-  bottom: 1rem;
-  inset-inline-start: 1rem;
-  box-shadow: var(--#{$prefix}shadow-dropdown);
-
-  @include media-print {
-    display: none;
-  }
-}
-
-//
-// Button loading
-//
-.btn-loading {
-  position: relative;
-  color: transparent !important;
-  text-shadow: none !important;
-  pointer-events: none;
-
-  > * {
-    opacity: 0;
+    --#{$prefix}btn-hover-bg: var(--#{$prefix}bg-surface-secondary);
+    --#{$prefix}btn-hover-border-color: transparent;
+    --#{$prefix}btn-hover-color: var(--#{$prefix}body-color);
   }
 
-  &:after {
-    content: '';
-    display: inline-block;
-    vertical-align: text-bottom;
-    border: $spinner-border-width var(--#{$prefix}border-style) currentColor;
-    border-inline-end-color: transparent;
+  @each $color, $value in map.merge($theme-colors, $social-colors) {
+    .btn-#{$color} {
+      @if $color == 'dark' {
+        --#{$prefix}btn-border-color: var(--#{$prefix}dark-mode-border-color);
+        --#{$prefix}btn-hover-border-color: var(--#{$prefix}dark-mode-border-active-color);
+        --#{$prefix}btn-active-border-color: var(--#{$prefix}dark-mode-border-active-color);
+      } @else {
+        --#{$prefix}btn-border-color: transparent;
+        --#{$prefix}btn-hover-border-color: transparent;
+        --#{$prefix}btn-active-border-color: transparent;
+      }
+
+      --#{$prefix}btn-color: var(--#{$prefix}#{$color}-fg, #{$white});
+      --#{$prefix}btn-bg: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-hover-color: var(--#{$prefix}#{$color}-fg);
+      --#{$prefix}btn-hover-bg: var(--#{$prefix}#{$color}-darken);
+      --#{$prefix}btn-active-color: var(--#{$prefix}#{$color}-fg);
+      --#{$prefix}btn-active-bg: var(--#{$prefix}#{$color}-darken);
+      --#{$prefix}btn-disabled-bg: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-disabled-color: var(--#{$prefix}#{$color}-fg);
+      --#{$prefix}btn-box-shadow: var(--#{$prefix}shadow-input);
+    }
+
+    .btn-outline-#{$color},
+    .btn-outline.btn-#{$color} {
+      --#{$prefix}btn-color: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-bg: transparent;
+      --#{$prefix}btn-border-color: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-hover-color: var(--#{$prefix}#{$color}-fg);
+      --#{$prefix}btn-hover-border-color: transparent;
+      --#{$prefix}btn-hover-bg: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-active-color: var(--#{$prefix}#{$color}-fg);
+      --#{$prefix}btn-active-bg: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-active-border-color: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-disabled-color: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-disabled-border-color: var(--#{$prefix}#{$color});
+    }
+
+    .btn-ghost-#{$color},
+    .btn-ghost.btn-#{$color} {
+      --#{$prefix}btn-color: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-bg: transparent;
+      --#{$prefix}btn-border-color: transparent;
+      --#{$prefix}btn-hover-color: var(--#{$prefix}#{$color}-fg);
+      --#{$prefix}btn-hover-bg: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-hover-border-color: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-active-color: var(--#{$prefix}#{$color}-fg);
+      --#{$prefix}btn-active-bg: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-active-border-color: transparent;
+      --#{$prefix}btn-active-shadow: #{$btn-active-box-shadow};
+      --#{$prefix}btn-disabled-color: var(--#{$prefix}#{$color});
+      --#{$prefix}btn-disabled-bg: transparent;
+      --#{$prefix}btn-disabled-border-color: transparent;
+      --#{$prefix}gradient: none;
+      --#{$prefix}btn-box-shadow: none;
+    }
+  }
+
+  //
+  // Button sizes
+  //
+  .btn-sm,
+  .btn-group-sm > .btn {
+    --#{$prefix}btn-line-height: #{$input-btn-line-height-sm};
+    --#{$prefix}btn-icon-size: #{$input-btn-icon-size-sm};
+  }
+
+  .btn-lg,
+  .btn-group-lg > .btn {
+    --#{$prefix}btn-line-height: #{$input-btn-line-height-lg};
+    --#{$prefix}btn-icon-size: #{$input-btn-icon-size-lg};
+  }
+
+  .btn-xl,
+  .btn-group-xl > .btn {
+    --#{$prefix}btn-line-height: #{$input-btn-line-height-xl};
+    --#{$prefix}btn-icon-size: #{$input-btn-icon-size-xl};
+    --#{$prefix}btn-padding-y: #{$input-btn-padding-y-xl};
+    --#{$prefix}btn-padding-x: #{$input-btn-padding-x-xl};
+    --#{$prefix}btn-font-size: #{$input-btn-font-size-xl};
+  }
+
+  //
+  // Button shapes
+  //
+  .btn-pill {
+    padding-inline-end: 1.5em;
+    padding-inline-start: 1.5em;
     @include border-radius(var(--#{$prefix}border-radius-pill));
-    color: var(--#{$prefix}btn-color);
-    position: absolute;
-    width: var(--#{$prefix}btn-icon-size);
-    height: var(--#{$prefix}btn-icon-size);
-    inset-inline-start: calc(50% - var(--#{$prefix}btn-icon-size) / 2);
-    top: calc(50% - var(--#{$prefix}btn-icon-size) / 2);
-    animation: spinner-border 0.75s linear infinite;
-  }
-}
 
-//
-// Action button
-//
-.btn-action {
-  --#{$prefix}border-color: transparent;
-  color: var(--#{$prefix}secondary);
-  @include border-radius(var(--#{$prefix}border-radius));
-  background: transparent;
-  box-shadow: none;
-
-  &:after {
-    content: none;
+    &[class*='btn-icon'] {
+      padding: 0.375rem 15px;
+    }
   }
 
-  &:focus {
-    outline: none;
-    box-shadow: none;
+  .btn-square {
+    border-radius: 0;
   }
 
-  &:hover,
-  &.show {
-    color: var(--#{$prefix}body-color);
-    background: var(--#{$prefix}active-bg);
-    border-color: transparent;
-  }
+  //
+  // Icon button
+  //
+  .btn-icon,
+  .btn-action {
+    padding-inline-start: 0;
+    padding-inline-end: 0;
 
-  &.show {
-    color: var(--#{$prefix}primary);
-  }
-
-  @include media-print {
-    display: none;
-  }
-}
-
-.btn-actions {
-  display: flex;
-
-  @include media-print {
-    display: none;
-  }
-}
-
-.btn-animate-icon {
-  .icon {
-    transition: transform 0.3s ease;
-  }
-
-  &:hover,
-  &:focus-visible {
     .icon {
-      transform: translateX(4px);
+      margin: calc(-1 * var(--#{$prefix}btn-padding-x));
+    }
+    //[BUG] btn-sm and btn-xl with an icon looks broken
+    //issue #2470 fixed
+    min-width: calc(var(--#{$prefix}btn-line-height) + (var(--#{$prefix}btn-padding-y) * 2) + (var(--#{$prefix}btn-border-width) * 2));
+  }
+
+  //
+  // Button list
+  //
+  .btn-list {
+    @include elements-list;
+  }
+
+  .btn-list-center {
+    justify-content: center;
+  }
+
+  //
+  // Button floating
+  //
+  .btn-floating {
+    position: fixed;
+    z-index: $zindex-fixed;
+    bottom: 1rem;
+    inset-inline-start: 1rem;
+    box-shadow: var(--#{$prefix}shadow-dropdown);
+
+    @include media-print {
+      display: none;
     }
   }
 
-  &.btn-animate-icon-rotate {
+  //
+  // Button loading
+  //
+  .btn-loading {
+    position: relative;
+    color: transparent !important;
+    text-shadow: none !important;
+    pointer-events: none;
+
+    > * {
+      opacity: 0;
+    }
+
+    &:after {
+      content: '';
+      display: inline-block;
+      vertical-align: text-bottom;
+      border: $spinner-border-width var(--#{$prefix}border-style) currentColor;
+      border-inline-end-color: transparent;
+      @include border-radius(var(--#{$prefix}border-radius-pill));
+      color: var(--#{$prefix}btn-color);
+      position: absolute;
+      width: var(--#{$prefix}btn-icon-size);
+      height: var(--#{$prefix}btn-icon-size);
+      inset-inline-start: calc(50% - var(--#{$prefix}btn-icon-size) / 2);
+      top: calc(50% - var(--#{$prefix}btn-icon-size) / 2);
+      animation: spinner-border 0.75s linear infinite;
+    }
+  }
+
+  //
+  // Action button
+  //
+  .btn-action {
+    --#{$prefix}border-color: transparent;
+    color: var(--#{$prefix}secondary);
+    @include border-radius(var(--#{$prefix}border-radius));
+    background: transparent;
+    box-shadow: none;
+
+    &:after {
+      content: none;
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: none;
+    }
+
+    &:hover,
+    &.show {
+      color: var(--#{$prefix}body-color);
+      background: var(--#{$prefix}active-bg);
+      border-color: transparent;
+    }
+
+    &.show {
+      color: var(--#{$prefix}primary);
+    }
+
+    @include media-print {
+      display: none;
+    }
+  }
+
+  .btn-actions {
+    display: flex;
+
+    @include media-print {
+      display: none;
+    }
+  }
+
+  .btn-animate-icon {
+    .icon {
+      transition: transform 0.3s ease;
+    }
+
     &:hover,
     &:focus-visible {
       .icon {
-        transform: rotate(90deg);
+        transform: translateX(4px);
       }
     }
-  }
 
-  &.btn-animate-icon-move-start {
-    &:hover,
-    &:focus-visible {
-      .icon {
-        transform: translateX(-4px);
+    &.btn-animate-icon-rotate {
+      &:hover,
+      &:focus-visible {
+        .icon {
+          transform: rotate(90deg);
+        }
       }
     }
-  }
 
-  &.btn-animate-icon-pulse {
-    &:hover,
-    &:focus-visible {
-      .icon {
-        transform: none;
-        animation: pulse 0.9s;
+    &.btn-animate-icon-move-start {
+      &:hover,
+      &:focus-visible {
+        .icon {
+          transform: translateX(-4px);
+        }
       }
     }
-  }
 
-  &.btn-animate-icon-shake {
-    &:hover,
-    &:focus-visible {
-      .icon {
-        transform: none;
-        animation: shake 0.9s;
+    &.btn-animate-icon-pulse {
+      &:hover,
+      &:focus-visible {
+        .icon {
+          transform: none;
+          animation: pulse 0.9s;
+        }
       }
     }
-  }
 
-  &.btn-animate-icon-tada {
-    &:hover,
-    &:focus-visible {
-      .icon {
-        transform: none;
-        animation: tada 0.9s;
+    &.btn-animate-icon-shake {
+      &:hover,
+      &:focus-visible {
+        .icon {
+          transform: none;
+          animation: shake 0.9s;
+        }
+      }
+    }
+
+    &.btn-animate-icon-tada {
+      &:hover,
+      &:focus-visible {
+        .icon {
+          transform: none;
+          animation: tada 0.9s;
+        }
       }
     }
   }

--- a/core/scss/ui/_calendars.scss
+++ b/core/scss/ui/_calendars.scss
@@ -1,104 +1,106 @@
-.calendar {
-  display: block;
-  font-size: $font-size-sm;
-  border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-  @include border-radius(var(--#{$prefix}border-radius));
-}
-
-.calendar-nav {
-  display: flex;
-  align-items: center;
-}
-
-.calendar-title {
-  flex: 1;
-  text-align: center;
-}
-
-.calendar-body,
-.calendar-header {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: start;
-  padding: 0.5rem 0;
-}
-
-.calendar-header {
-  color: var(--#{$prefix}secondary);
-}
-
-.calendar-date {
-  flex: 0 0 calc(100% / 7);
-  max-width: calc(100% / 7);
-  padding: 0.2rem;
-  text-align: center;
-  border: 0;
-
-  &.prev-month,
-  &.next-month {
-    opacity: 0.25;
+@layer components {
+  .calendar {
+    display: block;
+    font-size: $font-size-sm;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+    @include border-radius(var(--#{$prefix}border-radius));
   }
 
-  .date-item {
-    position: relative;
-    display: inline-block;
-    width: 1.4rem;
-    height: 1.4rem;
-    line-height: 1.4rem;
-    color: #66758c;
-    text-align: center;
-    text-decoration: none;
-    white-space: nowrap;
-    vertical-align: middle;
-    cursor: pointer;
-    background: 0 0;
-    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) transparent;
-    @include border-radius(var(--#{$prefix}border-radius-pill));
-    outline: 0;
-    @include transition(background $transition-time, border $transition-time, box-shadow 0.32s, color $transition-time);
+  .calendar-nav {
+    display: flex;
+    align-items: center;
+  }
 
-    &:hover {
-      color: var(--#{$prefix}primary);
+  .calendar-title {
+    flex: 1;
+    text-align: center;
+  }
+
+  .calendar-body,
+  .calendar-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: start;
+    padding: 0.5rem 0;
+  }
+
+  .calendar-header {
+    color: var(--#{$prefix}secondary);
+  }
+
+  .calendar-date {
+    flex: 0 0 calc(100% / 7);
+    max-width: calc(100% / 7);
+    padding: 0.2rem;
+    text-align: center;
+    border: 0;
+
+    &.prev-month,
+    &.next-month {
+      opacity: 0.25;
+    }
+
+    .date-item {
+      position: relative;
+      display: inline-block;
+      width: 1.4rem;
+      height: 1.4rem;
+      line-height: 1.4rem;
+      color: #66758c;
+      text-align: center;
       text-decoration: none;
-      background: #fefeff;
+      white-space: nowrap;
+      vertical-align: middle;
+      cursor: pointer;
+      background: 0 0;
+      border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) transparent;
+      @include border-radius(var(--#{$prefix}border-radius-pill));
+      outline: 0;
+      @include transition(background $transition-time, border $transition-time, box-shadow 0.32s, color $transition-time);
+
+      &:hover {
+        color: var(--#{$prefix}primary);
+        text-decoration: none;
+        background: #fefeff;
+        border-color: var(--#{$prefix}border-color);
+      }
+    }
+
+    .date-today {
+      color: var(--#{$prefix}primary);
       border-color: var(--#{$prefix}border-color);
     }
   }
 
-  .date-today {
-    color: var(--#{$prefix}primary);
-    border-color: var(--#{$prefix}border-color);
-  }
-}
+  .calendar-range {
+    position: relative;
 
-.calendar-range {
-  position: relative;
-
-  &:before {
-    position: absolute;
-    top: 50%;
-    inset-inline-end: 0;
-    inset-inline-start: 0;
-    height: 1.4rem;
-    content: '';
-    background: color-transparent(var(--#{$prefix}primary), 0.1);
-    transform: translateY(-50%);
-  }
-
-  &.range-start,
-  &.range-end {
-    .date-item {
-      color: $white;
-      background: var(--#{$prefix}primary);
-      border-color: var(--#{$prefix}primary);
+    &:before {
+      position: absolute;
+      top: 50%;
+      inset-inline-end: 0;
+      inset-inline-start: 0;
+      height: 1.4rem;
+      content: '';
+      background: color-transparent(var(--#{$prefix}primary), 0.1);
+      transform: translateY(-50%);
     }
-  }
 
-  &.range-start:before {
-    inset-inline-start: 50%;
-  }
+    &.range-start,
+    &.range-end {
+      .date-item {
+        color: $white;
+        background: var(--#{$prefix}primary);
+        border-color: var(--#{$prefix}primary);
+      }
+    }
 
-  &.range-end:before {
-    inset-inline-end: 50%;
+    &.range-start:before {
+      inset-inline-start: 50%;
+    }
+
+    &.range-end:before {
+      inset-inline-end: 50%;
+    }
   }
 }

--- a/core/scss/ui/_cards.scss
+++ b/core/scss/ui/_cards.scss
@@ -1,742 +1,745 @@
 @use 'sass:map';
 
+// Emitted outside the cascade layer since `@property` registration is global.
 @property --tblr-card-gradient-direction {
   syntax: '<angle>';
   inherits: true;
   initial-value: 180deg;
 }
 
-@keyframes gradient-animation {
-  0% {
-    --#{$prefix}card-gradient-direction: 180deg;
-  }
+@layer components {
+  @keyframes gradient-animation {
+    0% {
+      --#{$prefix}card-gradient-direction: 180deg;
+    }
 
-  100% {
-    --#{$prefix}card-gradient-direction: 540deg;
-  }
-}
-
-.card {
-  @include transition(transform $transition-time ease-out, opacity $transition-time ease-out, box-shadow $transition-time ease-out);
-
-  @include media-print {
-    border: none;
-    box-shadow: none;
-  }
-
-  @at-root a#{&} {
-    color: inherit;
-
-    &:hover {
-      text-decoration: none;
-      box-shadow: var(--#{$prefix}shadow-card-hover);
+    100% {
+      --#{$prefix}card-gradient-direction: 540deg;
     }
   }
 
   .card {
+    @include transition(transform $transition-time ease-out, opacity $transition-time ease-out, box-shadow $transition-time ease-out);
+
+    @include media-print {
+      border: none;
+      box-shadow: none;
+    }
+
+    @at-root a#{&} {
+      color: inherit;
+
+      &:hover {
+        text-decoration: none;
+        box-shadow: var(--#{$prefix}shadow-card-hover);
+      }
+    }
+
+    .card {
+      box-shadow: none;
+    }
+  }
+
+  // Card borderless
+  .card-borderless {
+    &,
+    .card-header,
+    .card-footer {
+      border-color: transparent;
+    }
+  }
+
+  // Card dashed
+  .card-dashed {
+    border: var(--#{$prefix}border-width) dashed var(--#{$prefix}border-color);
+  }
+
+  // Card transparent
+  .card-transparent {
+    background: transparent;
+    border: var(--#{$prefix}border-width) dashed var(--#{$prefix}border-color);
     box-shadow: none;
   }
-}
 
-// Card borderless
-.card-borderless {
-  &,
-  .card-header,
-  .card-footer {
-    border-color: transparent;
-  }
-}
-
-// Card dashed
-.card-dashed {
-  border: var(--#{$prefix}border-width) dashed var(--#{$prefix}border-color);
-}
-
-// Card transparent
-.card-transparent {
-  background: transparent;
-  border: var(--#{$prefix}border-width) dashed var(--#{$prefix}border-color);
-  box-shadow: none;
-}
-
-// Card stamp
-.card-stamp {
-  --#{$prefix}stamp-size: 7rem;
-  position: absolute;
-  top: 0;
-  inset-inline-end: 0;
-  width: calc(var(--#{$prefix}stamp-size) * 1);
-  height: calc(var(--#{$prefix}stamp-size) * 1);
-  max-height: 100%;
-  border-start-end-radius: $border-radius;
-  opacity: $card-stamp-opacity;
-  overflow: hidden;
-  pointer-events: none;
-}
-
-.card-stamp-lg {
-  --#{$prefix}stamp-size: 13rem;
-}
-
-.card-stamp-icon {
-  background: var(--#{$prefix}secondary);
-  color: var(--#{$prefix}card-bg, var(--#{$prefix}bg-surface));
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-  width: calc(var(--#{$prefix}stamp-size) * 1);
-  height: calc(var(--#{$prefix}stamp-size) * 1);
-  position: relative;
-  top: calc(var(--#{$prefix}stamp-size) * -0.25);
-  inset-inline-end: calc(var(--#{$prefix}stamp-size) * -0.25);
-  font-size: calc(var(--#{$prefix}stamp-size) * 0.75);
-  transform: rotate(10deg);
-
-  .icon {
-    stroke-width: 2;
-    width: calc(var(--#{$prefix}stamp-size) * 0.75);
-    height: calc(var(--#{$prefix}stamp-size) * 0.75);
-  }
-}
-
-// Card image
-.card-img,
-.card-img-start {
-  @include border-start-radius($card-inner-border-radius);
-}
-
-.card-img,
-.card-img-end {
-  @include border-end-radius($card-inner-border-radius);
-}
-
-.card-img-overlay {
-  display: flex;
-  flex-direction: column;
-  justify-content: end;
-}
-
-.card-img-overlay-dark {
-  background-image: $overlay-gradient;
-}
-
-.card-inactive {
-  pointer-events: none;
-  box-shadow: none;
-
-  .card-body {
-    opacity: 0.64;
-  }
-}
-
-.card-active {
-  --#{$prefix}card-border-color: var(--#{$prefix}primary);
-  --#{$prefix}card-bg: var(--#{$prefix}active-bg);
-}
-
-.card-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: $card-spacer-y $card-spacer-x;
-  text-align: center;
-  border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-  flex: 1;
-  color: inherit;
-  font-weight: var(--#{$prefix}font-weight-medium);
-  @include transition(background $transition-time);
-
-  &:hover {
-    text-decoration: none;
-    background: $active-bg;
-  }
-
-  & + & {
-    border-inline-start: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-  }
-}
-
-/**
-Stacked card
- */
-.card-stacked {
-  --#{$prefix}card-stacked-offset: 0.25rem;
-  position: relative;
-
-  &:after {
-    position: absolute;
-    top: calc(-1 * var(--#{$prefix}card-stacked-offset));
-    inset-inline-end: var(--#{$prefix}card-stacked-offset);
-    inset-inline-start: var(--#{$prefix}card-stacked-offset);
-    height: var(--#{$prefix}card-stacked-offset);
-    content: '';
-    background: var(--#{$prefix}card-bg, var(--#{$prefix}bg-surface));
-    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}card-border-color);
-    @include border-radius(var(--#{$prefix}card-border-radius) var(--#{$prefix}card-border-radius) 0 0);
-  }
-}
-
-.card-cover {
-  position: relative;
-  padding: $card-spacer-y $card-spacer-x;
-  background: #666666 no-repeat center/cover;
-
-  &:before {
+  // Card stamp
+  .card-stamp {
+    --#{$prefix}stamp-size: 7rem;
     position: absolute;
     top: 0;
     inset-inline-end: 0;
-    bottom: 0;
-    inset-inline-start: 0;
-    content: '';
-    background: rgba($dark, 0.48);
+    width: calc(var(--#{$prefix}stamp-size) * 1);
+    height: calc(var(--#{$prefix}stamp-size) * 1);
+    max-height: 100%;
+    border-start-end-radius: $border-radius;
+    opacity: $card-stamp-opacity;
+    overflow: hidden;
+    pointer-events: none;
   }
 
-  &:first-child,
-  &:first-child:before {
-    @include border-radius($border-radius $border-radius 0 0);
+  .card-stamp-lg {
+    --#{$prefix}stamp-size: 13rem;
   }
-}
 
-.card-cover-blurred {
-  &:before {
-    backdrop-filter: blur(2px);
+  .card-stamp-icon {
+    background: var(--#{$prefix}secondary);
+    color: var(--#{$prefix}card-bg, var(--#{$prefix}bg-surface));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    @include border-radius(var(--#{$prefix}border-radius-pill));
+    width: calc(var(--#{$prefix}stamp-size) * 1);
+    height: calc(var(--#{$prefix}stamp-size) * 1);
+    position: relative;
+    top: calc(var(--#{$prefix}stamp-size) * -0.25);
+    inset-inline-end: calc(var(--#{$prefix}stamp-size) * -0.25);
+    font-size: calc(var(--#{$prefix}stamp-size) * 0.75);
+    transform: rotate(10deg);
+
+    .icon {
+      stroke-width: 2;
+      width: calc(var(--#{$prefix}stamp-size) * 0.75);
+      height: calc(var(--#{$prefix}stamp-size) * 0.75);
+    }
   }
-}
 
-.card-actions {
-  margin: -0.5rem -0.5rem -0.5rem auto;
-  padding-inline-start: 0.5rem;
-
-  a {
-    text-decoration: none;
+  // Card image
+  .card-img,
+  .card-img-start {
+    @include border-start-radius($card-inner-border-radius);
   }
-}
 
-// Card header
-.card-header {
-  color: inherit;
-  display: flex;
-  align-items: center;
-  background: transparent;
+  .card-img,
+  .card-img-end {
+    @include border-end-radius($card-inner-border-radius);
+  }
 
-  &:first-child {
+  .card-img-overlay {
+    display: flex;
+    flex-direction: column;
+    justify-content: end;
+  }
+
+  .card-img-overlay-dark {
+    background-image: $overlay-gradient;
+  }
+
+  .card-inactive {
+    pointer-events: none;
+    box-shadow: none;
+
+    .card-body {
+      opacity: 0.64;
+    }
+  }
+
+  .card-active {
+    --#{$prefix}card-border-color: var(--#{$prefix}primary);
+    --#{$prefix}card-bg: var(--#{$prefix}active-bg);
+  }
+
+  .card-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: $card-spacer-y $card-spacer-x;
+    text-align: center;
+    border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+    flex: 1;
+    color: inherit;
+    font-weight: var(--#{$prefix}font-weight-medium);
+    @include transition(background $transition-time);
+
+    &:hover {
+      text-decoration: none;
+      background: $active-bg;
+    }
+
+    & + & {
+      border-inline-start: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+    }
+  }
+
+  /**
+  Stacked card
+   */
+  .card-stacked {
+    --#{$prefix}card-stacked-offset: 0.25rem;
+    position: relative;
+
+    &:after {
+      position: absolute;
+      top: calc(-1 * var(--#{$prefix}card-stacked-offset));
+      inset-inline-end: var(--#{$prefix}card-stacked-offset);
+      inset-inline-start: var(--#{$prefix}card-stacked-offset);
+      height: var(--#{$prefix}card-stacked-offset);
+      content: '';
+      background: var(--#{$prefix}card-bg, var(--#{$prefix}bg-surface));
+      border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}card-border-color);
+      @include border-radius(var(--#{$prefix}card-border-radius) var(--#{$prefix}card-border-radius) 0 0);
+    }
+  }
+
+  .card-cover {
+    position: relative;
+    padding: $card-spacer-y $card-spacer-x;
+    background: #666666 no-repeat center/cover;
+
+    &:before {
+      position: absolute;
+      top: 0;
+      inset-inline-end: 0;
+      bottom: 0;
+      inset-inline-start: 0;
+      content: '';
+      background: rgba($dark, 0.48);
+    }
+
+    &:first-child,
+    &:first-child:before {
+      @include border-radius($border-radius $border-radius 0 0);
+    }
+  }
+
+  .card-cover-blurred {
+    &:before {
+      backdrop-filter: blur(2px);
+    }
+  }
+
+  .card-actions {
+    margin: -0.5rem -0.5rem -0.5rem auto;
+    padding-inline-start: 0.5rem;
+
+    a {
+      text-decoration: none;
+    }
+  }
+
+  // Card header
+  .card-header {
+    color: inherit;
+    display: flex;
+    align-items: center;
+    background: transparent;
+
+    &:first-child {
+      @include border-radius(var(--#{$prefix}card-border-radius) var(--#{$prefix}card-border-radius) 0 0);
+    }
+  }
+
+  .card-header-light {
+    border-bottom-color: transparent;
+    background: var(--#{$prefix}bg-surface-tertiary);
+  }
+
+  .card-header-tabs {
+    background: $card-header-tabs-bg;
+    flex: 1;
+    margin: calc(var(--#{$prefix}card-cap-padding-y) * -1) calc(var(--#{$prefix}card-cap-padding-x) * -1) calc(var(--#{$prefix}card-cap-padding-y) * -1);
+    padding: calc(var(--#{$prefix}card-cap-padding-y) * 0.5) calc(var(--#{$prefix}card-cap-padding-x) * 0.5) 0;
     @include border-radius(var(--#{$prefix}card-border-radius) var(--#{$prefix}card-border-radius) 0 0);
   }
-}
 
-.card-header-light {
-  border-bottom-color: transparent;
-  background: var(--#{$prefix}bg-surface-tertiary);
-}
-
-.card-header-tabs {
-  background: $card-header-tabs-bg;
-  flex: 1;
-  margin: calc(var(--#{$prefix}card-cap-padding-y) * -1) calc(var(--#{$prefix}card-cap-padding-x) * -1) calc(var(--#{$prefix}card-cap-padding-y) * -1);
-  padding: calc(var(--#{$prefix}card-cap-padding-y) * 0.5) calc(var(--#{$prefix}card-cap-padding-x) * 0.5) 0;
-  @include border-radius(var(--#{$prefix}card-border-radius) var(--#{$prefix}card-border-radius) 0 0);
-}
-
-.card-header-pills {
-  flex: 1;
-  margin-top: -0.5rem;
-  margin-bottom: -0.5rem;
-}
-
-// Card rotate
-.card-rotate-left,
-.card-rotate-start {
-  transform: rotate(-1.5deg);
-}
-
-.card-rotate-right,
-.card-rotate-end {
-  transform: rotate(1.5deg);
-}
-
-// Card link
-.card-link {
-  color: inherit;
-
-  &:hover {
-    color: inherit;
-    text-decoration: none;
-    box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.08);
+  .card-header-pills {
+    flex: 1;
+    margin-top: -0.5rem;
+    margin-bottom: -0.5rem;
   }
-}
 
-.card-link-rotate:hover {
-  transform: rotate(1.5deg);
-  opacity: 1;
-}
+  // Card rotate
+  .card-rotate-left,
+  .card-rotate-start {
+    transform: rotate(-1.5deg);
+  }
 
-.card-link-pop:hover {
-  transform: translateY(-2px);
-  opacity: 1;
-}
+  .card-rotate-right,
+  .card-rotate-end {
+    transform: rotate(1.5deg);
+  }
 
-// Card footer
-.card-footer {
-  margin-top: auto;
+  // Card link
+  .card-link {
+    color: inherit;
 
-  &:last-child {
+    &:hover {
+      color: inherit;
+      text-decoration: none;
+      box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.08);
+    }
+  }
+
+  .card-link-rotate:hover {
+    transform: rotate(1.5deg);
+    opacity: 1;
+  }
+
+  .card-link-pop:hover {
+    transform: translateY(-2px);
+    opacity: 1;
+  }
+
+  // Card footer
+  .card-footer {
+    margin-top: auto;
+
+    &:last-child {
+      @include border-radius(0 0 var(--#{$prefix}card-border-radius) var(--#{$prefix}card-border-radius));
+    }
+  }
+
+  .card-footer-transparent {
+    background: transparent;
+    border-color: transparent;
+    padding-top: 0;
+  }
+
+  .card-footer-borderless {
+    border-top: none;
+  }
+
+  // Card progress
+  .card-progress {
+    height: 0.25rem;
+
+    &:last-child {
+      @include border-radius(0 0 2px 2px);
+    }
+
+    &:first-child {
+      @include border-radius(2px 2px 0 0);
+    }
+  }
+
+  .card-meta {
+    color: var(--#{$prefix}secondary);
+  }
+
+  .card-title {
+    display: block;
+    margin: 0 0 1rem;
+    font-size: $h3-font-size;
+    font-weight: var(--#{$prefix}font-weight-medium);
+    color: var(--#{$prefix}heading-color);
+    line-height: 1.5rem;
+
+    @at-root a#{&}:hover {
+      color: inherit;
+    }
+
+    .card-header & {
+      margin: 0;
+    }
+  }
+
+  .card-subtitle {
+    margin-bottom: $card-title-spacer-y;
+    color: var(--#{$prefix}secondary);
+    font-weight: normal;
+
+    .card-header & {
+      margin: 0;
+    }
+
+    .card-title & {
+      margin: 0 0 0 0.25rem;
+      font-size: $h4-font-size;
+    }
+  }
+
+  .card-body {
+    position: relative;
+
+    > :last-child {
+      margin-bottom: 0;
+    }
+
+    .card-sm > & {
+      padding: 1rem;
+    }
+
+    .card-md > & {
+      @include media-breakpoint-up(md) {
+        padding: 2.5rem;
+      }
+    }
+
+    .card-lg > & {
+      @include media-breakpoint-up(md) {
+        padding: 2rem;
+      }
+
+      @include media-breakpoint-up(lg) {
+        padding: 4rem;
+      }
+    }
+
+    @include media-print {
+      padding: 0;
+    }
+
+    & + & {
+      border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+    }
+  }
+
+  .card-body-scrollable {
+    overflow: auto;
+  }
+
+  /**
+  Card optinos
+   */
+  .card-options {
+    top: 1.5rem;
+    inset-inline-end: 0.75rem;
+    display: flex;
+    margin-inline-start: auto;
+  }
+
+  .card-options-link {
+    display: inline-block;
+    min-width: 1rem;
+    margin-inline-start: 0.25rem;
+    color: var(--#{$prefix}secondary);
+  }
+
+  /**
+  Card status
+   */
+  .card-status-top {
+    position: absolute;
+    top: 0;
+    inset-inline-end: 0;
+    inset-inline-start: 0;
+    height: $card-status-size;
+    @include border-radius(var(--#{$prefix}card-border-radius) var(--#{$prefix}card-border-radius) 0 0);
+  }
+
+  .card-status-start {
+    position: absolute;
+    inset-inline-end: auto;
+    bottom: 0;
+    width: $card-status-size;
+    height: 100%;
+    @include border-radius(var(--#{$prefix}card-border-radius) 0 0 var(--#{$prefix}card-border-radius));
+  }
+
+  .card-status-bottom {
+    position: absolute;
+    top: initial;
+    bottom: 0;
+    width: 100%;
+    height: $card-status-size;
     @include border-radius(0 0 var(--#{$prefix}card-border-radius) var(--#{$prefix}card-border-radius));
   }
-}
 
-.card-footer-transparent {
-  background: transparent;
-  border-color: transparent;
-  padding-top: 0;
-}
-
-.card-footer-borderless {
-  border-top: none;
-}
-
-// Card progress
-.card-progress {
-  height: 0.25rem;
-
-  &:last-child {
-    @include border-radius(0 0 2px 2px);
-  }
-
-  &:first-child {
-    @include border-radius(2px 2px 0 0);
-  }
-}
-
-.card-meta {
-  color: var(--#{$prefix}secondary);
-}
-
-.card-title {
-  display: block;
-  margin: 0 0 1rem;
-  font-size: $h3-font-size;
-  font-weight: var(--#{$prefix}font-weight-medium);
-  color: var(--#{$prefix}heading-color);
-  line-height: 1.5rem;
-
-  @at-root a#{&}:hover {
-    color: inherit;
-  }
-
-  .card-header & {
-    margin: 0;
-  }
-}
-
-.card-subtitle {
-  margin-bottom: $card-title-spacer-y;
-  color: var(--#{$prefix}secondary);
-  font-weight: normal;
-
-  .card-header & {
-    margin: 0;
-  }
-
-  .card-title & {
-    margin: 0 0 0 0.25rem;
-    font-size: $h4-font-size;
-  }
-}
-
-.card-body {
-  position: relative;
-
-  > :last-child {
-    margin-bottom: 0;
-  }
-
-  .card-sm > & {
-    padding: 1rem;
-  }
-
-  .card-md > & {
-    @include media-breakpoint-up(md) {
-      padding: 2.5rem;
-    }
-  }
-
-  .card-lg > & {
-    @include media-breakpoint-up(md) {
-      padding: 2rem;
-    }
-
-    @include media-breakpoint-up(lg) {
-      padding: 4rem;
-    }
-  }
-
-  @include media-print {
-    padding: 0;
-  }
-
-  & + & {
-    border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-  }
-}
-
-.card-body-scrollable {
-  overflow: auto;
-}
-
-/**
-Card optinos
- */
-.card-options {
-  top: 1.5rem;
-  inset-inline-end: 0.75rem;
-  display: flex;
-  margin-inline-start: auto;
-}
-
-.card-options-link {
-  display: inline-block;
-  min-width: 1rem;
-  margin-inline-start: 0.25rem;
-  color: var(--#{$prefix}secondary);
-}
-
-/**
-Card status
- */
-.card-status-top {
-  position: absolute;
-  top: 0;
-  inset-inline-end: 0;
-  inset-inline-start: 0;
-  height: $card-status-size;
-  @include border-radius(var(--#{$prefix}card-border-radius) var(--#{$prefix}card-border-radius) 0 0);
-}
-
-.card-status-start {
-  position: absolute;
-  inset-inline-end: auto;
-  bottom: 0;
-  width: $card-status-size;
-  height: 100%;
-  @include border-radius(var(--#{$prefix}card-border-radius) 0 0 var(--#{$prefix}card-border-radius));
-}
-
-.card-status-bottom {
-  position: absolute;
-  top: initial;
-  bottom: 0;
-  width: 100%;
-  height: $card-status-size;
-  @include border-radius(0 0 var(--#{$prefix}card-border-radius) var(--#{$prefix}card-border-radius));
-}
-
-/**
-Card table
- */
-.card-table {
-  margin-bottom: 0 !important;
-
-  tr {
-    td,
-    th {
-      &:first-child {
-        padding-left: $card-spacer-x;
-        border-left: 0;
-        border-top-left-radius: var(--#{$prefix}card-border-radius);
-      }
-
-      &:last-child {
-        padding-right: $card-spacer-x;
-        border-right: 0;
-        border-top-right-radius: var(--#{$prefix}card-border-radius);
-        padding-inline-start: $card-spacer-x;
-        border-inline-start: 0;
-      }
-
-      &:last-child {
-        padding-inline-end: $card-spacer-x;
-        border-inline-end: 0;
-      }
-    }
-  }
-
-  thead,
-  tbody,
-  tfoot {
-    &:last-child {
-      tr:last-child {
-        > *:last-child {
-          border-end-end-radius: calc(var(--#{$prefix}card-border-radius) - var(--#{$prefix}card-border-width));
-        }
-
-        > *:first-child {
-          border-end-start-radius: calc(var(--#{$prefix}card-border-radius) - var(--#{$prefix}card-border-width));
-        }
-      }
-    }
+  /**
+  Card table
+   */
+  .card-table {
+    margin-bottom: 0 !important;
 
     tr {
-      &:first-child {
-        border-top: 0;
+      td,
+      th {
+        &:first-child {
+          padding-left: $card-spacer-x;
+          border-left: 0;
+          border-top-left-radius: var(--#{$prefix}card-border-radius);
+        }
 
-        td,
-        th {
+        &:last-child {
+          padding-right: $card-spacer-x;
+          border-right: 0;
+          border-top-right-radius: var(--#{$prefix}card-border-radius);
+          padding-inline-start: $card-spacer-x;
+          border-inline-start: 0;
+        }
+
+        &:last-child {
+          padding-inline-end: $card-spacer-x;
+          border-inline-end: 0;
+        }
+      }
+    }
+
+    thead,
+    tbody,
+    tfoot {
+      &:last-child {
+        tr:last-child {
+          > *:last-child {
+            border-end-end-radius: calc(var(--#{$prefix}card-border-radius) - var(--#{$prefix}card-border-width));
+          }
+
+          > *:first-child {
+            border-end-start-radius: calc(var(--#{$prefix}card-border-radius) - var(--#{$prefix}card-border-width));
+          }
+        }
+      }
+
+      tr {
+        &:first-child {
           border-top: 0;
+
+          td,
+          th {
+            border-top: 0;
+          }
         }
       }
     }
-  }
 
-  tbody {
-    tr {
-      &:last-child {
-        td {
+    tbody {
+      tr {
+        &:last-child {
+          td {
+            border-bottom: 0;
+          }
+        }
+      }
+    }
+
+    tfoot {
+      tr {
+        &:last-child {
           border-bottom: 0;
         }
       }
     }
+
+    .card-body + & {
+      border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}table-border-color);
+    }
   }
 
-  tfoot {
-    tr {
+  /*
+  Card code
+   */
+  .card-code {
+    padding: 0;
+
+    .highlight {
+      margin: 0;
+      border: 0;
+    }
+
+    pre {
+      margin: 0 !important;
+      border: 0 !important;
+    }
+  }
+
+  /*
+  Card chart
+   */
+  .card-chart {
+    position: relative;
+    z-index: 1;
+    height: 3.5rem;
+  }
+
+  /**
+  Card avatar
+   */
+  .card-avatar {
+    margin-inline-start: auto;
+    margin-inline-end: auto;
+    box-shadow: 0 0 0 0.25rem var(--#{$prefix}card-bg, var(--#{$prefix}bg-surface));
+    margin-top: calc(-1 * calc(var(--#{$prefix}avatar-size) * 0.5));
+  }
+
+  /*
+  Card list group
+   */
+  .card-list-group {
+    .card-body + & {
+      border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+    }
+
+    .list-group-item {
+      padding-inline-end: $card-spacer-x;
+      padding-inline-start: $card-spacer-x;
+      border-inline-end: 0;
+      border-inline-start: 0;
+      border-radius: 0;
+
       &:last-child {
         border-bottom: 0;
       }
+
+      &:first-child {
+        border-top: 0;
+      }
     }
   }
 
-  .card-body + & {
-    border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}table-border-color);
-  }
-}
-
-/*
-Card code
- */
-.card-code {
-  padding: 0;
-
-  .highlight {
-    margin: 0;
-    border: 0;
-  }
-
-  pre {
-    margin: 0 !important;
-    border: 0 !important;
-  }
-}
-
-/*
-Card chart
- */
-.card-chart {
-  position: relative;
-  z-index: 1;
-  height: 3.5rem;
-}
-
-/**
-Card avatar
- */
-.card-avatar {
-  margin-inline-start: auto;
-  margin-inline-end: auto;
-  box-shadow: 0 0 0 0.25rem var(--#{$prefix}card-bg, var(--#{$prefix}bg-surface));
-  margin-top: calc(-1 * calc(var(--#{$prefix}avatar-size) * 0.5));
-}
-
-/*
-Card list group
- */
-.card-list-group {
-  .card-body + & {
-    border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-  }
-
-  .list-group-item {
-    padding-inline-end: $card-spacer-x;
-    padding-inline-start: $card-spacer-x;
-    border-inline-end: 0;
-    border-inline-start: 0;
-    border-radius: 0;
-
-    &:last-child {
+  // Card tabs
+  .card-tabs {
+    .nav-tabs {
+      position: relative;
+      z-index: $zindex-dropdown;
       border-bottom: 0;
-    }
 
-    &:first-child {
-      border-top: 0;
-    }
-  }
-}
+      .nav-link {
+        background: $card-cap-bg;
+        border: $card-border-width var(--#{$prefix}border-style) $card-border-color;
 
-// Card tabs
-.card-tabs {
-  .nav-tabs {
-    position: relative;
-    z-index: $zindex-dropdown;
-    border-bottom: 0;
+        &.active,
+        &:active,
+        &:hover {
+          border-color: $card-border-color;
+          color: var(--#{$prefix}body-color);
+        }
 
-    .nav-link {
-      background: $card-cap-bg;
-      border: $card-border-width var(--#{$prefix}border-style) $card-border-color;
-
-      &.active,
-      &:active,
-      &:hover {
-        border-color: $card-border-color;
-        color: var(--#{$prefix}body-color);
-      }
-
-      &.active {
-        color: $headings-color;
-        background: var(--#{$prefix}card-bg, var(--#{$prefix}bg-surface));
-        border-bottom-color: transparent;
-      }
-    }
-
-    .nav-item {
-      &:not(:first-child) {
-        .nav-link {
-          border-start-start-radius: 0;
+        &.active {
+          color: $headings-color;
+          background: var(--#{$prefix}card-bg, var(--#{$prefix}bg-surface));
+          border-bottom-color: transparent;
         }
       }
 
-      &:not(:last-child) {
-        .nav-link {
-          border-start-end-radius: 0;
+      .nav-item {
+        &:not(:first-child) {
+          .nav-link {
+            border-start-start-radius: 0;
+          }
+        }
+
+        &:not(:last-child) {
+          .nav-link {
+            border-start-end-radius: 0;
+          }
+        }
+
+        + .nav-item {
+          margin-inline-start: calc(-1 * #{$card-border-width});
         }
       }
-
-      + .nav-item {
-        margin-inline-start: calc(-1 * #{$card-border-width});
-      }
-    }
-  }
-
-  .nav-tabs-bottom {
-    margin-bottom: 0;
-
-    .nav-link {
-      margin-bottom: 0;
-
-      &.active {
-        border-top-color: transparent;
-      }
     }
 
-    .nav-item {
-      margin-top: calc(-1 * #{$card-border-width});
+    .nav-tabs-bottom {
       margin-bottom: 0;
 
       .nav-link {
-        border-bottom: $card-border-width var(--#{$prefix}border-style) $card-border-color;
-        @include border-radius(0 0 $card-border-radius $card-border-radius);
+        margin-bottom: 0;
+
+        &.active {
+          border-top-color: transparent;
+        }
       }
 
-      &:not(:first-child) .nav-link {
-        border-end-start-radius: 0;
-      }
+      .nav-item {
+        margin-top: calc(-1 * #{$card-border-width});
+        margin-bottom: 0;
 
-      &:not(:last-child) .nav-link {
-        border-end-end-radius: 0;
+        .nav-link {
+          border-bottom: $card-border-width var(--#{$prefix}border-style) $card-border-color;
+          @include border-radius(0 0 $card-border-radius $card-border-radius);
+        }
+
+        &:not(:first-child) .nav-link {
+          border-end-start-radius: 0;
+        }
+
+        &:not(:last-child) .nav-link {
+          border-end-end-radius: 0;
+        }
       }
+    }
+
+    .card {
+      border-end-start-radius: 0;
+    }
+
+    .nav-tabs + .tab-content .card {
+      border-end-start-radius: var(--#{$prefix}card-border-radius);
+      border-start-start-radius: 0 !important;
+    }
+
+    .tab-content:has(+ .nav-tabs) .card {
+      border-start-start-radius: var(--#{$prefix}card-border-radius);
+      border-end-start-radius: 0 !important;
     }
   }
 
-  .card {
-    border-end-start-radius: 0;
+  /**
+  Card note
+  */
+  .card-note {
+    --#{$prefix}card-bg: #fff7dd;
+    --#{$prefix}card-border-color: #fff1c9;
   }
 
-  .nav-tabs + .tab-content .card {
-    border-end-start-radius: var(--#{$prefix}card-border-radius);
-    border-start-start-radius: 0 !important;
+  /**
+  Card gradient
+  */
+  .card-gradient {
+    --#{$prefix}card-gradient-direction: 180deg;
+    --#{$prefix}card-gradient-opacity: 86%;
+    --#{$prefix}card-gradient: var(--tblr-primary), var(--tblr-primary);
+
+    background:
+      radial-gradient(ellipse at center, var(--#{$prefix}card-bg) 0%, color-mix(in srgb, var(--#{$prefix}card-bg) 0%, transparent) 80%) border-box,
+      linear-gradient(var(--#{$prefix}card-gradient-direction), color-mix(in srgb, var(--#{$prefix}card-bg) var(--#{$prefix}card-gradient-opacity), transparent) 0%, var(--#{$prefix}card-bg) 40%) border-box,
+      linear-gradient(calc(270deg + var(--#{$prefix}card-gradient-direction)), var(--#{$prefix}card-gradient)) border-box;
   }
-  
-  .tab-content:has(+ .nav-tabs) .card {
-    border-start-start-radius: var(--#{$prefix}card-border-radius);
-    border-end-start-radius: 0 !important;
+
+  @each $name, $color in map.merge($colors, $theme-colors) {
+    .card-gradient-#{$name} {
+      --#{$prefix}card-gradient: var(--tblr-#{$name}), var(--tblr-#{$name});
+    }
   }
-}
 
-/**
-Card note
-*/
-.card-note {
-  --#{$prefix}card-bg: #fff7dd;
-  --#{$prefix}card-border-color: #fff1c9;
-}
-
-/**
-Card gradient
-*/
-.card-gradient {
-  --#{$prefix}card-gradient-direction: 180deg;
-  --#{$prefix}card-gradient-opacity: 86%;
-  --#{$prefix}card-gradient: var(--tblr-primary), var(--tblr-primary);
-
-  background:
-    radial-gradient(ellipse at center, var(--#{$prefix}card-bg) 0%, color-mix(in srgb, var(--#{$prefix}card-bg) 0%, transparent) 80%) border-box,
-    linear-gradient(var(--#{$prefix}card-gradient-direction), color-mix(in srgb, var(--#{$prefix}card-bg) var(--#{$prefix}card-gradient-opacity), transparent) 0%, var(--#{$prefix}card-bg) 40%) border-box,
-    linear-gradient(calc(270deg + var(--#{$prefix}card-gradient-direction)), var(--#{$prefix}card-gradient)) border-box;
-}
-
-@each $name, $color in map.merge($colors, $theme-colors) {
-  .card-gradient-#{$name} {
-    --#{$prefix}card-gradient: var(--tblr-#{$name}), var(--tblr-#{$name});
+  .card-gradient-rainbow {
+    --#{$prefix}card-gradient: #78c5d6, #459ba8, #79c267, #c5d647, #f5d63d, #f08b33, #e868a2, #be61a5;
   }
-}
 
-.card-gradient-rainbow {
-  --#{$prefix}card-gradient: #78c5d6, #459ba8, #79c267, #c5d647, #f5d63d, #f08b33, #e868a2, #be61a5;
-}
+  .card-gradient-sun {
+    --#{$prefix}card-gradient: #fd1d1d, #fcb045;
+  }
 
-.card-gradient-sun {
-  --#{$prefix}card-gradient: #fd1d1d, #fcb045;
-}
+  .card-gradient-snow {
+    --#{$prefix}card-gradient: #333, #e9ecef;
+  }
 
-.card-gradient-snow {
-  --#{$prefix}card-gradient: #333, #e9ecef;
-}
+  .card-gradient-ocean {
+    --#{$prefix}card-gradient: #1cb5e0, #000851;
+  }
 
-.card-gradient-ocean {
-  --#{$prefix}card-gradient: #1cb5e0, #000851;
-}
+  .card-gradient-mellow {
+    --#{$prefix}card-gradient: #f8ff00, #3ad59f;
+  }
 
-.card-gradient-mellow {
-  --#{$prefix}card-gradient: #f8ff00, #3ad59f;
-}
+  .card-gradient-disco {
+    --#{$prefix}card-gradient: #fc466b, #3f5efb;
+  }
 
-.card-gradient-disco {
-  --#{$prefix}card-gradient: #fc466b, #3f5efb;
-}
+  .card-gradient-psychedelic {
+    --#{$prefix}card-gradient: #fcc5e4, #fda34b, #ff7882, #c8699e, #7046aa, #0c1db8, #020f75;
+  }
 
-.card-gradient-psychedelic {
-  --#{$prefix}card-gradient: #fcc5e4, #fda34b, #ff7882, #c8699e, #7046aa, #0c1db8, #020f75;
-}
+  .card-gradient-love {
+    --#{$prefix}card-gradient: #f235e6, #bc0707;
+  }
 
-.card-gradient-love {
-  --#{$prefix}card-gradient: #f235e6, #bc0707;
-}
+  .card-gradient-gold {
+    --#{$prefix}card-gradient: #9d4100, #bf7122, #f59f00, #ffd700;
+  }
 
-.card-gradient-gold {
-  --#{$prefix}card-gradient: #9d4100, #bf7122, #f59f00, #ffd700;
-}
+  .card-gradient-animated {
+    animation: gradient-animation 15s linear infinite;
+  }
 
-.card-gradient-animated {
-  animation: gradient-animation 15s linear infinite;
-}
+  .card-gradient-bottom {
+    --#{$prefix}card-gradient-direction: 0deg;
+  }
 
-.card-gradient-bottom {
-  --#{$prefix}card-gradient-direction: 0deg;
-}
+  .card-gradient-end {
+    --#{$prefix}card-gradient-direction: 270deg;
+  }
 
-.card-gradient-end {
-  --#{$prefix}card-gradient-direction: 270deg;
-}
-
-.card-gradient-start {
-  --#{$prefix}card-gradient-direction: 90deg;
+  .card-gradient-start {
+    --#{$prefix}card-gradient-direction: 90deg;
+  }
 }

--- a/core/scss/ui/_carousel.scss
+++ b/core/scss/ui/_carousel.scss
@@ -1,71 +1,73 @@
-.carousel {
-}
-
-.carousel-indicators-vertical {
-  inset-inline-start: auto;
-  top: 0;
-  margin: 0 1rem 0 0;
-  flex-direction: column;
-
-  [data-bs-target],
-  [data-target] {
-    margin: $carousel-indicator-spacer 0 $carousel-indicator-spacer;
-    width: $carousel-indicator-height;
-    height: $carousel-indicator-width;
-    border: 0;
-    border-inline-start: $carousel-indicator-hit-area-height var(--#{$prefix}border-style) transparent;
-    border-inline-end: $carousel-indicator-hit-area-height var(--#{$prefix}border-style) transparent;
-  }
-}
-
-.carousel-indicators-dot {
-  [data-bs-target],
-  [data-target] {
-    width: $carousel-indicator-dot-width;
-    height: $carousel-indicator-dot-width;
-    @include border-radius(var(--#{$prefix}border-radius-pill));
-    border: $carousel-indicator-hit-area-height var(--#{$prefix}border-style) transparent;
-    margin: 0;
-  }
-}
-
-.carousel-indicators-thumb {
-  [data-bs-target],
-  [data-target] {
-    width: $carousel-indicator-thumb-width * 0.5;
-    height: auto;
-    background: no-repeat center/cover;
-    border: 0;
-    @include border-radius(var(--#{$prefix}border-radius));
-    box-shadow: $box-shadow;
-    margin: 0 $carousel-indicator-spacer;
-    opacity: $carousel-indicator-thumb-opacity;
-
-    @include media-breakpoint-up(lg) {
-      width: $carousel-indicator-thumb-width;
-    }
-
-    &:before {
-      content: '';
-      padding-top: var(--#{$prefix}aspect-ratio, 100%);
-      display: block;
-    }
+@layer components {
+  .carousel {
   }
 
-  &.carousel-indicators-vertical {
+  .carousel-indicators-vertical {
+    inset-inline-start: auto;
+    top: 0;
+    margin: 0 1rem 0 0;
+    flex-direction: column;
+
     [data-bs-target],
     [data-target] {
-      margin: $carousel-indicator-spacer 0;
+      margin: $carousel-indicator-spacer 0 $carousel-indicator-spacer;
+      width: $carousel-indicator-height;
+      height: $carousel-indicator-width;
+      border: 0;
+      border-inline-start: $carousel-indicator-hit-area-height var(--#{$prefix}border-style) transparent;
+      border-inline-end: $carousel-indicator-hit-area-height var(--#{$prefix}border-style) transparent;
     }
   }
-}
 
-.carousel-caption-background {
-  background: red;
-  position: absolute;
-  inset-inline-start: 0;
-  inset-inline-end: 0;
-  bottom: 0;
-  height: 90%;
-  background: linear-gradient(0deg, rgba($dark, 0.9), rgba($dark, 0));
+  .carousel-indicators-dot {
+    [data-bs-target],
+    [data-target] {
+      width: $carousel-indicator-dot-width;
+      height: $carousel-indicator-dot-width;
+      @include border-radius(var(--#{$prefix}border-radius-pill));
+      border: $carousel-indicator-hit-area-height var(--#{$prefix}border-style) transparent;
+      margin: 0;
+    }
+  }
+
+  .carousel-indicators-thumb {
+    [data-bs-target],
+    [data-target] {
+      width: $carousel-indicator-thumb-width * 0.5;
+      height: auto;
+      background: no-repeat center/cover;
+      border: 0;
+      @include border-radius(var(--#{$prefix}border-radius));
+      box-shadow: $box-shadow;
+      margin: 0 $carousel-indicator-spacer;
+      opacity: $carousel-indicator-thumb-opacity;
+
+      @include media-breakpoint-up(lg) {
+        width: $carousel-indicator-thumb-width;
+      }
+
+      &:before {
+        content: '';
+        padding-top: var(--#{$prefix}aspect-ratio, 100%);
+        display: block;
+      }
+    }
+
+    &.carousel-indicators-vertical {
+      [data-bs-target],
+      [data-target] {
+        margin: $carousel-indicator-spacer 0;
+      }
+    }
+  }
+
+  .carousel-caption-background {
+    background: red;
+    position: absolute;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
+    bottom: 0;
+    height: 90%;
+    background: linear-gradient(0deg, rgba($dark, 0.9), rgba($dark, 0));
+  }
 }

--- a/core/scss/ui/_charts.scss
+++ b/core/scss/ui/_charts.scss
@@ -1,61 +1,63 @@
-.chart {
-  display: block;
-  min-height: 10rem;
+@layer components {
+  .chart {
+    display: block;
+    min-height: 10rem;
 
-  text {
-    font-family: inherit;
+    text {
+      font-family: inherit;
+    }
   }
-}
 
-.chart-sm {
-  height: 2.5rem;
-}
+  .chart-sm {
+    height: 2.5rem;
+  }
 
-.chart-lg {
-  height: 15rem;
-}
+  .chart-lg {
+    height: 15rem;
+  }
 
-.chart-square {
-  height: 5.75rem;
-}
+  .chart-square {
+    height: 5.75rem;
+  }
 
-/**
-Chart sparkline
- */
-.chart-sparkline {
-  position: relative;
-  width: 4rem;
-  height: 2.5rem;
-  line-height: 1;
-  min-height: 0 !important;
-}
+  /**
+  Chart sparkline
+   */
+  .chart-sparkline {
+    position: relative;
+    width: 4rem;
+    height: 2.5rem;
+    line-height: 1;
+    min-height: 0 !important;
+  }
 
-.chart-sparkline-sm {
-  height: 1.5rem;
-}
+  .chart-sparkline-sm {
+    height: 1.5rem;
+  }
 
-.chart-sparkline-square {
-  width: 2.5rem;
-}
+  .chart-sparkline-square {
+    width: 2.5rem;
+  }
 
-.chart-sparkline-wide {
-  width: 6rem;
-}
+  .chart-sparkline-wide {
+    width: 6rem;
+  }
 
-.chart-sparkline-label {
-  position: absolute;
-  top: 0;
-  inset-inline-end: 0;
-  bottom: 0;
-  inset-inline-start: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: $h6-font-size;
+  .chart-sparkline-label {
+    position: absolute;
+    top: 0;
+    inset-inline-end: 0;
+    bottom: 0;
+    inset-inline-start: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: $h6-font-size;
 
-  .icon {
-    width: 1rem;
-    height: 1rem;
-    font-size: 1rem;
+    .icon {
+      width: 1rem;
+      height: 1rem;
+      font-size: 1rem;
+    }
   }
 }

--- a/core/scss/ui/_chat.scss
+++ b/core/scss/ui/_chat.scss
@@ -1,38 +1,40 @@
-.chat {
-}
+@layer components {
+  .chat {
+  }
 
-.chat-bubbles {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
+  .chat-bubbles {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
 
-.chat-bubble {
-  background: var(--#{$prefix}bg-surface-secondary);
-  @include border-radius(var(--#{$prefix}border-radius-lg));
-  padding: 1rem;
-  position: relative;
-}
+  .chat-bubble {
+    background: var(--#{$prefix}bg-surface-secondary);
+    @include border-radius(var(--#{$prefix}border-radius-lg));
+    padding: 1rem;
+    position: relative;
+  }
 
-.chat-bubble-me {
-  background-color: var(--#{$prefix}primary-lt);
-  box-shadow: none;
-}
+  .chat-bubble-me {
+    background-color: var(--#{$prefix}primary-lt);
+    box-shadow: none;
+  }
 
-.chat-bubble-title {
-  margin-bottom: 0.25rem;
-}
+  .chat-bubble-title {
+    margin-bottom: 0.25rem;
+  }
 
-.chat-bubble-author {
-  font-weight: 600;
-}
+  .chat-bubble-author {
+    font-weight: 600;
+  }
 
-.chat-bubble-date {
-  color: var(--#{$prefix}secondary);
-}
+  .chat-bubble-date {
+    color: var(--#{$prefix}secondary);
+  }
 
-.chat-bubble-body {
-  > *:last-child {
-    margin-bottom: 0;
+  .chat-bubble-body {
+    > *:last-child {
+      margin-bottom: 0;
+    }
   }
 }

--- a/core/scss/ui/_close.scss
+++ b/core/scss/ui/_close.scss
@@ -1,65 +1,67 @@
-.btn-close {
-  --#{$prefix}btn-close-color: currentColor;
-  --#{$prefix}btn-close-bg: #{escape-svg($btn-close-bg)};
-  --#{$prefix}btn-close-opacity: #{$btn-close-opacity};
-  --#{$prefix}btn-close-hover-opacity: #{$btn-close-hover-opacity};
-  --#{$prefix}btn-close-focus-shadow: #{$btn-close-focus-shadow};
-  --#{$prefix}btn-close-focus-opacity: #{$btn-close-focus-opacity};
-  --#{$prefix}btn-close-disabled-opacity: #{$btn-close-disabled-opacity};
-  --#{$prefix}btn-close-size: #{$btn-close-width};
+@layer components {
+  .btn-close {
+    --#{$prefix}btn-close-color: currentColor;
+    --#{$prefix}btn-close-bg: #{escape-svg($btn-close-bg)};
+    --#{$prefix}btn-close-opacity: #{$btn-close-opacity};
+    --#{$prefix}btn-close-hover-opacity: #{$btn-close-hover-opacity};
+    --#{$prefix}btn-close-focus-shadow: #{$btn-close-focus-shadow};
+    --#{$prefix}btn-close-focus-opacity: #{$btn-close-focus-opacity};
+    --#{$prefix}btn-close-disabled-opacity: #{$btn-close-disabled-opacity};
+    --#{$prefix}btn-close-size: #{$btn-close-width};
 
-  width: var(--#{$prefix}btn-close-size);
-  height: var(--#{$prefix}btn-close-size);
-  padding: $btn-close-padding-y $btn-close-padding-x;
-  color: var(--#{$prefix}btn-close-color);
-  mask: var(--#{$prefix}btn-close-bg) no-repeat center/calc(var(--#{$prefix}btn-close-size) * 0.75);
-  background-color: var(--#{$prefix}btn-close-color);
-  border: 0;
-  @include border-radius(var(--tblr-border-radius));
-  opacity: var(--#{$prefix}btn-close-opacity);
-  cursor: pointer;
-  display: block;
-
-  &:hover {
+    width: var(--#{$prefix}btn-close-size);
+    height: var(--#{$prefix}btn-close-size);
+    padding: $btn-close-padding-y $btn-close-padding-x;
     color: var(--#{$prefix}btn-close-color);
-    text-decoration: none;
-    opacity: var(--#{$prefix}btn-close-hover-opacity);
+    mask: var(--#{$prefix}btn-close-bg) no-repeat center/calc(var(--#{$prefix}btn-close-size) * 0.75);
     background-color: var(--#{$prefix}btn-close-color);
+    border: 0;
+    @include border-radius(var(--tblr-border-radius));
+    opacity: var(--#{$prefix}btn-close-opacity);
+    cursor: pointer;
+    display: block;
+
+    &:hover {
+      color: var(--#{$prefix}btn-close-color);
+      text-decoration: none;
+      opacity: var(--#{$prefix}btn-close-hover-opacity);
+      background-color: var(--#{$prefix}btn-close-color);
+    }
+
+    &:focus {
+      outline: 0;
+      box-shadow: var(--#{$prefix}btn-close-focus-shadow);
+      opacity: var(--#{$prefix}btn-close-focus-opacity);
+    }
+
+    &:disabled,
+    &.disabled {
+      pointer-events: none;
+      user-select: none;
+      opacity: var(--#{$prefix}btn-close-disabled-opacity);
+    }
+
+    @include media-print {
+      display: none;
+    }
   }
 
-  &:focus {
-    outline: 0;
-    box-shadow: var(--#{$prefix}btn-close-focus-shadow);
-    opacity: var(--#{$prefix}btn-close-focus-opacity);
-  }
+  // @mixin btn-close-white() {
+  //   --#{$prefix}btn-close-filter: #{$btn-close-filter-dark};
+  // }
 
-  &:disabled,
-  &.disabled {
-    pointer-events: none;
-    user-select: none;
-    opacity: var(--#{$prefix}btn-close-disabled-opacity);
-  }
+  // .btn-close-white {
+  //   @include btn-close-white();
+  // }
 
-  @include media-print {
-    display: none;
-  }
+  // :root,
+  // [data-bs-theme="light"] {
+  //   --#{$prefix}btn-close-filter: #{$btn-close-filter};
+  // }
+
+  // @if $enable-dark-mode {
+  //   @include color-mode(dark, true) {
+  //     @include btn-close-white();
+  //   }
+  // }
 }
-
-// @mixin btn-close-white() {
-//   --#{$prefix}btn-close-filter: #{$btn-close-filter-dark};
-// }
-
-// .btn-close-white {
-//   @include btn-close-white();
-// }
-
-// :root,
-// [data-bs-theme="light"] {
-//   --#{$prefix}btn-close-filter: #{$btn-close-filter};
-// }
-
-// @if $enable-dark-mode {
-//   @include color-mode(dark, true) {
-//     @include btn-close-white();
-//   }
-// }

--- a/core/scss/ui/_datagrid.scss
+++ b/core/scss/ui/_datagrid.scss
@@ -2,16 +2,18 @@
 // Base styles
 //
 
-.datagrid {
-  --#{$prefix}datagrid-padding: #{$datagrid-padding};
-  --#{$prefix}datagrid-item-width: #{$datagrid-item-width};
+@layer components {
+  .datagrid {
+    --#{$prefix}datagrid-padding: #{$datagrid-padding};
+    --#{$prefix}datagrid-item-width: #{$datagrid-item-width};
 
-  display: grid;
-  grid-gap: var(--#{$prefix}datagrid-padding);
-  grid-template-columns: repeat(auto-fit, minmax(var(--#{$prefix}datagrid-item-width), 1fr));
-}
+    display: grid;
+    grid-gap: var(--#{$prefix}datagrid-padding);
+    grid-template-columns: repeat(auto-fit, minmax(var(--#{$prefix}datagrid-item-width), 1fr));
+  }
 
-.datagrid-title {
-  @include subheader;
-  margin-bottom: 0.25rem;
+  .datagrid-title {
+    @include subheader;
+    margin-bottom: 0.25rem;
+  }
 }

--- a/core/scss/ui/_dropdowns.scss
+++ b/core/scss/ui/_dropdowns.scss
@@ -1,121 +1,123 @@
-.dropdown-menu {
-  --#{$prefix}dropdown-item-gap: 0.5rem;
-  --#{$prefix}dropdown-item-icon-size: #{$icon-size};
-  --#{$prefix}dropdown-item-icon-color: var(--#{$prefix}tertiary);
-  user-select: none;
-  background-clip: border-box;
+@layer components {
+  .dropdown-menu {
+    --#{$prefix}dropdown-item-gap: 0.5rem;
+    --#{$prefix}dropdown-item-icon-size: #{$icon-size};
+    --#{$prefix}dropdown-item-icon-color: var(--#{$prefix}tertiary);
+    user-select: none;
+    background-clip: border-box;
 
-  &.card {
-    padding: 0;
-    min-width: $dropdown-max-width;
-    display: none;
+    &.card {
+      padding: 0;
+      min-width: $dropdown-max-width;
+      display: none;
 
-    &.show {
-      display: flex;
+      &.show {
+        display: flex;
+      }
+    }
+
+    @include media-print {
+      display: none;
     }
   }
-
-  @include media-print {
-    display: none;
-  }
-}
-
-.dropdown-item {
-  min-width: $dropdown-min-width;
-  display: flex;
-  align-items: center;
-  margin: 0;
-  line-height: $line-height-base;
-  gap: var(--#{$prefix}dropdown-item-gap);
-}
-
-.dropdown-item-icon {
-  width: var(--#{$prefix}dropdown-item-icon-size) !important;
-  height: var(--#{$prefix}dropdown-item-icon-size) !important;
-  color: var(--#{$prefix}dropdown-item-icon-color);
-  text-align: center;
-}
-
-.dropdown-item-indicator {
-  height: 1.25rem;
-  display: inline-flex;
-  line-height: 1;
-  vertical-align: bottom;
-  align-items: center;
-}
-
-.dropdown-header {
-  @include subheader;
-  padding-bottom: 0.25rem;
-  pointer-events: none;
-}
-
-.dropdown-menu-scrollable {
-  height: auto;
-  max-height: $dropdown-scrollable-height;
-  overflow-x: hidden;
-}
-
-.dropdown-menu-column {
-  min-width: $dropdown-min-width;
 
   .dropdown-item {
-    min-width: 0;
-  }
-}
-
-.dropdown-menu-columns {
-  display: flex;
-  flex: 0 0.25rem;
-}
-
-.dropdown-menu-arrow {
-  &:before {
-    content: '';
-    position: absolute;
-    top: -0.25rem;
-    inset-inline-start: 0.75rem;
-    display: block;
-    background: inherit;
-    width: 14px;
-    height: 14px;
-    /*rtl:ignore*/
-    transform: rotate(45deg);
-    transform-origin: center;
-    border: 1px solid;
-    border-color: inherit;
-    z-index: -1;
-    clip: rect(0px, 9px, 9px, 0px);
-  }
-
-  &.dropdown-menu-end {
-    &:before {
-      inset-inline-end: 0.75rem;
-      inset-inline-start: auto;
-    }
-  }
-}
-
-.dropend {
-  > .dropdown-menu {
-    margin-top: subtract(calc(-1 * $dropdown-padding-y), 1px);
-    margin-inline-start: -0.25rem;
-  }
-
-  .dropdown-toggle {
-    &:after {
-      margin-inline-start: auto;
-    }
-  }
-}
-
-.dropdown-menu-card {
-  padding: 0;
-  min-width: 20rem;
-
-  > .card {
+    min-width: $dropdown-min-width;
+    display: flex;
+    align-items: center;
     margin: 0;
-    border: 0;
-    box-shadow: none;
+    line-height: $line-height-base;
+    gap: var(--#{$prefix}dropdown-item-gap);
+  }
+
+  .dropdown-item-icon {
+    width: var(--#{$prefix}dropdown-item-icon-size) !important;
+    height: var(--#{$prefix}dropdown-item-icon-size) !important;
+    color: var(--#{$prefix}dropdown-item-icon-color);
+    text-align: center;
+  }
+
+  .dropdown-item-indicator {
+    height: 1.25rem;
+    display: inline-flex;
+    line-height: 1;
+    vertical-align: bottom;
+    align-items: center;
+  }
+
+  .dropdown-header {
+    @include subheader;
+    padding-bottom: 0.25rem;
+    pointer-events: none;
+  }
+
+  .dropdown-menu-scrollable {
+    height: auto;
+    max-height: $dropdown-scrollable-height;
+    overflow-x: hidden;
+  }
+
+  .dropdown-menu-column {
+    min-width: $dropdown-min-width;
+
+    .dropdown-item {
+      min-width: 0;
+    }
+  }
+
+  .dropdown-menu-columns {
+    display: flex;
+    flex: 0 0.25rem;
+  }
+
+  .dropdown-menu-arrow {
+    &:before {
+      content: '';
+      position: absolute;
+      top: -0.25rem;
+      inset-inline-start: 0.75rem;
+      display: block;
+      background: inherit;
+      width: 14px;
+      height: 14px;
+      /*rtl:ignore*/
+      transform: rotate(45deg);
+      transform-origin: center;
+      border: 1px solid;
+      border-color: inherit;
+      z-index: -1;
+      clip: rect(0px, 9px, 9px, 0px);
+    }
+
+    &.dropdown-menu-end {
+      &:before {
+        inset-inline-end: 0.75rem;
+        inset-inline-start: auto;
+      }
+    }
+  }
+
+  .dropend {
+    > .dropdown-menu {
+      margin-top: subtract(calc(-1 * $dropdown-padding-y), 1px);
+      margin-inline-start: -0.25rem;
+    }
+
+    .dropdown-toggle {
+      &:after {
+        margin-inline-start: auto;
+      }
+    }
+  }
+
+  .dropdown-menu-card {
+    padding: 0;
+    min-width: 20rem;
+
+    > .card {
+      margin: 0;
+      border: 0;
+      box-shadow: none;
+    }
   }
 }

--- a/core/scss/ui/_empty.scss
+++ b/core/scss/ui/_empty.scss
@@ -1,59 +1,61 @@
-.empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  padding: 1rem;
-  text-align: center;
-
-  @include media-breakpoint-up(md) {
-    padding: 3rem;
-  }
-}
-
-.empty-icon {
-  margin: 0 0 1rem;
-  width: 3rem;
-  height: 3rem;
-  line-height: 1;
-  color: var(--#{$prefix}secondary);
-
-  svg {
-    width: 100%;
+@layer components {
+  .empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
     height: 100%;
+    padding: 1rem;
+    text-align: center;
+
+    @include media-breakpoint-up(md) {
+      padding: 3rem;
+    }
   }
-}
 
-.empty-img {
-  margin: 0 0 2rem;
-  line-height: 1;
-}
+  .empty-icon {
+    margin: 0 0 1rem;
+    width: 3rem;
+    height: 3rem;
+    line-height: 1;
+    color: var(--#{$prefix}secondary);
 
-.empty-header {
-  margin: 0 0 1rem;
-  font-size: 4rem;
-  font-weight: var(--#{$prefix}font-weight-light);
-  line-height: 1;
-  color: var(--#{$prefix}secondary);
-}
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+  }
 
-.empty-title {
-  font-size: $h2-font-size;
-  line-height: $h2-line-height;
-  font-weight: $headings-font-weight;
-}
+  .empty-img {
+    margin: 0 0 2rem;
+    line-height: 1;
+  }
 
-.empty-title,
-.empty-subtitle {
-  margin: 0 0 0.5rem;
-}
+  .empty-header {
+    margin: 0 0 1rem;
+    font-size: 4rem;
+    font-weight: var(--#{$prefix}font-weight-light);
+    line-height: 1;
+    color: var(--#{$prefix}secondary);
+  }
 
-.empty-action {
-  margin-top: 1.5rem;
-}
+  .empty-title {
+    font-size: $h2-font-size;
+    line-height: $h2-line-height;
+    font-weight: $headings-font-weight;
+  }
 
-.empty-bordered {
-  border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-  @include border-radius(var(--#{$prefix}border-radius));
+  .empty-title,
+  .empty-subtitle {
+    margin: 0 0 0.5rem;
+  }
+
+  .empty-action {
+    margin-top: 1.5rem;
+  }
+
+  .empty-bordered {
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+    @include border-radius(var(--#{$prefix}border-radius));
+  }
 }

--- a/core/scss/ui/_flags.scss
+++ b/core/scss/ui/_flags.scss
@@ -1,35 +1,36 @@
 @use 'sass:map';
 @use '../config';
 
+@layer components {
+  .flag {
+    position: relative;
+    display: inline-block;
+    width: config.$avatar-size;
+    aspect-ratio: 1.33333;
+    background: no-repeat center/cover;
+    box-shadow: config.$flag-box-shadow;
+    @include config.border-radius(config.$flag-border-radius);
+    vertical-align: bottom;
 
-.flag {
-  position: relative;
-  display: inline-block;
-  width: config.$avatar-size;
-  aspect-ratio: 1.33333;
-  background: no-repeat center/cover;
-  box-shadow: config.$flag-box-shadow;
-  @include config.border-radius(config.$flag-border-radius);
-  vertical-align: bottom;
-
-  &.flag-country-np {
-    box-shadow: none;
-    border-radius: 0;
+    &.flag-country-np {
+      box-shadow: none;
+      border-radius: 0;
+    }
   }
-}
 
-@each $country in config.$flag-countries {
-  .flag-country-#{$country} {
-    background-image: url('#{config.$assets-base}/img/flags/#{$country}.svg');
+  @each $country in config.$flag-countries {
+    .flag-country-#{$country} {
+      background-image: url('#{config.$assets-base}/img/flags/#{$country}.svg');
+    }
   }
-}
 
-@each $flag-size, $size in config.$flag-sizes {
-  .flag-#{$flag-size} {
-    width: map.get($size, size);
+  @each $flag-size, $size in config.$flag-sizes {
+    .flag-#{$flag-size} {
+      width: map.get($size, size);
 
-    @if map.has-key($size, border-radius) {
-      @include config.border-radius(map.get($size, border-radius));
+      @if map.has-key($size, border-radius) {
+        @include config.border-radius(map.get($size, border-radius));
+      }
     }
   }
 }

--- a/core/scss/ui/_forms.scss
+++ b/core/scss/ui/_forms.scss
@@ -1,251 +1,253 @@
-textarea {
-  &[cols] {
-    height: auto;
-  }
-}
-
-/**
-Form label
- */
-.col-form-label,
-.form-label {
-  display: block;
-  font-weight: var(--#{$prefix}font-weight-medium);
-
-  &.required {
-    &:after {
-      content: '*';
-      margin-inline-start: 0.25rem;
-      color: $red;
+@layer components {
+  textarea {
+    &[cols] {
+      height: auto;
     }
   }
-}
 
-.form-label-description {
-  float: inline-end;
-  font-weight: var(--#{$prefix}font-weight-normal);
-  color: $form-secondary-color;
-}
+  /**
+  Form label
+   */
+  .col-form-label,
+  .form-label {
+    display: block;
+    font-weight: var(--#{$prefix}font-weight-medium);
 
-/**
-Form hint
- */
-.form-hint {
-  display: block;
-  color: $form-secondary-color;
-
-  &:last-child {
-    margin-bottom: 0;
+    &.required {
+      &:after {
+        content: '*';
+        margin-inline-start: 0.25rem;
+        color: $red;
+      }
+    }
   }
 
-  & + .form-control {
-    margin-top: 0.25rem;
-  }
-
-  .form-label + & {
-    margin-top: -0.25rem;
-  }
-
-  .input-group + &,
-  .form-control + &,
-  .form-select + & {
-    margin-top: 0.5rem;
+  .form-label-description {
+    float: inline-end;
+    font-weight: var(--#{$prefix}font-weight-normal);
     color: $form-secondary-color;
   }
-}
 
-/**
-Form select
- */
-.form-select {
-  &:-moz-focusring {
-    color: var(--#{$prefix}body-color);
-  }
-}
-
-/**
-Form control
- */
-.form-control {
-  &:-webkit-autofill {
-    box-shadow: 0 0 0 1000px var(--#{$prefix}bg-surface-secondary) inset;
-    color: var(--#{$prefix}body-color);
-    -webkit-text-fill-color: var(--#{$prefix}body-color);
-  }
-
-  &:disabled,
-  &.disabled {
+  /**
+  Form hint
+   */
+  .form-hint {
+    display: block;
     color: $form-secondary-color;
-    user-select: none;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    & + .form-control {
+      margin-top: 0.25rem;
+    }
+
+    .form-label + & {
+      margin-top: -0.25rem;
+    }
+
+    .input-group + &,
+    .form-control + &,
+    .form-select + & {
+      margin-top: 0.5rem;
+      color: $form-secondary-color;
+    }
   }
 
-  &[size] {
-    width: auto;
+  /**
+  Form select
+   */
+  .form-select {
+    &:-moz-focusring {
+      color: var(--#{$prefix}body-color);
+    }
   }
-}
 
-.form-control-light {
-  background-color: var(--#{$prefix}gray-100);
-  border-color: transparent;
-}
+  /**
+  Form control
+   */
+  .form-control {
+    &:-webkit-autofill {
+      box-shadow: 0 0 0 1000px var(--#{$prefix}bg-surface-secondary) inset;
+      color: var(--#{$prefix}body-color);
+      -webkit-text-fill-color: var(--#{$prefix}body-color);
+    }
 
-.form-control-dark {
-  background-color: rgba($black, 0.1);
-  color: $white;
-  border-color: transparent;
+    &:disabled,
+    &.disabled {
+      color: $form-secondary-color;
+      user-select: none;
+    }
 
-  &:focus {
+    &[size] {
+      width: auto;
+    }
+  }
+
+  .form-control-light {
+    background-color: var(--#{$prefix}gray-100);
+    border-color: transparent;
+  }
+
+  .form-control-dark {
     background-color: rgba($black, 0.1);
-    box-shadow: none;
-    border-color: rgba($white, 0.24);
-  }
-
-  &::placeholder {
-    color: rgba($white, 0.6);
-  }
-}
-
-.form-control-rounded {
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-}
-
-.form-control-flush {
-  padding: 0;
-  background: none !important;
-  border-color: transparent !important;
-  resize: none;
-  box-shadow: none !important;
-  line-height: inherit;
-}
-
-.form-footer {
-  margin-top: 2rem;
-}
-
-.form-fieldset {
-  padding: 1rem;
-  margin-bottom: 1rem;
-  background: var(--#{$prefix}bg-surface-secondary);
-  border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-  @include border-radius(var(--#{$prefix}border-radius));
-}
-
-fieldset:empty {
-  display: none;
-}
-
-/**
-Form help
- */
-.form-help {
-  display: inline-flex;
-  font-weight: var(--#{$prefix}font-weight-semibold);
-  align-items: center;
-  justify-content: center;
-  width: 1.125rem;
-  height: 1.125rem;
-  font-size: 0.75rem;
-  color: $form-secondary-color;
-  text-align: center;
-  text-decoration: none;
-  cursor: pointer;
-  user-select: none;
-  background: var(--#{$prefix}gray-100);
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-  @include transition(background-color $transition-time, color $transition-time);
-
-  &:hover,
-  &[aria-describedby] {
     color: $white;
-    background: var(--#{$prefix}primary);
+    border-color: transparent;
+
+    &:focus {
+      background-color: rgba($black, 0.1);
+      box-shadow: none;
+      border-color: rgba($white, 0.24);
+    }
+
+    &::placeholder {
+      color: rgba($white, 0.6);
+    }
   }
-}
 
-/**
-Input group
- */
-.input-group {
-  box-shadow: $input-box-shadow;
-  @include border-radius($input-border-radius);
-
-  .form-control,
-  .btn {
-    box-shadow: none;
+  .form-control-rounded {
+    @include border-radius(var(--#{$prefix}border-radius-pill));
   }
-}
 
-.input-group-link {
-  font-size: $h5-font-size;
-}
+  .form-control-flush {
+    padding: 0;
+    background: none !important;
+    border-color: transparent !important;
+    resize: none;
+    box-shadow: none !important;
+    line-height: inherit;
+  }
 
-.input-group-flat {
-  &:focus-within {
-    box-shadow: $input-focus-box-shadow;
+  .form-footer {
+    margin-top: 2rem;
+  }
+
+  .form-fieldset {
+    padding: 1rem;
+    margin-bottom: 1rem;
+    background: var(--#{$prefix}bg-surface-secondary);
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+    @include border-radius(var(--#{$prefix}border-radius));
+  }
+
+  fieldset:empty {
+    display: none;
+  }
+
+  /**
+  Form help
+   */
+  .form-help {
+    display: inline-flex;
+    font-weight: var(--#{$prefix}font-weight-semibold);
+    align-items: center;
+    justify-content: center;
+    width: 1.125rem;
+    height: 1.125rem;
+    font-size: 0.75rem;
+    color: $form-secondary-color;
+    text-align: center;
+    text-decoration: none;
+    cursor: pointer;
+    user-select: none;
+    background: var(--#{$prefix}gray-100);
+    @include border-radius(var(--#{$prefix}border-radius-pill));
+    @include transition(background-color $transition-time, color $transition-time);
+
+    &:hover,
+    &[aria-describedby] {
+      color: $white;
+      background: var(--#{$prefix}primary);
+    }
+  }
+
+  /**
+  Input group
+   */
+  .input-group {
+    box-shadow: $input-box-shadow;
     @include border-radius($input-border-radius);
 
     .form-control,
-    .input-group-text {
-      border-color: $input-focus-border-color !important;
-    }
-  }
-
-  .form-control {
-    &:focus {
-      border-color: $input-border-color;
+    .btn {
       box-shadow: none;
     }
+  }
 
-    &:not(:last-child) {
-      border-inline-end: 0;
+  .input-group-link {
+    font-size: $h5-font-size;
+  }
+
+  .input-group-flat {
+    &:focus-within {
+      box-shadow: $input-focus-box-shadow;
+      @include border-radius($input-border-radius);
+
+      .form-control,
+      .input-group-text {
+        border-color: $input-focus-border-color !important;
+      }
     }
 
-    &:not(:first-child) {
-      border-inline-start: 0;
+    .form-control {
+      &:focus {
+        border-color: $input-border-color;
+        box-shadow: none;
+      }
+
+      &:not(:last-child) {
+        border-inline-end: 0;
+      }
+
+      &:not(:first-child) {
+        border-inline-start: 0;
+      }
+    }
+
+    .input-group-text {
+      background: $form-check-input-bg;
+      z-index: 10;
+      @include transition($input-transition);
+
+      &:first-child {
+        padding-inline-end: 0;
+        border-inline-end: 0;
+      }
+
+      &:last-child {
+        padding-inline-start: 0;
+        border-inline-start: 0;
+      }
     }
   }
 
-  .input-group-text {
-    background: $form-check-input-bg;
-    z-index: 10;
-    @include transition($input-transition);
-
-    &:first-child {
-      padding-inline-end: 0;
-      border-inline-end: 0;
-    }
-
-    &:last-child {
-      padding-inline-start: 0;
-      border-inline-start: 0;
-    }
+  /**
+  Upload files
+   */
+  .form-file-button {
+    margin-inline-start: 0;
+    border-inline-start: 0;
   }
-}
 
-/**
-Upload files
- */
-.form-file-button {
-  margin-inline-start: 0;
-  border-inline-start: 0;
-}
+  /**
+  Floating inputs
+   */
+  // Fix for the bug in twbs/bootstrap v5.3.3. Issue #39080. Should be fixed in v5.3.4
+  label[for='floating-input'] {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
-/**
-Floating inputs
- */
-// Fix for the bug in twbs/bootstrap v5.3.3. Issue #39080. Should be fixed in v5.3.4
-label[for='floating-input'] {
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/**
-Forms on mobile devices 
-  */
-.form-control,
-.form-select {
-  @include media-breakpoint-down(sm) {
-    font-size: 1rem;
+  /**
+  Forms on mobile devices 
+    */
+  .form-control,
+  .form-select {
+    @include media-breakpoint-down(sm) {
+      font-size: 1rem;
+    }
   }
 }

--- a/core/scss/ui/_grid.scss
+++ b/core/scss/ui/_grid.scss
@@ -1,133 +1,135 @@
 @use 'sass:map';
 
-.row > * {
-  min-width: 0;
-}
+@layer components {
+  .row > * {
+    min-width: 0;
+  }
 
-.col-separator {
-  border-inline-start: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-}
+  .col-separator {
+    border-inline-start: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+  }
 
-.container {
-  @each $variation, $size in $container-variations {
-    &-#{$variation} {
-      @include make-container();
-      max-width: $size;
+  .container {
+    @each $variation, $size in $container-variations {
+      &-#{$variation} {
+        @include make-container();
+        max-width: $size;
+      }
     }
   }
-}
 
-@each $name, $value in (0: 0, sm: 0.375rem, md: 1.5rem, lg: 3rem) {
-  .row-#{$name} {
-    margin-inline-end: calc(-1 * $value);
-    margin-inline-start: calc(-1 * $value);
+  @each $name, $value in (0: 0, sm: 0.375rem, md: 1.5rem, lg: 3rem) {
+    .row-#{$name} {
+      margin-inline-end: calc(-1 * $value);
+      margin-inline-start: calc(-1 * $value);
 
+      > .col,
+      > [class*='col-'] {
+        padding-inline-end: $value;
+        padding-inline-start: $value;
+      }
+
+      .card {
+        margin-bottom: 2 * $value;
+      }
+    }
+  }
+
+  .row-deck {
     > .col,
     > [class*='col-'] {
-      padding-inline-end: $value;
-      padding-inline-start: $value;
-    }
+      display: flex;
+      align-items: stretch;
 
-    .card {
-      margin-bottom: 2 * $value;
-    }
-  }
-}
-
-.row-deck {
-  > .col,
-  > [class*='col-'] {
-    display: flex;
-    align-items: stretch;
-
-    .card {
-      flex: 1 1 auto;
+      .card {
+        flex: 1 1 auto;
+      }
     }
   }
-}
-
-.row-cards {
-  --#{$prefix}gutter-x: #{$cards-grid-gap};
-  --#{$prefix}gutter-y: #{$cards-grid-gap};
-  min-width: 0;
 
   .row-cards {
-    flex: 1;
+    --#{$prefix}gutter-x: #{$cards-grid-gap};
+    --#{$prefix}gutter-y: #{$cards-grid-gap};
+    min-width: 0;
+
+    .row-cards {
+      flex: 1;
+    }
   }
-}
 
-@each $name,
-  $size
-    in map.merge(
-      (
-        null: $spacer,
-      ),
-      $spacers
-    )
-{
-  $name-prefixed: if(sass($name == null): null; else: '-#{$name}');
+  @each $name,
+    $size
+      in map.merge(
+        (
+          null: $spacer,
+        ),
+        $spacers
+      )
+  {
+    $name-prefixed: if(sass($name == null): null; else: '-#{$name}');
 
-  .space-y#{$name-prefixed} {
+    .space-y#{$name-prefixed} {
+      display: flex;
+      flex-direction: column;
+      gap: $size;
+    }
+
+    .space-x#{$name-prefixed} {
+      display: flex;
+      gap: $size;
+    }
+  }
+
+  @each $name,
+    $size
+      in map.merge(
+        (
+          null: $spacer,
+        ),
+        $spacers
+      )
+  {
+    $name-prefixed: if(sass($name == null): null; else: '-#{$name}');
+
+    .divide-y#{$name-prefixed} {
+      > :not(template) ~ :not(template) {
+        border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color-translucent) !important;
+      }
+
+      > :not(template):not(:first-child) {
+        padding-top: $size !important;
+      }
+
+      > :not(template):not(:last-child) {
+        padding-bottom: $size !important;
+      }
+    }
+
+    .divide-x#{$name-prefixed} {
+      > :not(template) ~ :not(template) {
+        border-inline-start: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color-translucent) !important;
+      }
+
+      > :not(template):not(:first-child) {
+        padding-inline-start: $size !important;
+      }
+
+      > :not(template):not(:last-child) {
+        padding-inline-end: $size !important;
+      }
+    }
+  }
+
+  .divide-y-fill {
     display: flex;
     flex-direction: column;
-    gap: $size;
-  }
+    height: 100%;
 
-  .space-x#{$name-prefixed} {
-    display: flex;
-    gap: $size;
-  }
-}
-
-@each $name,
-  $size
-    in map.merge(
-      (
-        null: $spacer,
-      ),
-      $spacers
-    )
-{
-  $name-prefixed: if(sass($name == null): null; else: '-#{$name}');
-
-  .divide-y#{$name-prefixed} {
-    > :not(template) ~ :not(template) {
-      border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color-translucent) !important;
+    > :not(template) {
+      flex: 1;
+      display: flex;
+      justify-content: center;
+      flex-direction: column;
     }
-
-    > :not(template):not(:first-child) {
-      padding-top: $size !important;
-    }
-
-    > :not(template):not(:last-child) {
-      padding-bottom: $size !important;
-    }
-  }
-
-  .divide-x#{$name-prefixed} {
-    > :not(template) ~ :not(template) {
-      border-inline-start: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color-translucent) !important;
-    }
-
-    > :not(template):not(:first-child) {
-      padding-inline-start: $size !important;
-    }
-
-    > :not(template):not(:last-child) {
-      padding-inline-end: $size !important;
-    }
-  }
-}
-
-.divide-y-fill {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-
-  > :not(template) {
-    flex: 1;
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
   }
 }

--- a/core/scss/ui/_icons.scss
+++ b/core/scss/ui/_icons.scss
@@ -1,72 +1,75 @@
 //
 // Icon component
 //
-.icon {
-  --#{$prefix}icon-size: #{$font-size-base * $line-height-base};
-  width: var(--#{$prefix}icon-size);
-  height: var(--#{$prefix}icon-size);
-  font-size: var(--#{$prefix}icon-size);
-  vertical-align: bottom;
 
-  @if $icon-stroke-width {
-    stroke-width: $icon-stroke-width;
+@layer components {
+  .icon {
+    --#{$prefix}icon-size: #{$font-size-base * $line-height-base};
+    width: var(--#{$prefix}icon-size);
+    height: var(--#{$prefix}icon-size);
+    font-size: var(--#{$prefix}icon-size);
+    vertical-align: bottom;
+
+    @if $icon-stroke-width {
+      stroke-width: $icon-stroke-width;
+    }
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 
-  &:hover {
-    text-decoration: none;
+  //
+  // Inline icon
+  //
+  .icon-inline {
+    --#{$prefix}icon-size: 1rem;
+    vertical-align: -0.2rem;
   }
-}
 
-//
-// Inline icon
-//
-.icon-inline {
-  --#{$prefix}icon-size: 1rem;
-  vertical-align: -0.2rem;
-}
+  //
+  // Filled icon
+  //
+  .icon-filled {
+    fill: currentColor;
+  }
 
-//
-// Filled icon
-//
-.icon-filled {
-  fill: currentColor;
-}
+  //
+  // Icon size
+  //
+  .icon-sm {
+    --#{$prefix}icon-size: 1rem;
+    stroke-width: 1.5;
+  }
 
-//
-// Icon size
-//
-.icon-sm {
-  --#{$prefix}icon-size: 1rem;
-  stroke-width: 1.5;
-}
+  .icon-md {
+    --#{$prefix}icon-size: 2.5rem;
+    stroke-width: 1;
+  }
 
-.icon-md {
-  --#{$prefix}icon-size: 2.5rem;
-  stroke-width: 1;
-}
+  .icon-lg {
+    --#{$prefix}icon-size: 3.5rem;
+    stroke-width: 1;
+  }
 
-.icon-lg {
-  --#{$prefix}icon-size: 3.5rem;
-  stroke-width: 1;
-}
+  //
+  // Icons animation
+  //
+  .icon-pulse {
+    transition: all 0.15s ease 0s;
+    animation: pulse 2s ease infinite;
+    animation-fill-mode: both;
+  }
 
-//
-// Icons animation
-//
-.icon-pulse {
-  transition: all 0.15s ease 0s;
-  animation: pulse 2s ease infinite;
-  animation-fill-mode: both;
-}
+  .icon-tada {
+    transition: all 0.15s ease 0s;
+    animation: tada 3s ease infinite;
+    animation-fill-mode: both;
+  }
 
-.icon-tada {
-  transition: all 0.15s ease 0s;
-  animation: tada 3s ease infinite;
-  animation-fill-mode: both;
-}
-
-.icon-rotate {
-  transition: all 0.15s ease 0s;
-  animation: rotate-360 3s linear infinite;
-  animation-fill-mode: both;
+  .icon-rotate {
+    transition: all 0.15s ease 0s;
+    animation: rotate-360 3s linear infinite;
+    animation-fill-mode: both;
+  }
 }

--- a/core/scss/ui/_images.scss
+++ b/core/scss/ui/_images.scss
@@ -1,21 +1,23 @@
 @use 'sass:math';
 
-.img-responsive {
-  --#{$prefix}img-responsive-ratio: #{math.percentage(0.75)};
-  background: no-repeat center/cover;
-  padding-top: var(--#{$prefix}img-responsive-ratio);
-}
-
-.img-responsive-grid {
-  padding-top: calc(var(--#{$prefix}img-responsive-ratio) - calc(var(--#{$prefix}gutter-y) / 2));
-}
-
-@each $key, $ratio in $aspect-ratios {
-  .img-responsive-#{$key} {
-    --#{$prefix}img-responsive-ratio: #{$ratio};
+@layer components {
+  .img-responsive {
+    --#{$prefix}img-responsive-ratio: #{math.percentage(0.75)};
+    background: no-repeat center/cover;
+    padding-top: var(--#{$prefix}img-responsive-ratio);
   }
-}
 
-.img-bg {
-  background: no-repeat center/cover;
+  .img-responsive-grid {
+    padding-top: calc(var(--#{$prefix}img-responsive-ratio) - calc(var(--#{$prefix}gutter-y) / 2));
+  }
+
+  @each $key, $ratio in $aspect-ratios {
+    .img-responsive-#{$key} {
+      --#{$prefix}img-responsive-ratio: #{$ratio};
+    }
+  }
+
+  .img-bg {
+    background: no-repeat center/cover;
+  }
 }

--- a/core/scss/ui/_legend.scss
+++ b/core/scss/ui/_legend.scss
@@ -1,12 +1,15 @@
 /**
 Legend
  */
-.legend {
-  --#{$prefix}legend-size: #{$legend-size};
-  display: inline-block;
-  background: $legend-bg;
-  width: var(--#{$prefix}legend-size);
-  height: var(--#{$prefix}legend-size);
-  @include border-radius($legend-border-radius);
-  border: 1px solid var(--#{$prefix}border-color-translucent);
+
+@layer components {
+  .legend {
+    --#{$prefix}legend-size: #{$legend-size};
+    display: inline-block;
+    background: $legend-bg;
+    width: var(--#{$prefix}legend-size);
+    height: var(--#{$prefix}legend-size);
+    @include border-radius($legend-border-radius);
+    border: 1px solid var(--#{$prefix}border-color-translucent);
+  }
 }

--- a/core/scss/ui/_lists.scss
+++ b/core/scss/ui/_lists.scss
@@ -1,122 +1,124 @@
-.list-group {
-  margin-inline-start: 0;
-  margin-inline-end: 0;
-}
+@layer components {
+  .list-group {
+    margin-inline-start: 0;
+    margin-inline-end: 0;
+  }
 
-.list-group-header {
-  background: $list-group-header-bg;
-  padding: 0.5rem $list-group-item-padding-x;
-  font-size: $h5-font-size;
-  font-weight: var(--#{$prefix}font-weight-medium);
-  line-height: 1;
-  text-transform: uppercase;
-  color: $list-group-header-color;
-  border-bottom: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+  .list-group-header {
+    background: $list-group-header-bg;
+    padding: 0.5rem $list-group-item-padding-x;
+    font-size: $h5-font-size;
+    font-weight: var(--#{$prefix}font-weight-medium);
+    line-height: 1;
+    text-transform: uppercase;
+    color: $list-group-header-color;
+    border-bottom: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
 
-  .list-group-flush > & {
-    &:last-child {
-      border-bottom-width: 0;
+    .list-group-flush > & {
+      &:last-child {
+        border-bottom-width: 0;
+      }
     }
   }
-}
 
-.list-group-item {
-  background-color: inherit;
-}
-
-.list-group-item.active {
-  background-color: $dropdown-link-hover-bg;
-  border-inline-start-color: $component-active-bg;
-  border-inline-start-width: $border-width-wide;
-}
-
-.list-group-item {
-  &.disabled,
-  &:disabled {
-    color: $gray-500;
-    background-color: $dropdown-link-hover-bg;
-  }
-}
-
-.list-bordered {
-  .list-item {
-    border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-    margin-top: -1px;
-
-    &:first-child {
-      border-top: none;
-    }
-  }
-}
-
-.list-group-hoverable {
   .list-group-item {
-    &:active,
-    &:focus,
-    &:hover {
+    background-color: inherit;
+  }
+
+  .list-group-item.active {
+    background-color: $dropdown-link-hover-bg;
+    border-inline-start-color: $component-active-bg;
+    border-inline-start-width: $border-width-wide;
+  }
+
+  .list-group-item {
+    &.disabled,
+    &:disabled {
+      color: $gray-500;
       background-color: $dropdown-link-hover-bg;
     }
   }
 
-  .list-group-item-actions {
-    opacity: 0;
-    @include transition(opacity $transition-time);
-  }
+  .list-bordered {
+    .list-item {
+      border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+      margin-top: -1px;
 
-  .list-group-item:hover .list-group-item-actions,
-  .list-group-item-actions.show {
-    opacity: 1;
-  }
-}
-
-.list-group-transparent {
-  --#{$prefix}list-group-border-radius: 0;
-  margin: 0 (-$list-group-item-padding-x);
-
-  .list-group-item {
-    background: none;
-    border: 0;
-
-    .icon {
-      color: var(--#{$prefix}secondary);
-    }
-
-    &.active {
-      font-weight: var(--#{$prefix}font-weight-semibold);
-      color: inherit;
-      background: $list-group-active-bg;
-
-      .icon {
-        color: inherit;
+      &:first-child {
+        border-top: none;
       }
     }
   }
-}
 
-/**
-Seprated list
-*/
-.list-separated {
-  display: flex;
-  flex-direction: column;
-  gap: $spacer;
-}
+  .list-group-hoverable {
+    .list-group-item {
+      &:active,
+      &:focus,
+      &:hover {
+        background-color: $dropdown-link-hover-bg;
+      }
+    }
 
-/**
-Inline list
- */
-.list-inline {
-  margin: 0;
-}
+    .list-group-item-actions {
+      opacity: 0;
+      @include transition(opacity $transition-time);
+    }
 
-.list-inline-item:not(:last-child) {
-  margin-inline-end: auto;
-  margin-inline-end: $list-inline-padding;
-}
+    .list-group-item:hover .list-group-item-actions,
+    .list-group-item-actions.show {
+      opacity: 1;
+    }
+  }
 
-.list-inline-dots {
-  .list-inline-item + .list-inline-item:before {
-    content: ' · ';
+  .list-group-transparent {
+    --#{$prefix}list-group-border-radius: 0;
+    margin: 0 (-$list-group-item-padding-x);
+
+    .list-group-item {
+      background: none;
+      border: 0;
+
+      .icon {
+        color: var(--#{$prefix}secondary);
+      }
+
+      &.active {
+        font-weight: var(--#{$prefix}font-weight-semibold);
+        color: inherit;
+        background: $list-group-active-bg;
+
+        .icon {
+          color: inherit;
+        }
+      }
+    }
+  }
+
+  /**
+  Seprated list
+  */
+  .list-separated {
+    display: flex;
+    flex-direction: column;
+    gap: $spacer;
+  }
+
+  /**
+  Inline list
+   */
+  .list-inline {
+    margin: 0;
+  }
+
+  .list-inline-item:not(:last-child) {
+    margin-inline-end: auto;
     margin-inline-end: $list-inline-padding;
+  }
+
+  .list-inline-dots {
+    .list-inline-item + .list-inline-item:before {
+      content: ' · ';
+      margin-inline-end: $list-inline-padding;
+    }
   }
 }

--- a/core/scss/ui/_loaders.scss
+++ b/core/scss/ui/_loaders.scss
@@ -1,71 +1,73 @@
-.loader {
-  position: relative;
-  display: block;
-  width: $loader-size;
-  height: $loader-size;
-  color: $blue;
-  vertical-align: middle;
-
-  &:after {
-    position: absolute;
-    top: 0;
-    inset-inline-start: 0;
-    width: 100%;
-    height: 100%;
-    content: '';
-    border: 1px var(--#{$prefix}border-style);
-    border-color: transparent;
-    border-top-color: currentColor;
-    border-inline-start-color: currentColor;
-
-    @include border-radius(var(--#{$prefix}border-radius-pill));
-    animation: rotate-360 0.6s linear;
-    animation-iteration-count: infinite;
-  }
-}
-
-/**
-Dimmer
-*/
-.dimmer {
-  position: relative;
-
+@layer components {
   .loader {
-    position: absolute;
-    top: 50%;
-    inset-inline-end: 0;
-    inset-inline-start: 0;
-    display: none;
-    margin: 0 auto;
-    transform: translateY(-50%);
+    position: relative;
+    display: block;
+    width: $loader-size;
+    height: $loader-size;
+    color: $blue;
+    vertical-align: middle;
+
+    &:after {
+      position: absolute;
+      top: 0;
+      inset-inline-start: 0;
+      width: 100%;
+      height: 100%;
+      content: '';
+      border: 1px var(--#{$prefix}border-style);
+      border-color: transparent;
+      border-top-color: currentColor;
+      border-inline-start-color: currentColor;
+
+      @include border-radius(var(--#{$prefix}border-radius-pill));
+      animation: rotate-360 0.6s linear;
+      animation-iteration-count: infinite;
+    }
   }
 
-  &.active {
+  /**
+  Dimmer
+  */
+  .dimmer {
+    position: relative;
+
     .loader {
-      display: block;
+      position: absolute;
+      top: 50%;
+      inset-inline-end: 0;
+      inset-inline-start: 0;
+      display: none;
+      margin: 0 auto;
+      transform: translateY(-50%);
     }
 
-    .dimmer-content {
-      pointer-events: none;
-      opacity: 0.1;
+    &.active {
+      .loader {
+        display: block;
+      }
+
+      .dimmer-content {
+        pointer-events: none;
+        opacity: 0.1;
+      }
     }
   }
-}
 
-@keyframes animated-dots {
-  0% {
-    transform: translateX(-100%);
+  @keyframes animated-dots {
+    0% {
+      transform: translateX(-100%);
+    }
   }
-}
 
-.animated-dots {
-  display: inline-block;
-  overflow: hidden;
-  vertical-align: bottom;
-
-  &:after {
+  .animated-dots {
     display: inline-block;
-    content: '...';
-    animation: animated-dots 1.2s steps(4, jump-none) infinite;
+    overflow: hidden;
+    vertical-align: bottom;
+
+    &:after {
+      display: inline-block;
+      content: '...';
+      animation: animated-dots 1.2s steps(4, jump-none) infinite;
+    }
   }
 }

--- a/core/scss/ui/_markdown.scss
+++ b/core/scss/ui/_markdown.scss
@@ -4,64 +4,67 @@ $markdown-line-height: var(--#{$prefix}line-height-lg) !default;
 /**
 Prose (formerly markdown)
  */
-.prose,
-.markdown {
-  line-height: $markdown-line-height;
-  font-size: $markdown-font-size;
 
-  > :first-child {
-    margin-top: 0;
-  }
+@layer components {
+  .prose,
+  .markdown {
+    line-height: $markdown-line-height;
+    font-size: $markdown-font-size;
 
-  > :last-child,
-  > :last-child .highlight {
-    margin-bottom: 0;
-  }
-
-  > hr {
-    @include media-breakpoint-up(md) {
-      margin-top: 3em;
-      margin-bottom: 3em;
-    }
-  }
-
-  > {
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      font-weight: $headings-font-weight;
+    > :first-child {
+      margin-top: 0;
     }
 
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      margin-top: 2.5rem;
+    > :last-child,
+    > :last-child .highlight {
+      margin-bottom: 0;
     }
-  }
 
-  > table {
-    font-size: var(--#{$prefix}body-font-size);
-    @extend .table, .table-bordered, .table-sm;
-  }
+    > hr {
+      @include media-breakpoint-up(md) {
+        margin-top: 3em;
+        margin-bottom: 3em;
+      }
+    }
 
-  > blockquote {
-    font-size: $h3-font-size;
-    margin: 1.5rem 0;
-    padding: 0.5rem 1.5rem;
-  }
+    > {
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6 {
+        font-weight: $headings-font-weight;
+      }
 
-  > img,
-  > p > img {
-    @include border-radius(var(--#{$prefix}border-radius));
-    border: 1px solid var(--#{$prefix}border-color);
-  }
+      h2,
+      h3,
+      h4,
+      h5,
+      h6 {
+        margin-top: 2.5rem;
+      }
+    }
 
-  pre {
-    max-height: 20rem;
+    > table {
+      font-size: var(--#{$prefix}body-font-size);
+      @extend .table, .table-bordered, .table-sm;
+    }
+
+    > blockquote {
+      font-size: $h3-font-size;
+      margin: 1.5rem 0;
+      padding: 0.5rem 1.5rem;
+    }
+
+    > img,
+    > p > img {
+      @include border-radius(var(--#{$prefix}border-radius));
+      border: 1px solid var(--#{$prefix}border-color);
+    }
+
+    pre {
+      max-height: 20rem;
+    }
   }
 }

--- a/core/scss/ui/_modals.scss
+++ b/core/scss/ui/_modals.scss
@@ -1,74 +1,76 @@
-.modal-content,
-.modal-header {
-  > .btn-close {
+@layer components {
+  .modal-content,
+  .modal-header {
+    > .btn-close {
+      position: absolute;
+      top: 0;
+      inset-inline-end: 0;
+      width: $modal-header-height;
+      height: $modal-header-height;
+      margin: 0;
+      padding: 0;
+      z-index: 10;
+    }
+  }
+
+  .modal-body {
+    @include scrollbar;
+
+    .modal-title {
+      margin-bottom: 1rem;
+    }
+
+    & + & {
+      border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+    }
+  }
+
+  .modal-status {
     position: absolute;
     top: 0;
+    inset-inline-start: 0;
     inset-inline-end: 0;
-    width: $modal-header-height;
-    height: $modal-header-height;
-    margin: 0;
-    padding: 0;
-    z-index: 10;
+    height: $modal-status-size;
+    background: var(--#{$prefix}secondary);
+    @include border-radius($modal-content-border-radius $modal-content-border-radius 0 0);
   }
-}
 
-.modal-body {
-  @include scrollbar;
+  .modal-header {
+    align-items: center;
+    min-height: $modal-header-height;
+    background: $modal-header-bg;
+    padding: 0 $modal-header-height 0 $modal-inner-padding;
+  }
 
   .modal-title {
-    margin-bottom: 1rem;
+    font-size: $h3-font-size;
+    font-weight: $headings-font-weight;
+    color: $headings-color;
+    line-height: $line-height-base;
   }
 
-  & + & {
-    border-top: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-  }
-}
+  .modal-footer {
+    @if $modal-footer-border-width == 0 {
+      padding-top: 0;
+    } @else {
+      padding-top: 0.75rem;
+    }
 
-.modal-status {
-  position: absolute;
-  top: 0;
-  inset-inline-start: 0;
-  inset-inline-end: 0;
-  height: $modal-status-size;
-  background: var(--#{$prefix}secondary);
-  @include border-radius($modal-content-border-radius $modal-content-border-radius 0 0);
-}
-
-.modal-header {
-  align-items: center;
-  min-height: $modal-header-height;
-  background: $modal-header-bg;
-  padding: 0 $modal-header-height 0 $modal-inner-padding;
-}
-
-.modal-title {
-  font-size: $h3-font-size;
-  font-weight: $headings-font-weight;
-  color: $headings-color;
-  line-height: $line-height-base;
-}
-
-.modal-footer {
-  @if $modal-footer-border-width == 0 {
-    padding-top: 0;
-  } @else {
-    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 
-  padding-bottom: 0.75rem;
-}
+  .modal-blur {
+    backdrop-filter: blur($modal-backdrop-blur);
+  }
 
-.modal-blur {
-  backdrop-filter: blur($modal-backdrop-blur);
-}
+  .modal-full-width {
+    max-width: none;
+    margin: 0 $modal-dialog-margin;
+  }
 
-.modal-full-width {
-  max-width: none;
-  margin: 0 $modal-dialog-margin;
-}
-
-.modal {
-  @include media-print {
-    display: none !important;
+  .modal {
+    @include media-print {
+      display: none !important;
+    }
   }
 }

--- a/core/scss/ui/_nav.scss
+++ b/core/scss/ui/_nav.scss
@@ -1,114 +1,116 @@
-.nav {
-  --#{$prefix}nav-link-hover-bg: #{color-transparent(var(--#{$prefix}nav-link-color), 0.04)};
-}
-
-.nav-vertical {
-  &,
+@layer components {
   .nav {
-    flex-direction: column;
-    flex-wrap: nowrap;
+    --#{$prefix}nav-link-hover-bg: #{color-transparent(var(--#{$prefix}nav-link-color), 0.04)};
   }
 
-  .nav {
-    margin-inline-start: 1.25rem;
-    border-inline-start: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-    padding-inline-start: 0.5rem;
-  }
+  .nav-vertical {
+    &,
+    .nav {
+      flex-direction: column;
+      flex-wrap: nowrap;
+    }
 
-  .nav-link.active,
-  .nav-item.show .nav-link {
-    font-weight: var(--#{$prefix}font-weight-semibold);
-    color: var(--#{$prefix}nav-link-active-color);
-  }
+    .nav {
+      margin-inline-start: 1.25rem;
+      border-inline-start: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+      padding-inline-start: 0.5rem;
+    }
 
-  &.nav-pills {
-    margin: 0 calc(-1 * $nav-link-padding-x);
-  }
-}
+    .nav-link.active,
+    .nav-item.show .nav-link {
+      font-weight: var(--#{$prefix}font-weight-semibold);
+      color: var(--#{$prefix}nav-link-active-color);
+    }
 
-//
-// Nav bordered
-//
-.nav-bordered {
-  border-bottom: $nav-bordered-border-width var(--#{$prefix}border-style) $nav-bordered-border-color;
-
-  .nav-item {
-    + .nav-item {
-      margin-inline-start: $nav-bordered-margin-x;
+    &.nav-pills {
+      margin: 0 calc(-1 * $nav-link-padding-x);
     }
   }
 
-  .nav-link {
-    padding-inline-start: 0;
-    padding-inline-end: 0;
-    margin: 0 0 calc(-1 * #{$nav-bordered-border-width});
-    border: 0;
-    border-bottom: $nav-bordered-link-active-border-width var(--#{$prefix}border-style) transparent;
+  //
+  // Nav bordered
+  //
+  .nav-bordered {
+    border-bottom: $nav-bordered-border-width var(--#{$prefix}border-style) $nav-bordered-border-color;
 
-    &:hover {
-      background-color: transparent;
+    .nav-item {
+      + .nav-item {
+        margin-inline-start: $nav-bordered-margin-x;
+      }
     }
-  }
 
-  .nav-link.active,
-  .nav-item.show .nav-link {
-    color: $nav-bordered-link-active-color;
-    border-color: $nav-bordered-link-active-border-color;
-  }
-}
-
-.nav-underline {
-  .nav-link {
-    border-radius: 0;
-  }
-}
-
-.nav-link {
-  display: flex;
-  align-items: center;
-  @include transition(color $transition-time, background-color $transition-time);
-
-  &:hover,
-  &:focus {
-    background-color: var(--#{$prefix}nav-link-hover-bg);
-  }
-}
-
-.nav-link-toggle {
-  margin-inline-start: auto;
-  padding: 0 0.25rem;
-  @include transition(transform $transition-time);
-  @include caret();
-
-  &:after {
-    margin: 0;
-  }
-
-  @at-root .nav-link[aria-expanded='true'] & {
-    transform: rotate(180deg);
-  }
-}
-
-.nav-link-icon {
-  width: $nav-link-icon-size;
-  height: $nav-link-icon-size;
-  margin-inline-end: 0.5rem;
-  color: $nav-link-icon-color;
-
-  svg {
-    display: block;
-    height: 100%;
-  }
-
-  .nav-link:hover & {
-    color: var(--#{$prefix}nav-link-hover-icon-color);
-  }
-}
-
-.nav-fill {
-  .nav-item {
     .nav-link {
-      justify-content: center;
+      padding-inline-start: 0;
+      padding-inline-end: 0;
+      margin: 0 0 calc(-1 * #{$nav-bordered-border-width});
+      border: 0;
+      border-bottom: $nav-bordered-link-active-border-width var(--#{$prefix}border-style) transparent;
+
+      &:hover {
+        background-color: transparent;
+      }
+    }
+
+    .nav-link.active,
+    .nav-item.show .nav-link {
+      color: $nav-bordered-link-active-color;
+      border-color: $nav-bordered-link-active-border-color;
+    }
+  }
+
+  .nav-underline {
+    .nav-link {
+      border-radius: 0;
+    }
+  }
+
+  .nav-link {
+    display: flex;
+    align-items: center;
+    @include transition(color $transition-time, background-color $transition-time);
+
+    &:hover,
+    &:focus {
+      background-color: var(--#{$prefix}nav-link-hover-bg);
+    }
+  }
+
+  .nav-link-toggle {
+    margin-inline-start: auto;
+    padding: 0 0.25rem;
+    @include transition(transform $transition-time);
+    @include caret();
+
+    &:after {
+      margin: 0;
+    }
+
+    @at-root .nav-link[aria-expanded='true'] & {
+      transform: rotate(180deg);
+    }
+  }
+
+  .nav-link-icon {
+    width: $nav-link-icon-size;
+    height: $nav-link-icon-size;
+    margin-inline-end: 0.5rem;
+    color: $nav-link-icon-color;
+
+    svg {
+      display: block;
+      height: 100%;
+    }
+
+    .nav-link:hover & {
+      color: var(--#{$prefix}nav-link-hover-icon-color);
+    }
+  }
+
+  .nav-fill {
+    .nav-item {
+      .nav-link {
+        justify-content: center;
+      }
     }
   }
 }

--- a/core/scss/ui/_offcanvas.scss
+++ b/core/scss/ui/_offcanvas.scss
@@ -1,23 +1,25 @@
-.offcanvas {
-  @include media-print {
-    display: none;
+@layer components {
+  .offcanvas {
+    @include media-print {
+      display: none;
+    }
   }
-}
 
-.offcanvas-header {
-  border-bottom: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-}
+  .offcanvas-header {
+    border-bottom: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+  }
 
-.offcanvas-footer {
-  padding: $offcanvas-padding-y $offcanvas-padding-x;
-}
+  .offcanvas-footer {
+    padding: $offcanvas-padding-y $offcanvas-padding-x;
+  }
 
-.offcanvas-title {
-  font-size: $h3-font-size;
-  font-weight: var(--#{$prefix}font-weight-medium);
-  line-height: 1.5rem;
-}
+  .offcanvas-title {
+    font-size: $h3-font-size;
+    font-weight: var(--#{$prefix}font-weight-medium);
+    line-height: 1.5rem;
+  }
 
-.offcanvas-narrow {
-  width: 20rem;
+  .offcanvas-narrow {
+    width: 20rem;
+  }
 }

--- a/core/scss/ui/_pagination.scss
+++ b/core/scss/ui/_pagination.scss
@@ -1,75 +1,77 @@
-.pagination {
-  margin: 0;
-  --#{$prefix}pagination-gap: 0.25rem;
-  user-select: none;
-  gap: var(--#{$prefix}pagination-gap);
-  line-height: var(--#{$prefix}body-line-height);
+@layer components {
+  .pagination {
+    margin: 0;
+    --#{$prefix}pagination-gap: 0.25rem;
+    user-select: none;
+    gap: var(--#{$prefix}pagination-gap);
+    line-height: var(--#{$prefix}body-line-height);
 
-  @include media-print {
-    display: none;
-  }
-}
-
-.page-link {
-  min-width: 2rem;
-  @include border-radius(var(--#{$prefix}pagination-border-radius));
-}
-
-.page-item:not(.active) .page-link:hover {
-  background: var(--#{$prefix}pagination-hover-bg);
-}
-
-.page-text {
-  padding-inline-start: 0.5rem;
-  padding-inline-end: 0.5rem;
-}
-
-.page-item {
-  text-align: center;
-
-  &.page-prev,
-  &.page-next {
-    flex: 0 0 50%;
-    text-align: start;
+    @include media-print {
+      display: none;
+    }
   }
 
-  &.page-next {
-    margin-inline-start: auto;
-    text-align: end;
-  }
-}
-
-.page-item-subtitle {
-  margin-bottom: 2px;
-  font-size: 12px;
-  color: var(--#{$prefix}secondary);
-  text-transform: uppercase;
-
-  .page-item.disabled & {
-    color: $pagination-disabled-color;
-  }
-}
-
-.page-item-title {
-  font-size: $h3-font-size;
-  font-weight: var(--#{$prefix}font-weight-normal);
-  color: var(--#{$prefix}body-color);
-
-  .page-link:hover & {
-    color: $link-color;
+  .page-link {
+    min-width: 2rem;
+    @include border-radius(var(--#{$prefix}pagination-border-radius));
   }
 
-  .page-item.disabled & {
-    color: $pagination-disabled-color;
+  .page-item:not(.active) .page-link:hover {
+    background: var(--#{$prefix}pagination-hover-bg);
   }
-}
 
-.pagination-outline {
-  --#{$prefix}pagination-border-color: var(--#{$prefix}border-color);
-  --#{$prefix}pagination-disabled-border-color: var(--#{$prefix}border-color);
-  --#{$prefix}pagination-border-width: 1px;
-}
+  .page-text {
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+  }
 
-.pagination-circle {
-  --#{$prefix}pagination-border-radius: var(--tblr-border-radius-pill);
+  .page-item {
+    text-align: center;
+
+    &.page-prev,
+    &.page-next {
+      flex: 0 0 50%;
+      text-align: start;
+    }
+
+    &.page-next {
+      margin-inline-start: auto;
+      text-align: end;
+    }
+  }
+
+  .page-item-subtitle {
+    margin-bottom: 2px;
+    font-size: 12px;
+    color: var(--#{$prefix}secondary);
+    text-transform: uppercase;
+
+    .page-item.disabled & {
+      color: $pagination-disabled-color;
+    }
+  }
+
+  .page-item-title {
+    font-size: $h3-font-size;
+    font-weight: var(--#{$prefix}font-weight-normal);
+    color: var(--#{$prefix}body-color);
+
+    .page-link:hover & {
+      color: $link-color;
+    }
+
+    .page-item.disabled & {
+      color: $pagination-disabled-color;
+    }
+  }
+
+  .pagination-outline {
+    --#{$prefix}pagination-border-color: var(--#{$prefix}border-color);
+    --#{$prefix}pagination-disabled-border-color: var(--#{$prefix}border-color);
+    --#{$prefix}pagination-border-width: 1px;
+  }
+
+  .pagination-circle {
+    --#{$prefix}pagination-border-radius: var(--tblr-border-radius-pill);
+  }
 }

--- a/core/scss/ui/_patterns.scss
+++ b/core/scss/ui/_patterns.scss
@@ -1,240 +1,230 @@
-.bg-pattern-diagonal {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-size: .5rem;
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   background-image: repeating-linear-gradient(-45deg, var(--#{$prefix}pattern-fill) 0 1px, transparent 0 50%);
-   background-clip: padding-box;
-   background-size: var(--#{$prefix}pattern-size) var(--#{$prefix}pattern-size);
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+@layer components {
+  .bg-pattern-diagonal {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-size: 0.5rem;
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    background-image: repeating-linear-gradient(-45deg, var(--#{$prefix}pattern-fill) 0 1px, transparent 0 50%);
+    background-clip: padding-box;
+    background-size: var(--#{$prefix}pattern-size) var(--#{$prefix}pattern-size);
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-diagonal-2 {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-size: .5rem;
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   background-image: repeating-linear-gradient(45deg, var(--#{$prefix}pattern-fill) 0 1px, transparent 0 50%);
-   background-clip: padding-box;
-   background-size: var(--#{$prefix}pattern-size) var(--#{$prefix}pattern-size);
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-diagonal-2 {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-size: 0.5rem;
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    background-image: repeating-linear-gradient(45deg, var(--#{$prefix}pattern-fill) 0 1px, transparent 0 50%);
+    background-clip: padding-box;
+    background-size: var(--#{$prefix}pattern-size) var(--#{$prefix}pattern-size);
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-dots {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-size: 5px;
-   --#{$prefix}pattern-dot: .5px;
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 20%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   background-image: radial-gradient(circle, var(--#{$prefix}pattern-fill) var(--#{$prefix}pattern-dot), transparent var(--#{$prefix}pattern-dot)),
-   radial-gradient(circle, var(--#{$prefix}pattern-fill) var(--#{$prefix}pattern-dot), transparent var(--#{$prefix}pattern-dot));
-   background-position: 0 0,
-   calc(var(--#{$prefix}pattern-size) / 2) calc(var(--#{$prefix}pattern-size) / 2);
-   background-size: var(--#{$prefix}pattern-size) var(--#{$prefix}pattern-size);
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-dots {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-size: 5px;
+    --#{$prefix}pattern-dot: 0.5px;
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 20%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    background-image: radial-gradient(circle, var(--#{$prefix}pattern-fill) var(--#{$prefix}pattern-dot), transparent var(--#{$prefix}pattern-dot)), radial-gradient(circle, var(--#{$prefix}pattern-fill) var(--#{$prefix}pattern-dot), transparent var(--#{$prefix}pattern-dot));
+    background-position:
+      0 0,
+      calc(var(--#{$prefix}pattern-size) / 2) calc(var(--#{$prefix}pattern-size) / 2);
+    background-size: var(--#{$prefix}pattern-size) var(--#{$prefix}pattern-size);
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-rectangles {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 3%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   --#{$prefix}pattern-size: .5rem;
-   background-image: repeating-linear-gradient(45deg, var(--#{$prefix}pattern-fill) 25%, transparent 25%, transparent 75%, var(--#{$prefix}pattern-fill) 75%, var(--#{$prefix}pattern-fill)),
-   repeating-linear-gradient(45deg, var(--#{$prefix}pattern-fill) 25%, transparent 25%, transparent 75%, var(--#{$prefix}pattern-fill) 75%, var(--#{$prefix}pattern-fill));
-   background-position: -1px -1px,
-   calc(var(--#{$prefix}pattern-size) - 1px) calc(var(--#{$prefix}pattern-size) - 1px);
-   background-size: calc(var(--#{$prefix}pattern-size) * 2) calc(var(--#{$prefix}pattern-size) * 2);
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-rectangles {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 3%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    --#{$prefix}pattern-size: 0.5rem;
+    background-image:
+      repeating-linear-gradient(45deg, var(--#{$prefix}pattern-fill) 25%, transparent 25%, transparent 75%, var(--#{$prefix}pattern-fill) 75%, var(--#{$prefix}pattern-fill)),
+      repeating-linear-gradient(45deg, var(--#{$prefix}pattern-fill) 25%, transparent 25%, transparent 75%, var(--#{$prefix}pattern-fill) 75%, var(--#{$prefix}pattern-fill));
+    background-position:
+      -1px -1px,
+      calc(var(--#{$prefix}pattern-size) - 1px) calc(var(--#{$prefix}pattern-size) - 1px);
+    background-size: calc(var(--#{$prefix}pattern-size) * 2) calc(var(--#{$prefix}pattern-size) * 2);
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-lines {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 6%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   --#{$prefix}pattern-size: .5rem;
-   background-size: var(--#{$prefix}pattern-size) var(--#{$prefix}pattern-size);
-   background-image: repeating-linear-gradient(0deg, var(--#{$prefix}pattern-fill), var(--#{$prefix}pattern-fill) 1px, transparent 1px, transparent);
-   background-position: -1px -1px;
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-lines {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 6%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    --#{$prefix}pattern-size: 0.5rem;
+    background-size: var(--#{$prefix}pattern-size) var(--#{$prefix}pattern-size);
+    background-image: repeating-linear-gradient(0deg, var(--#{$prefix}pattern-fill), var(--#{$prefix}pattern-fill) 1px, transparent 1px, transparent);
+    background-position: -1px -1px;
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-lines-vertical {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 6%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   --#{$prefix}pattern-size: .5rem;
-   background-size: var(--#{$prefix}pattern-size) var(--#{$prefix}pattern-size);
-   background-image: repeating-linear-gradient(90deg, var(--#{$prefix}pattern-fill), var(--#{$prefix}pattern-fill) 1px, transparent 1px, transparent);
-   background-position: -1px -1px;
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-lines-vertical {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 6%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    --#{$prefix}pattern-size: 0.5rem;
+    background-size: var(--#{$prefix}pattern-size) var(--#{$prefix}pattern-size);
+    background-image: repeating-linear-gradient(90deg, var(--#{$prefix}pattern-fill), var(--#{$prefix}pattern-fill) 1px, transparent 1px, transparent);
+    background-position: -1px -1px;
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-grid {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 6%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   --#{$prefix}pattern-size: .5rem;
-   background-image: linear-gradient(to right, var(--#{$prefix}pattern-fill) 1px, transparent 1px),
-   linear-gradient(to bottom, var(--#{$prefix}pattern-fill) 1px, transparent 1px);
-   background-size: calc(var(--#{$prefix}pattern-size) * 2) calc(var(--#{$prefix}pattern-size) * 2);
-   background-position: -1px -1px, -1px -1px;
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-grid {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 6%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    --#{$prefix}pattern-size: 0.5rem;
+    background-image: linear-gradient(to right, var(--#{$prefix}pattern-fill) 1px, transparent 1px), linear-gradient(to bottom, var(--#{$prefix}pattern-fill) 1px, transparent 1px);
+    background-size: calc(var(--#{$prefix}pattern-size) * 2) calc(var(--#{$prefix}pattern-size) * 2);
+    background-position:
+      -1px -1px,
+      -1px -1px;
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-grid-diagonal {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   --#{$prefix}pattern-size: .5rem;
-   background-image: linear-gradient(45deg, transparent 49%, var(--#{$prefix}pattern-fill) 49%, var(--#{$prefix}pattern-fill) 51%, transparent 51%),
-   linear-gradient(-45deg, transparent 49%, var(--#{$prefix}pattern-fill) 49%, var(--#{$prefix}pattern-fill) 51%, transparent 51%);
-   background-size: calc(var(--#{$prefix}pattern-size) * 2) calc(var(--#{$prefix}pattern-size) * 2);
-   background-position: center center;
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-grid-diagonal {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    --#{$prefix}pattern-size: 0.5rem;
+    background-image: linear-gradient(45deg, transparent 49%, var(--#{$prefix}pattern-fill) 49%, var(--#{$prefix}pattern-fill) 51%, transparent 51%), linear-gradient(-45deg, transparent 49%, var(--#{$prefix}pattern-fill) 49%, var(--#{$prefix}pattern-fill) 51%, transparent 51%);
+    background-size: calc(var(--#{$prefix}pattern-size) * 2) calc(var(--#{$prefix}pattern-size) * 2);
+    background-position: center center;
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-blueprint {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-size: .5rem;
-   --#{$prefix}pattern-line: color-mix(in oklch, var(--#{$prefix}pattern-color) 6%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   background-image: linear-gradient(var(--#{$prefix}pattern-line) 2px, transparent 2px),
-   linear-gradient(90deg, var(--#{$prefix}pattern-line) 2px, transparent 2px),
-   linear-gradient(var(--#{$prefix}pattern-line) 1px, transparent 1px),
-   linear-gradient(90deg, var(--#{$prefix}pattern-line) 1px, transparent 1px);
-   background-size: calc(var(--#{$prefix}pattern-size) * 10) calc(var(--#{$prefix}pattern-size) * 10),
-   calc(var(--#{$prefix}pattern-size) * 10) calc(var(--#{$prefix}pattern-size) * 10),
-   calc(var(--#{$prefix}pattern-size) * 2) calc(var(--#{$prefix}pattern-size) * 2),
-   calc(var(--#{$prefix}pattern-size) * 2) calc(var(--#{$prefix}pattern-size) * 2);
-   background-position: -3px -3px, -3px -3px, -2px -2px, -2px -2px;
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-blueprint {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-size: 0.5rem;
+    --#{$prefix}pattern-line: color-mix(in oklch, var(--#{$prefix}pattern-color) 6%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    background-image: linear-gradient(var(--#{$prefix}pattern-line) 2px, transparent 2px), linear-gradient(90deg, var(--#{$prefix}pattern-line) 2px, transparent 2px), linear-gradient(var(--#{$prefix}pattern-line) 1px, transparent 1px), linear-gradient(90deg, var(--#{$prefix}pattern-line) 1px, transparent 1px);
+    background-size:
+      calc(var(--#{$prefix}pattern-size) * 10) calc(var(--#{$prefix}pattern-size) * 10),
+      calc(var(--#{$prefix}pattern-size) * 10) calc(var(--#{$prefix}pattern-size) * 10),
+      calc(var(--#{$prefix}pattern-size) * 2) calc(var(--#{$prefix}pattern-size) * 2),
+      calc(var(--#{$prefix}pattern-size) * 2) calc(var(--#{$prefix}pattern-size) * 2);
+    background-position:
+      -3px -3px,
+      -3px -3px,
+      -2px -2px,
+      -2px -2px;
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-cross-dots {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-size: .5rem;
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   background-image: radial-gradient(var(--#{$prefix}pattern-fill) 1px, transparent 1px),
-   radial-gradient(var(--#{$prefix}pattern-fill) 1px, transparent 1px);
-   background-size: calc(var(--#{$prefix}pattern-size) * 2) calc(var(--#{$prefix}pattern-size) * 2);
-   background-position: 0 0,
-   var(--#{$prefix}pattern-size) var(--#{$prefix}pattern-size);
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-cross-dots {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-size: 0.5rem;
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    background-image: radial-gradient(var(--#{$prefix}pattern-fill) 1px, transparent 1px), radial-gradient(var(--#{$prefix}pattern-fill) 1px, transparent 1px);
+    background-size: calc(var(--#{$prefix}pattern-size) * 2) calc(var(--#{$prefix}pattern-size) * 2);
+    background-position:
+      0 0,
+      var(--#{$prefix}pattern-size) var(--#{$prefix}pattern-size);
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-circles {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-size: .5rem;
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   background-image: radial-gradient(circle at center top, transparent 9%, var(--#{$prefix}pattern-fill) 10%, var(--#{$prefix}pattern-fill) 15%, transparent 16%),
-   radial-gradient(circle at center bottom, transparent 9%, var(--#{$prefix}pattern-fill) 10%, var(--#{$prefix}pattern-fill) 15%, transparent 16%),
-   radial-gradient(circle at right center, transparent 9%, var(--#{$prefix}pattern-fill) 10%, var(--#{$prefix}pattern-fill) 15%, transparent 16%),
-   radial-gradient(circle at left center, transparent 9%, var(--#{$prefix}pattern-fill) 10%, var(--#{$prefix}pattern-fill) 15%, transparent 16%);
-   background-position: 0 0;
-   background-size: calc(var(--#{$prefix}pattern-size) * 3) calc(var(--#{$prefix}pattern-size) * 3);
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-circles {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-size: 0.5rem;
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    background-image:
+      radial-gradient(circle at center top, transparent 9%, var(--#{$prefix}pattern-fill) 10%, var(--#{$prefix}pattern-fill) 15%, transparent 16%), radial-gradient(circle at center bottom, transparent 9%, var(--#{$prefix}pattern-fill) 10%, var(--#{$prefix}pattern-fill) 15%, transparent 16%),
+      radial-gradient(circle at right center, transparent 9%, var(--#{$prefix}pattern-fill) 10%, var(--#{$prefix}pattern-fill) 15%, transparent 16%), radial-gradient(circle at left center, transparent 9%, var(--#{$prefix}pattern-fill) 10%, var(--#{$prefix}pattern-fill) 15%, transparent 16%);
+    background-position: 0 0;
+    background-size: calc(var(--#{$prefix}pattern-size) * 3) calc(var(--#{$prefix}pattern-size) * 3);
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-diagonal-stripes {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-size: .5rem;
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 5%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   background-image: repeating-linear-gradient(45deg,
-      transparent,
-      transparent var(--#{$prefix}pattern-size),
-      var(--#{$prefix}pattern-fill) var(--#{$prefix}pattern-size),
-      var(--#{$prefix}pattern-fill) calc(2 * var(--#{$prefix}pattern-size)));
-   background-repeat: no-repeat;
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-diagonal-stripes {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-size: 0.5rem;
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 5%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    background-image: repeating-linear-gradient(45deg, transparent, transparent var(--#{$prefix}pattern-size), var(--#{$prefix}pattern-fill) var(--#{$prefix}pattern-size), var(--#{$prefix}pattern-fill) calc(2 * var(--#{$prefix}pattern-size)));
+    background-repeat: no-repeat;
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-diagonal-stripes-2 {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-size: .5rem;
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 5%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   background-image: repeating-linear-gradient(-45deg,
-      transparent,
-      transparent var(--#{$prefix}pattern-size),
-      var(--#{$prefix}pattern-fill) var(--#{$prefix}pattern-size),
-      var(--#{$prefix}pattern-fill) calc(2 * var(--#{$prefix}pattern-size)));
-   background-repeat: no-repeat;
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-diagonal-stripes-2 {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-size: 0.5rem;
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 5%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    background-image: repeating-linear-gradient(-45deg, transparent, transparent var(--#{$prefix}pattern-size), var(--#{$prefix}pattern-fill) var(--#{$prefix}pattern-size), var(--#{$prefix}pattern-fill) calc(2 * var(--#{$prefix}pattern-size)));
+    background-repeat: no-repeat;
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-zigzag {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-size: .5rem;
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 5%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   background: linear-gradient(135deg, var(--#{$prefix}pattern-fill) 25%, transparent 25%) calc(-1 * var(--#{$prefix}pattern-size)) 0,
-   linear-gradient(225deg, var(--#{$prefix}pattern-fill) 25%, transparent 25%) calc(-1 * var(--#{$prefix}pattern-size)) 0,
-   linear-gradient(315deg, var(--#{$prefix}pattern-fill) 25%, transparent 25%),
-   linear-gradient(45deg, var(--#{$prefix}pattern-fill) 25%, transparent 25%);
-   background-size: calc(2 * var(--#{$prefix}pattern-size)) calc(2 * var(--#{$prefix}pattern-size));
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-zigzag {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-size: 0.5rem;
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 5%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    background:
+      linear-gradient(135deg, var(--#{$prefix}pattern-fill) 25%, transparent 25%) calc(-1 * var(--#{$prefix}pattern-size)) 0,
+      linear-gradient(225deg, var(--#{$prefix}pattern-fill) 25%, transparent 25%) calc(-1 * var(--#{$prefix}pattern-size)) 0,
+      linear-gradient(315deg, var(--#{$prefix}pattern-fill) 25%, transparent 25%),
+      linear-gradient(45deg, var(--#{$prefix}pattern-fill) 25%, transparent 25%);
+    background-size: calc(2 * var(--#{$prefix}pattern-size)) calc(2 * var(--#{$prefix}pattern-size));
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-vertical-stripes {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-size: .5rem;
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 5%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   background-image: repeating-linear-gradient(90deg,
-      transparent,
-      transparent var(--#{$prefix}pattern-size),
-      var(--#{$prefix}pattern-fill) var(--#{$prefix}pattern-size),
-      var(--#{$prefix}pattern-fill) calc(2 * var(--#{$prefix}pattern-size)));
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-vertical-stripes {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-size: 0.5rem;
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 5%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    background-image: repeating-linear-gradient(90deg, transparent, transparent var(--#{$prefix}pattern-size), var(--#{$prefix}pattern-fill) var(--#{$prefix}pattern-size), var(--#{$prefix}pattern-fill) calc(2 * var(--#{$prefix}pattern-size)));
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-.bg-pattern-horizontal-stripes {
-   --#{$prefix}pattern-color: var(--#{$prefix}body-color);
-   --#{$prefix}pattern-size: .5rem;
-   --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 5%, transparent);
-   --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
-   background-image: repeating-linear-gradient(0deg,
-      transparent,
-      transparent var(--#{$prefix}pattern-size),
-      var(--#{$prefix}pattern-fill) var(--#{$prefix}pattern-size),
-      var(--#{$prefix}pattern-fill) calc(2 * var(--#{$prefix}pattern-size)));
-   background-position: -1px -1px;
-   background-clip: padding-box;
-   border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
-}
+  .bg-pattern-horizontal-stripes {
+    --#{$prefix}pattern-color: var(--#{$prefix}body-color);
+    --#{$prefix}pattern-size: 0.5rem;
+    --#{$prefix}pattern-fill: color-mix(in oklch, var(--#{$prefix}pattern-color) 5%, transparent);
+    --#{$prefix}pattern-border: color-mix(in oklch, var(--#{$prefix}pattern-color) 10%, transparent);
+    background-image: repeating-linear-gradient(0deg, transparent, transparent var(--#{$prefix}pattern-size), var(--#{$prefix}pattern-fill) var(--#{$prefix}pattern-size), var(--#{$prefix}pattern-fill) calc(2 * var(--#{$prefix}pattern-size)));
+    background-position: -1px -1px;
+    background-clip: padding-box;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}pattern-border);
+  }
 
-// Color variants
-@each $color, $value in $theme-colors {
-   .bg-pattern-#{$color} { 
+  // Color variants
+  @each $color, $value in $theme-colors {
+    .bg-pattern-#{$color} {
       --#{$prefix}pattern-color: #{$value};
-   }
-}
+    }
+  }
 
-// Sizes
-$sizes: (
-   'sm': .25rem,
-   'md': .5rem,
-   'lg': .75rem,
-   'xl': 1rem,
-);
+  // Sizes
+  $sizes: (
+    'sm': 0.25rem,
+    'md': 0.5rem,
+    'lg': 0.75rem,
+    'xl': 1rem,
+  );
 
-@each $size, $value in $sizes {
-   .bg-pattern-#{$size} {
+  @each $size, $value in $sizes {
+    .bg-pattern-#{$size} {
       --#{$prefix}pattern-size: #{$value};
-   }
+    }
+  }
 }

--- a/core/scss/ui/_payments.scss
+++ b/core/scss/ui/_payments.scss
@@ -1,29 +1,31 @@
 @use 'sass:map';
 @use '../config';
 
-.payment {
-  height: config.$avatar-size;
-  aspect-ratio: 1.66666;
-  display: inline-block;
-  background: no-repeat center/100% 100%;
-  vertical-align: bottom;
-  font-style: normal;
-  box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.1);
-  @include config.border-radius(var(--#{config.$prefix}border-radius));
-}
-
-@each $payment in config.$payment-providers {
-  .payment-provider-#{$payment} {
-    background-image: url('#{config.$assets-base}/img/payments/#{$payment}.svg');
+@layer components {
+  .payment {
+    height: config.$avatar-size;
+    aspect-ratio: 1.66666;
+    display: inline-block;
+    background: no-repeat center/100% 100%;
+    vertical-align: bottom;
+    font-style: normal;
+    box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.1);
+    @include config.border-radius(var(--#{config.$prefix}border-radius));
   }
 
-  .payment-provider-#{$payment}-dark {
-    background-image: url('#{config.$assets-base}/img/payments/#{$payment}-dark.svg');
-  }
-}
+  @each $payment in config.$payment-providers {
+    .payment-provider-#{$payment} {
+      background-image: url('#{config.$assets-base}/img/payments/#{$payment}.svg');
+    }
 
-@each $payment-size, $size in config.$payment-sizes {
-  .payment-#{$payment-size} {
-    height: map.get($size, size);
+    .payment-provider-#{$payment}-dark {
+      background-image: url('#{config.$assets-base}/img/payments/#{$payment}-dark.svg');
+    }
+  }
+
+  @each $payment-size, $size in config.$payment-sizes {
+    .payment-#{$payment-size} {
+      height: map.get($size, size);
+    }
   }
 }

--- a/core/scss/ui/_placeholder.scss
+++ b/core/scss/ui/_placeholder.scss
@@ -1,9 +1,11 @@
-.placeholder {
-  &:not(.btn):not([class*='bg-']) {
-    background-color: currentColor !important;
-  }
+@layer components {
+  .placeholder {
+    &:not(.btn):not([class*='bg-']) {
+      background-color: currentColor !important;
+    }
 
-  &:not(.avatar):not([class*='card-img-']) {
-    @include border-radius(var(--#{$prefix}border-radius));
+    &:not(.avatar):not([class*='card-img-']) {
+      @include border-radius(var(--#{$prefix}border-radius));
+    }
   }
 }

--- a/core/scss/ui/_popovers.scss
+++ b/core/scss/ui/_popovers.scss
@@ -1,5 +1,7 @@
-.popover {
-  @include media-print {
-    display: none;
+@layer components {
+  .popover {
+    @include media-print {
+      display: none;
+    }
   }
 }

--- a/core/scss/ui/_progress.scss
+++ b/core/scss/ui/_progress.scss
@@ -1,145 +1,147 @@
-@keyframes progress-indeterminate {
-  0% {
-    inset-inline-end: 100%;
-    inset-inline-start: -35%;
+@layer components {
+  @keyframes progress-indeterminate {
+    0% {
+      inset-inline-end: 100%;
+      inset-inline-start: -35%;
+    }
+
+    100%,
+    60% {
+      inset-inline-end: -90%;
+      inset-inline-start: 100%;
+    }
   }
 
-  100%,
-  60% {
-    inset-inline-end: -90%;
-    inset-inline-start: 100%;
+  /**
+  Progress
+   */
+  .progress {
+    position: relative;
+    width: 100%;
+    line-height: $progress-height;
+    appearance: none;
+
+    &::-webkit-progress-bar {
+      background: var(--#{$prefix}progress-bg);
+    }
+
+    &::-webkit-progress-value {
+      background-color: var(--#{$prefix}primary);
+    }
+
+    &::-moz-progress-bar {
+      background-color: var(--#{$prefix}primary);
+    }
+
+    &::-ms-fill {
+      background-color: var(--#{$prefix}primary);
+      border: none;
+    }
   }
-}
 
-/**
-Progress
- */
-.progress {
-  position: relative;
-  width: 100%;
-  line-height: $progress-height;
-  appearance: none;
-
-  &::-webkit-progress-bar {
-    background: var(--#{$prefix}progress-bg);
+  .progress-sm {
+    height: 0.25rem;
   }
 
-  &::-webkit-progress-value {
-    background-color: var(--#{$prefix}primary);
+  .progress-lg {
+    height: 0.75rem;
   }
 
-  &::-moz-progress-bar {
-    background-color: var(--#{$prefix}primary);
+  .progress-xl {
+    height: 1rem;
   }
 
-  &::-ms-fill {
-    background-color: var(--#{$prefix}primary);
-    border: none;
+  /**
+  Progress bar
+   */
+  .progress-bar {
+    height: 100%;
+    @include transition(width $transition-time, background $transition-time);
   }
-}
 
-.progress-sm {
-  height: 0.25rem;
-}
+  .progress-bar-indeterminate {
+    &:after,
+    &:before {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      inset-inline-start: 0;
+      content: '';
+      background-color: inherit;
+      will-change: left, right;
+    }
 
-.progress-lg {
-  height: 0.75rem;
-}
+    &:before {
+      animation: progress-indeterminate 1.5s cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
+    }
+  }
 
-.progress-xl {
-  height: 1rem;
-}
+  .progress-separated {
+    .progress-bar {
+      box-shadow: 0 0 0 2px var(--#{$prefix}card-bg, var(--#{$prefix}bg-surface));
+    }
+  }
 
-/**
-Progress bar
- */
-.progress-bar {
-  height: 100%;
-  @include transition(width $transition-time, background $transition-time);
-}
+  /**
+  Progressbg
+   */
+  .progressbg {
+    position: relative;
+    padding: 0.25rem 0.5rem;
+    display: flex;
+  }
 
-.progress-bar-indeterminate {
-  &:after,
-  &:before {
+  .progressbg-text {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    @include text-truncate;
+  }
+
+  .progressbg-progress {
     position: absolute;
     top: 0;
+    inset-inline-end: 0;
     bottom: 0;
     inset-inline-start: 0;
-    content: '';
-    background-color: inherit;
-    will-change: left, right;
+    z-index: 0;
+    height: 100%;
+    background: transparent;
+    pointer-events: none;
   }
 
-  &:before {
-    animation: progress-indeterminate 1.5s cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
+  .progressbg-value {
+    font-weight: var(--#{$prefix}font-weight-medium);
+    margin-inline-start: auto;
+    padding-inline-start: 2rem;
   }
-}
 
-.progress-separated {
-  .progress-bar {
-    box-shadow: 0 0 0 2px var(--#{$prefix}card-bg, var(--#{$prefix}bg-surface));
+  /**
+  Progress steps
+   */
+  .progress-steps {
+    display: flex;
+    flex-wrap: nowrap;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    gap: 0.25rem;
   }
-}
 
-/**
-Progressbg
- */
-.progressbg {
-  position: relative;
-  padding: 0.25rem 0.5rem;
-  display: flex;
-}
+  .progress-steps-item {
+    flex: 1 1 0;
+    min-height: 0.25rem;
+    margin-top: 0;
+    color: inherit;
+    text-align: center;
+    cursor: default;
+    background-color: var(--tblr-border-color);
+    @include border-radius(var(--#{$prefix}border-radius-pill));
 
-.progressbg-text {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  align-items: center;
-  @include text-truncate;
-}
-
-.progressbg-progress {
-  position: absolute;
-  top: 0;
-  inset-inline-end: 0;
-  bottom: 0;
-  inset-inline-start: 0;
-  z-index: 0;
-  height: 100%;
-  background: transparent;
-  pointer-events: none;
-}
-
-.progressbg-value {
-  font-weight: var(--#{$prefix}font-weight-medium);
-  margin-inline-start: auto;
-  padding-inline-start: 2rem;
-}
-
-/**
-Progress steps
- */
-.progress-steps {
-  display: flex;
-  flex-wrap: nowrap;
-  width: 100%;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-  gap: 0.25rem;
-}
-
-.progress-steps-item {
-  flex: 1 1 0;
-  min-height: 0.25rem;
-  margin-top: 0;
-  color: inherit;
-  text-align: center;
-  cursor: default;
-  background-color: var(--tblr-border-color);
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-
-  @at-root a#{&} {
-    cursor: pointer;
+    @at-root a#{&} {
+      cursor: pointer;
+    }
   }
 }

--- a/core/scss/ui/_ribbons.scss
+++ b/core/scss/ui/_ribbons.scss
@@ -1,156 +1,158 @@
 // stylelint-disable declaration-no-important
 
-.ribbon {
-  --#{$prefix}ribbon-margin: #{$card-ribbon-margin};
-  --#{$prefix}ribbon-border-radius: #{$card-ribbon-border-radius};
-  position: absolute;
-  top: 0.75rem;
-  inset-inline-end: calc(-1 * var(--#{$prefix}ribbon-margin));
-  z-index: 1;
-  padding: 0.25rem 0.75rem;
-  font-size: $card-ribbon-font-size;
-  font-weight: var(--#{$prefix}font-weight-semibold);
-  line-height: 1;
-  color: $white;
-  text-align: center;
-  text-transform: uppercase;
-  background: var(--#{$prefix}primary);
-  border-color: var(--#{$prefix}primary);
-  @include border-radius(var(--#{$prefix}ribbon-border-radius) 0 var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius));
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 2rem;
-  min-width: 2rem;
-
-  &:before {
+@layer components {
+  .ribbon {
+    --#{$prefix}ribbon-margin: #{$card-ribbon-margin};
+    --#{$prefix}ribbon-border-radius: #{$card-ribbon-border-radius};
     position: absolute;
-    inset-inline-end: 0;
-    bottom: 100%;
-    width: 0;
-    height: 0;
-    content: '';
-    filter: brightness(70%);
-    border: calc(var(--#{$prefix}ribbon-margin) * 0.5) var(--#{$prefix}border-style);
-    border-color: inherit;
-    border-top-color: transparent;
-    border-inline-end-color: transparent;
-  }
+    top: 0.75rem;
+    inset-inline-end: calc(-1 * var(--#{$prefix}ribbon-margin));
+    z-index: 1;
+    padding: 0.25rem 0.75rem;
+    font-size: $card-ribbon-font-size;
+    font-weight: var(--#{$prefix}font-weight-semibold);
+    line-height: 1;
+    color: $white;
+    text-align: center;
+    text-transform: uppercase;
+    background: var(--#{$prefix}primary);
+    border-color: var(--#{$prefix}primary);
+    @include border-radius(var(--#{$prefix}ribbon-border-radius) 0 var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius));
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2rem;
+    min-width: 2rem;
 
-  @if $enable-extra-colors {
-    @each $color, $value in $extra-colors {
-      &.bg-#{$color} {
-        border-color: var(--#{$prefix}#{$color});
-      }
+    &:before {
+      position: absolute;
+      inset-inline-end: 0;
+      bottom: 100%;
+      width: 0;
+      height: 0;
+      content: '';
+      filter: brightness(70%);
+      border: calc(var(--#{$prefix}ribbon-margin) * 0.5) var(--#{$prefix}border-style);
+      border-color: inherit;
+      border-top-color: transparent;
+      border-inline-end-color: transparent;
+    }
 
-      &.bg-#{$color}-lt {
-        border-color: color-transparent(var(--#{$prefix}#{$color}), 0.1) !important;
+    @if $enable-extra-colors {
+      @each $color, $value in $extra-colors {
+        &.bg-#{$color} {
+          border-color: var(--#{$prefix}#{$color});
+        }
+
+        &.bg-#{$color}-lt {
+          border-color: color-transparent(var(--#{$prefix}#{$color}), 0.1) !important;
+        }
       }
+    }
+
+    .icon {
+      width: 1.25rem;
+      height: 1.25rem;
+      font-size: 1.25rem;
     }
   }
 
-  .icon {
-    width: 1.25rem;
-    height: 1.25rem;
-    font-size: 1.25rem;
-  }
-}
-
-.ribbon-top {
-  top: calc(-1 * var(--#{$prefix}ribbon-margin));
-  inset-inline-end: 0.75rem;
-  width: 2rem;
-  padding: 0.5rem 0;
-  @include border-radius(0 var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius));
-
-  &:before {
-    top: 0;
-    inset-inline-end: 100%;
-    bottom: auto;
-    border-color: inherit;
-    border-top-color: transparent;
-    border-inline-start-color: transparent;
-  }
-
-  &.ribbon-start {
-    inset-inline-end: auto;
-    inset-inline-start: 0.75rem;
+  .ribbon-top {
+    top: calc(-1 * var(--#{$prefix}ribbon-margin));
+    inset-inline-end: 0.75rem;
+    width: 2rem;
+    padding: 0.5rem 0;
+    @include border-radius(0 var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius));
 
     &:before {
       top: 0;
       inset-inline-end: 100%;
-      inset-inline-start: auto;
+      bottom: auto;
+      border-color: inherit;
+      border-top-color: transparent;
+      border-inline-start-color: transparent;
     }
-  }
-}
 
-.ribbon-start {
-  inset-inline-end: auto;
-  inset-inline-start: calc(-1 * var(--#{$prefix}ribbon-margin));
-  @include border-radius(0 var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius));
-
-  &:before {
-    top: auto;
-    bottom: 100%;
-    inset-inline-start: 0;
-    border-color: inherit;
-    border-top-color: transparent;
-    border-inline-start-color: transparent;
-  }
-}
-
-.ribbon-bottom {
-  top: auto;
-  bottom: 0.75rem;
-}
-
-.ribbon-bookmark {
-  padding-inline-start: 0.25rem;
-  @include border-radius(0 0 var(--#{$prefix}ribbon-border-radius) 0);
-
-  &:after {
-    position: absolute;
-    top: 0;
-    inset-inline-end: 100%;
-    display: block;
-    width: 0;
-    height: 0;
-    content: '';
-    border: 1rem var(--#{$prefix}border-style);
-    border-color: inherit;
-    border-inline-end-width: 0;
-    border-inline-start-color: transparent;
-    border-inline-start-width: 0.5rem;
-  }
-
-  &.ribbon-left {
-    padding-inline-end: 0.5rem;
-
-    &:after {
+    &.ribbon-start {
       inset-inline-end: auto;
-      inset-inline-start: 100%;
-      border-inline-end-color: transparent;
+      inset-inline-start: 0.75rem;
 
-      border-inline-end-width: 0.5rem;
-      border-inline-start-width: 0;
+      &:before {
+        top: 0;
+        inset-inline-end: 100%;
+        inset-inline-start: auto;
+      }
     }
   }
 
-  &.ribbon-top {
-    padding-inline-end: 0;
-    padding-bottom: 0.25rem;
-    padding-inline-start: 0;
-    @include border-radius(0 var(--#{$prefix}ribbon-border-radius) 0 0);
+  .ribbon-start {
+    inset-inline-end: auto;
+    inset-inline-start: calc(-1 * var(--#{$prefix}ribbon-margin));
+    @include border-radius(0 var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius) var(--#{$prefix}ribbon-border-radius));
 
-    &:after {
-      top: 100%;
-      inset-inline-end: 0;
+    &:before {
+      top: auto;
+      bottom: 100%;
       inset-inline-start: 0;
       border-color: inherit;
-      border-width: 1rem;
-      border-top-width: 0;
-      border-bottom-color: transparent;
-      border-bottom-width: 0.5rem;
+      border-top-color: transparent;
+      border-inline-start-color: transparent;
+    }
+  }
+
+  .ribbon-bottom {
+    top: auto;
+    bottom: 0.75rem;
+  }
+
+  .ribbon-bookmark {
+    padding-inline-start: 0.25rem;
+    @include border-radius(0 0 var(--#{$prefix}ribbon-border-radius) 0);
+
+    &:after {
+      position: absolute;
+      top: 0;
+      inset-inline-end: 100%;
+      display: block;
+      width: 0;
+      height: 0;
+      content: '';
+      border: 1rem var(--#{$prefix}border-style);
+      border-color: inherit;
+      border-inline-end-width: 0;
+      border-inline-start-color: transparent;
+      border-inline-start-width: 0.5rem;
+    }
+
+    &.ribbon-left {
+      padding-inline-end: 0.5rem;
+
+      &:after {
+        inset-inline-end: auto;
+        inset-inline-start: 100%;
+        border-inline-end-color: transparent;
+
+        border-inline-end-width: 0.5rem;
+        border-inline-start-width: 0;
+      }
+    }
+
+    &.ribbon-top {
+      padding-inline-end: 0;
+      padding-bottom: 0.25rem;
+      padding-inline-start: 0;
+      @include border-radius(0 var(--#{$prefix}ribbon-border-radius) 0 0);
+
+      &:after {
+        top: 100%;
+        inset-inline-end: 0;
+        inset-inline-start: 0;
+        border-color: inherit;
+        border-width: 1rem;
+        border-top-width: 0;
+        border-bottom-color: transparent;
+        border-bottom-width: 0.5rem;
+      }
     }
   }
 }

--- a/core/scss/ui/_segmented.scss
+++ b/core/scss/ui/_segmented.scss
@@ -1,102 +1,104 @@
-.nav-segmented {
-  --#{$prefix}nav-bg: var(--#{$prefix}bg-surface-tertiary);
-  --#{$prefix}nav-padding: 2px;
-  --#{$prefix}nav-height: 2.5rem;
-  --#{$prefix}nav-gap: 0.25rem;
-  --#{$prefix}nav-active-bg: var(--#{$prefix}bg-surface);
-  --#{$prefix}nav-font-size: inherit;
-  --#{$prefix}nav-radius: 6px;
+@layer components {
+  .nav-segmented {
+    --#{$prefix}nav-bg: var(--#{$prefix}bg-surface-tertiary);
+    --#{$prefix}nav-padding: 2px;
+    --#{$prefix}nav-height: 2.5rem;
+    --#{$prefix}nav-gap: 0.25rem;
+    --#{$prefix}nav-active-bg: var(--#{$prefix}bg-surface);
+    --#{$prefix}nav-font-size: inherit;
+    --#{$prefix}nav-radius: 6px;
 
-  --#{$prefix}nav-link-disabled-color: var(--#{$prefix}disabled-color);
-  --#{$prefix}nav-link-gap: 0.25rem;
-  --#{$prefix}nav-link-padding-x: 0.75rem;
-  --#{$prefix}nav-link-icon-size: 1.25rem;
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: var(--#{$prefix}nav-gap);
-  padding: var(--#{$prefix}nav-padding);
-  list-style: none;
-  background: var(--#{$prefix}nav-bg);
-  @include border-radius(calc(var(--#{$prefix}nav-radius) + var(--#{$prefix}nav-padding)));
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
-
-  .nav-link {
+    --#{$prefix}nav-link-disabled-color: var(--#{$prefix}disabled-color);
+    --#{$prefix}nav-link-gap: 0.25rem;
+    --#{$prefix}nav-link-padding-x: 0.75rem;
+    --#{$prefix}nav-link-icon-size: 1.25rem;
     display: inline-flex;
-    gap: calc(0.25rem + var(--#{$prefix}nav-link-gap));
-    align-items: center;
-    margin: 0;
-    font-size: var(--#{$prefix}nav-font-size);
-    min-width: calc(var(--#{$prefix}nav-height) - 2 * var(--#{$prefix}nav-padding));
-    height: calc(var(--#{$prefix}nav-height) - 2 * var(--#{$prefix}nav-padding));
-    padding: 0 calc(var(--#{$prefix}nav-link-padding-x) - 2px);
-    border: 1px solid transparent;
-    background: transparent;
-    color: var(--#{$prefix}secondary);
-    text-align: center;
-    text-decoration: none;
-    white-space: nowrap;
-    cursor: pointer;
-    transition:
-      background-color $transition-time,
-      color $transition-time;
-    @include border-radius(var(--#{$prefix}nav-radius));
-    flex-grow: 1;
-    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--#{$prefix}nav-gap);
+    padding: var(--#{$prefix}nav-padding);
+    list-style: none;
+    background: var(--#{$prefix}nav-bg);
+    @include border-radius(calc(var(--#{$prefix}nav-radius) + var(--#{$prefix}nav-padding)));
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
 
-    &:hover,
-    &.hover {
-      background: rgba(0, 0, 0, 0.04);
+    .nav-link {
+      display: inline-flex;
+      gap: calc(0.25rem + var(--#{$prefix}nav-link-gap));
+      align-items: center;
+      margin: 0;
+      font-size: var(--#{$prefix}nav-font-size);
+      min-width: calc(var(--#{$prefix}nav-height) - 2 * var(--#{$prefix}nav-padding));
+      height: calc(var(--#{$prefix}nav-height) - 2 * var(--#{$prefix}nav-padding));
+      padding: 0 calc(var(--#{$prefix}nav-link-padding-x) - 2px);
+      border: 1px solid transparent;
+      background: transparent;
+      color: var(--#{$prefix}secondary);
+      text-align: center;
+      text-decoration: none;
+      white-space: nowrap;
+      cursor: pointer;
+      transition:
+        background-color $transition-time,
+        color $transition-time;
+      @include border-radius(var(--#{$prefix}nav-radius));
+      flex-grow: 1;
+      justify-content: center;
+
+      &:hover,
+      &.hover {
+        background: rgba(0, 0, 0, 0.04);
+        color: var(--#{$prefix}body-color);
+      }
+
+      &.disabled,
+      &:disabled {
+        color: var(--#{$prefix}nav-link-disabled-color);
+        cursor: not-allowed;
+      }
+    }
+
+    .nav-link-input:checked + .nav-link,
+    .nav-link.active {
       color: var(--#{$prefix}body-color);
+      background: var(--#{$prefix}nav-active-bg);
+      border-color: var(--#{$prefix}border-color);
     }
 
-    &.disabled,
-    &:disabled {
-      color: var(--#{$prefix}nav-link-disabled-color);
-      cursor: not-allowed;
+    .nav-link-input {
+      display: none;
+    }
+
+    .nav-link-icon {
+      width: var(--#{$prefix}nav-link-icon-size);
+      height: var(--#{$prefix}nav-link-icon-size);
+      margin: 0 -0.25rem;
+      color: inherit;
     }
   }
 
-  .nav-link-input:checked + .nav-link,
-  .nav-link.active {
-    color: var(--#{$prefix}body-color);
-    background: var(--#{$prefix}nav-active-bg);
-    border-color: var(--#{$prefix}border-color);
+  .nav-segmented-vertical {
+    flex-direction: column;
+
+    .nav-link {
+      justify-content: start;
+    }
   }
 
-  .nav-link-input {
-    display: none;
+  .nav-sm {
+    --#{$prefix}nav-height: 2rem;
+    --#{$prefix}nav-font-size: var(--tblr-font-size-h5);
+    --#{$prefix}nav-radius: 4px;
+    --#{$prefix}nav-link-padding-x: 0.5rem;
+    --#{$prefix}nav-link-gap: 0.25rem;
+    --#{$prefix}nav-link-icon-size: 1rem;
   }
 
-  .nav-link-icon {
-    width: var(--#{$prefix}nav-link-icon-size);
-    height: var(--#{$prefix}nav-link-icon-size);
-    margin: 0 -0.25rem;
-    color: inherit;
+  .nav-lg {
+    --#{$prefix}nav-height: 3rem;
+    --#{$prefix}nav-font-size: var(--tblr-font-size-h3);
+    --#{$prefix}nav-radius: 8px;
+    --#{$prefix}nav-link-padding-x: 1rem;
+    --#{$prefix}nav-link-gap: 0.5rem;
+    --#{$prefix}nav-link-icon-size: 1.5rem;
   }
-}
-
-.nav-segmented-vertical {
-  flex-direction: column;
-
-  .nav-link {
-    justify-content: start;
-  }
-}
-
-.nav-sm {
-  --#{$prefix}nav-height: 2rem;
-  --#{$prefix}nav-font-size: var(--tblr-font-size-h5);
-  --#{$prefix}nav-radius: 4px;
-  --#{$prefix}nav-link-padding-x: 0.5rem;
-  --#{$prefix}nav-link-gap: 0.25rem;
-  --#{$prefix}nav-link-icon-size: 1rem;
-}
-
-.nav-lg {
-  --#{$prefix}nav-height: 3rem;
-  --#{$prefix}nav-font-size: var(--tblr-font-size-h3);
-  --#{$prefix}nav-radius: 8px;
-  --#{$prefix}nav-link-padding-x: 1rem;
-  --#{$prefix}nav-link-gap: 0.5rem;
-  --#{$prefix}nav-link-icon-size: 1.5rem;
 }

--- a/core/scss/ui/_signature.scss
+++ b/core/scss/ui/_signature.scss
@@ -1,15 +1,17 @@
-.signature {
-  --#{$prefix}signature-padding: var(--#{$prefix}spacer-1);
-  --#{$prefix}signature-border-radius: var(--#{$prefix}border-radius);
-  border: var(--#{$prefix}border-width) solid var(--#{$prefix}border-color);
-  padding: var(--#{$prefix}signature-padding);
-  @include border-radius(var(--#{$prefix}border-radius));
-}
+@layer components {
+  .signature {
+    --#{$prefix}signature-padding: var(--#{$prefix}spacer-1);
+    --#{$prefix}signature-border-radius: var(--#{$prefix}border-radius);
+    border: var(--#{$prefix}border-width) solid var(--#{$prefix}border-color);
+    padding: var(--#{$prefix}signature-padding);
+    @include border-radius(var(--#{$prefix}border-radius));
+  }
 
-.signature-canvas {
-  border: var(--#{$prefix}border-width) dashed var(--#{$prefix}border-color);
-  @include border-radius(calc(var(--#{$prefix}signature-border-radius) - var(--#{$prefix}signature-padding)));
-  display: block;
-  cursor: crosshair;
-  width: 100%;
+  .signature-canvas {
+    border: var(--#{$prefix}border-width) dashed var(--#{$prefix}border-color);
+    @include border-radius(calc(var(--#{$prefix}signature-border-radius) - var(--#{$prefix}signature-padding)));
+    display: block;
+    cursor: crosshair;
+    width: 100%;
+  }
 }

--- a/core/scss/ui/_social.scss
+++ b/core/scss/ui/_social.scss
@@ -1,27 +1,29 @@
 @use 'sass:map';
 @use '../config';
 
-.social {
-  position: relative;
-  display: inline-block;
-  height: config.$avatar-size;
-  aspect-ratio: 1;
-  background: no-repeat center/cover;
-  vertical-align: bottom;
-}
+@layer components {
+  .social {
+    position: relative;
+    display: inline-block;
+    height: config.$avatar-size;
+    aspect-ratio: 1;
+    background: no-repeat center/cover;
+    vertical-align: bottom;
+  }
 
-@each $app in config.$social-apps {
-  .social-app-#{$app} {
-    background-image: url('#{config.$assets-base}/img/social/#{$app}.svg');
+  @each $app in config.$social-apps {
+    .social-app-#{$app} {
+      background-image: url('#{config.$assets-base}/img/social/#{$app}.svg');
 
-    &.social-gray {
-      background-image: url('#{config.$assets-base}/img/social/#{$app}-gray.svg');
+      &.social-gray {
+        background-image: url('#{config.$assets-base}/img/social/#{$app}-gray.svg');
+      }
     }
   }
-}
 
-@each $flag-size, $size in config.$flag-sizes {
-  .social-#{$flag-size} {
-    height: map.get($size, size);
+  @each $flag-size, $size in config.$flag-sizes {
+    .social-#{$flag-size} {
+      height: map.get($size, size);
+    }
   }
 }

--- a/core/scss/ui/_stars.scss
+++ b/core/scss/ui/_stars.scss
@@ -1,9 +1,11 @@
-.stars {
-  display: inline-flex;
-  color: $gray-400;
-  font-size: $h5-font-size;
+@layer components {
+  .stars {
+    display: inline-flex;
+    color: $gray-400;
+    font-size: $h5-font-size;
 
-  .star:not(:first-child) {
-    margin-inline-start: 0.25rem;
+    .star:not(:first-child) {
+      margin-inline-start: 0.25rem;
+    }
   }
 }

--- a/core/scss/ui/_status.scss
+++ b/core/scss/ui/_status.scss
@@ -1,165 +1,167 @@
 @use 'sass:map';
 
-@keyframes status-pulsate-main {
-  40% {
-    transform: scale(1.25, 1.25);
+@layer components {
+  @keyframes status-pulsate-main {
+    40% {
+      transform: scale(1.25, 1.25);
+    }
+    60% {
+      transform: scale(1.25, 1.25);
+    }
   }
-  60% {
-    transform: scale(1.25, 1.25);
-  }
-}
 
-@keyframes status-pulsate-secondary {
-  10% {
-    transform: scale(1, 1);
+  @keyframes status-pulsate-secondary {
+    10% {
+      transform: scale(1, 1);
+    }
+    30% {
+      transform: scale(3, 3);
+    }
+    80% {
+      transform: scale(3, 3);
+    }
+    100% {
+      transform: scale(1, 1);
+    }
   }
-  30% {
-    transform: scale(3, 3);
-  }
-  80% {
-    transform: scale(3, 3);
-  }
-  100% {
-    transform: scale(1, 1);
-  }
-}
 
-@keyframes status-pulsate-tertiary {
-  25% {
-    transform: scale(1, 1);
+  @keyframes status-pulsate-tertiary {
+    25% {
+      transform: scale(1, 1);
+    }
+    80% {
+      transform: scale(3, 3);
+      opacity: 0;
+    }
+    100% {
+      transform: scale(3, 3);
+      opacity: 0;
+    }
   }
-  80% {
-    transform: scale(3, 3);
-    opacity: 0;
+
+  //
+  // Status
+  //
+  .status {
+    --#{$prefix}status-height: #{$status-height};
+    --#{$prefix}status-color: #{$text-secondary};
+    --#{$prefix}status-color-rgb: #{to-rgb($text-secondary)};
+
+    display: inline-flex;
+    align-items: center;
+    height: var(--#{$prefix}status-height);
+    padding: 0.25rem 0.75rem;
+    gap: 0.5rem;
+    color: var(--#{$prefix}status-color);
+    background: color-transparent(var(--#{$prefix}status-color), 0.1);
+    font-size: $font-size-base;
+    text-transform: none;
+    letter-spacing: normal;
+    @include border-radius(var(--#{$prefix}border-radius-pill));
+    font-weight: var(--#{$prefix}font-weight-medium);
+    line-height: 1;
+    margin: 0;
+
+    .status-dot {
+      background: var(--#{$prefix}status-color);
+    }
+
+    .icon {
+      font-size: 1.25rem;
+    }
   }
-  100% {
-    transform: scale(3, 3);
-    opacity: 0;
+
+  .status-lite {
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color) !important;
+    background: transparent !important;
+    color: var(--#{$prefix}body-color) !important;
   }
-}
 
-//
-// Status
-//
-.status {
-  --#{$prefix}status-height: #{$status-height};
-  --#{$prefix}status-color: #{$text-secondary};
-  --#{$prefix}status-color-rgb: #{to-rgb($text-secondary)};
+  @each $name, $color in map.merge($theme-colors, $social-colors) {
+    .status-#{$name} {
+      --#{$prefix}status-color: var(--#{$prefix}#{$name});
+      --#{$prefix}status-color-rgb: var(--#{$prefix}#{$name}-rgb);
+    }
+  }
 
-  display: inline-flex;
-  align-items: center;
-  height: var(--#{$prefix}status-height);
-  padding: 0.25rem 0.75rem;
-  gap: 0.5rem;
-  color: var(--#{$prefix}status-color);
-  background: color-transparent(var(--#{$prefix}status-color), 0.1);
-  font-size: $font-size-base;
-  text-transform: none;
-  letter-spacing: normal;
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-  font-weight: var(--#{$prefix}font-weight-medium);
-  line-height: 1;
-  margin: 0;
-
+  //
+  // Status dot
+  //
   .status-dot {
-    background: var(--#{$prefix}status-color);
+    --#{$prefix}status-dot-color: var(--#{$prefix}status-color, #{$text-secondary});
+    --#{$prefix}status-size: #{$status-dot-size};
+    position: relative;
+    display: inline-block;
+    width: var(--#{$prefix}status-size);
+    height: var(--#{$prefix}status-size);
+    background: var(--#{$prefix}status-dot-color);
+    @include border-radius(var(--#{$prefix}border-radius-pill));
   }
 
-  .icon {
-    font-size: 1.25rem;
-  }
-}
-
-.status-lite {
-  border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color) !important;
-  background: transparent !important;
-  color: var(--#{$prefix}body-color) !important;
-}
-
-@each $name, $color in map.merge($theme-colors, $social-colors) {
-  .status-#{$name} {
-    --#{$prefix}status-color: var(--#{$prefix}#{$name});
-    --#{$prefix}status-color-rgb: var(--#{$prefix}#{$name}-rgb);
-  }
-}
-
-//
-// Status dot
-//
-.status-dot {
-  --#{$prefix}status-dot-color: var(--#{$prefix}status-color, #{$text-secondary});
-  --#{$prefix}status-size: #{$status-dot-size};
-  position: relative;
-  display: inline-block;
-  width: var(--#{$prefix}status-size);
-  height: var(--#{$prefix}status-size);
-  background: var(--#{$prefix}status-dot-color);
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-}
-
-.status-dot-animated {
-  &:before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    z-index: 0;
-    background: inherit;
-    border-radius: inherit;
-    opacity: 0.6;
-    animation: 1s linear 2s backwards infinite status-pulsate-tertiary;
-  }
-}
-
-//
-// Status indicator
-//
-.status-indicator {
-  --#{$prefix}status-indicator-size: 2.5rem;
-  --#{$prefix}status-indicator-color: var(--#{$prefix}status-color, #{$text-secondary});
-  display: block;
-  position: relative;
-  width: var(--#{$prefix}status-indicator-size);
-  height: var(--#{$prefix}status-indicator-size);
-}
-
-.status-indicator-circle {
-  --#{$prefix}status-circle-size: 0.75rem;
-  position: absolute;
-  inset-inline-start: 50%;
-  top: 50%;
-  margin: calc(var(--#{$prefix}status-circle-size) / -2) 0 0 calc(var(--#{$prefix}status-circle-size) / -2);
-  width: var(--#{$prefix}status-circle-size);
-  height: var(--#{$prefix}status-circle-size);
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-  background: var(--#{$prefix}status-color);
-
-  &:nth-child(1) {
-    z-index: 3;
+  .status-dot-animated {
+    &:before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      z-index: 0;
+      background: inherit;
+      border-radius: inherit;
+      opacity: 0.6;
+      animation: 1s linear 2s backwards infinite status-pulsate-tertiary;
+    }
   }
 
-  &:nth-child(2) {
-    z-index: 2;
-    opacity: 0.1;
+  //
+  // Status indicator
+  //
+  .status-indicator {
+    --#{$prefix}status-indicator-size: 2.5rem;
+    --#{$prefix}status-indicator-color: var(--#{$prefix}status-color, #{$text-secondary});
+    display: block;
+    position: relative;
+    width: var(--#{$prefix}status-indicator-size);
+    height: var(--#{$prefix}status-indicator-size);
   }
 
-  &:nth-child(3) {
-    z-index: 1;
-    opacity: 0.3;
-  }
-}
-
-.status-indicator-animated {
   .status-indicator-circle {
+    --#{$prefix}status-circle-size: 0.75rem;
+    position: absolute;
+    inset-inline-start: 50%;
+    top: 50%;
+    margin: calc(var(--#{$prefix}status-circle-size) / -2) 0 0 calc(var(--#{$prefix}status-circle-size) / -2);
+    width: var(--#{$prefix}status-circle-size);
+    height: var(--#{$prefix}status-circle-size);
+    @include border-radius(var(--#{$prefix}border-radius-pill));
+    background: var(--#{$prefix}status-color);
+
     &:nth-child(1) {
-      animation: 2s linear 1s infinite backwards status-pulsate-main;
+      z-index: 3;
     }
 
     &:nth-child(2) {
-      animation: 2s linear 1s infinite backwards status-pulsate-secondary;
+      z-index: 2;
+      opacity: 0.1;
     }
 
     &:nth-child(3) {
-      animation: 2s linear 1s infinite backwards status-pulsate-tertiary;
+      z-index: 1;
+      opacity: 0.3;
+    }
+  }
+
+  .status-indicator-animated {
+    .status-indicator-circle {
+      &:nth-child(1) {
+        animation: 2s linear 1s infinite backwards status-pulsate-main;
+      }
+
+      &:nth-child(2) {
+        animation: 2s linear 1s infinite backwards status-pulsate-secondary;
+      }
+
+      &:nth-child(3) {
+        animation: 2s linear 1s infinite backwards status-pulsate-tertiary;
+      }
     }
   }
 }

--- a/core/scss/ui/_steps.scss
+++ b/core/scss/ui/_steps.scss
@@ -1,155 +1,158 @@
 //
 // Steps
 //
-.steps {
-  --#{$prefix}steps-color: #{$steps-color};
-  --#{$prefix}steps-inactive-color: #{$steps-inactive-color};
-  --#{$prefix}steps-dot-size: 0.5rem;
-  --#{$prefix}steps-border-width: #{$steps-border-width};
-  display: flex;
-  flex-wrap: nowrap;
-  width: 100%;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-}
 
-@each $name, $color in $extra-colors {
-  .steps-#{$name} {
-    --#{$prefix}steps-color: var(--#{$prefix}#{$name});
-
-    &-lt {
-      --#{$prefix}steps-color: var(--#{$prefix}#{$name}-lt);
-    }
-  }
-}
-
-//
-// Step item
-//
-.step-item {
-  position: relative;
-  flex: 1 1 0;
-  min-height: 1rem;
-  margin-top: 0;
-  color: inherit;
-  text-align: center;
-  cursor: default;
-  padding-top: calc(var(--#{$prefix}steps-dot-size));
-
-  @at-root a#{&} {
-    cursor: pointer;
-
-    &:hover {
-      color: inherit;
-    }
-  }
-
-  &:after,
-  &:before {
-    background: var(--#{$prefix}steps-color);
-  }
-
-  &:not(:last-child):after {
-    position: absolute;
-    inset-inline-start: 50%;
-    width: 100%;
-    content: '';
-    transform: translateY(-50%);
-  }
-
-  &:after {
-    top: calc(var(--#{$prefix}steps-dot-size) * 0.5);
-    height: var(--#{$prefix}steps-border-width);
-  }
-
-  &:before {
-    content: '';
-    position: absolute;
-    top: 0;
-    inset-inline-start: 50%;
-    z-index: 1;
-    box-sizing: content-box;
+@layer components {
+  .steps {
+    --#{$prefix}steps-color: #{$steps-color};
+    --#{$prefix}steps-inactive-color: #{$steps-inactive-color};
+    --#{$prefix}steps-dot-size: 0.5rem;
+    --#{$prefix}steps-border-width: #{$steps-border-width};
     display: flex;
-    align-items: center;
-    justify-content: center;
-    @include border-radius(var(--#{$prefix}border-radius-pill));
-    transform: translateX(-50%);
-    color: var(--#{$prefix}white);
-    width: var(--#{$prefix}steps-dot-size);
-    height: var(--#{$prefix}steps-dot-size);
+    flex-wrap: nowrap;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    list-style: none;
   }
 
-  &.active {
-    font-weight: var(--#{$prefix}font-weight-semibold);
+  @each $name, $color in $extra-colors {
+    .steps-#{$name} {
+      --#{$prefix}steps-color: var(--#{$prefix}#{$name});
 
-    &:after {
-      background: var(--#{$prefix}steps-inactive-color);
-    }
-
-    & ~ .step-item {
-      color: var(--#{$prefix}disabled-color);
-
-      &:after,
-      &:before {
-        background: var(--#{$prefix}steps-inactive-color);
+      &-lt {
+        --#{$prefix}steps-color: var(--#{$prefix}#{$name}-lt);
       }
     }
   }
-}
 
-//
-// Steps counter
-//
-.steps-counter {
-  --#{$prefix}steps-dot-size: 1.5rem;
-  counter-reset: steps;
-
+  //
+  // Step item
+  //
   .step-item {
-    counter-increment: steps;
+    position: relative;
+    flex: 1 1 0;
+    min-height: 1rem;
+    margin-top: 0;
+    color: inherit;
+    text-align: center;
+    cursor: default;
+    padding-top: calc(var(--#{$prefix}steps-dot-size));
+
+    @at-root a#{&} {
+      cursor: pointer;
+
+      &:hover {
+        color: inherit;
+      }
+    }
+
+    &:after,
+    &:before {
+      background: var(--#{$prefix}steps-color);
+    }
+
+    &:not(:last-child):after {
+      position: absolute;
+      inset-inline-start: 50%;
+      width: 100%;
+      content: '';
+      transform: translateY(-50%);
+    }
+
+    &:after {
+      top: calc(var(--#{$prefix}steps-dot-size) * 0.5);
+      height: var(--#{$prefix}steps-border-width);
+    }
 
     &:before {
-      content: counter(steps);
-    }
-  }
-}
-
-//
-// Steps vertical
-//
-.steps-vertical {
-  --#{$prefix}steps-dot-offset: 6px;
-  flex-direction: column;
-
-  &.steps-counter {
-    --#{$prefix}steps-dot-offset: -2px;
-  }
-
-  .step-item {
-    text-align: start;
-    padding-top: 0;
-    padding-inline-start: calc(var(--#{$prefix}steps-dot-size) + 1rem);
-    min-height: auto;
-
-    &:not(:first-child) {
-      margin-top: 1rem;
+      content: '';
+      position: absolute;
+      top: 0;
+      inset-inline-start: 50%;
+      z-index: 1;
+      box-sizing: content-box;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      @include border-radius(var(--#{$prefix}border-radius-pill));
+      transform: translateX(-50%);
+      color: var(--#{$prefix}white);
+      width: var(--#{$prefix}steps-dot-size);
+      height: var(--#{$prefix}steps-dot-size);
     }
 
-    &:before {
-      top: var(--#{$prefix}steps-dot-offset);
-      inset-inline-start: 0;
-      transform: translate(0, 0);
-    }
+    &.active {
+      font-weight: var(--#{$prefix}font-weight-semibold);
 
-    &:not(:last-child) {
       &:after {
-        position: absolute;
-        content: '';
-        transform: translateX(-50%);
+        background: var(--#{$prefix}steps-inactive-color);
+      }
+
+      & ~ .step-item {
+        color: var(--#{$prefix}disabled-color);
+
+        &:after,
+        &:before {
+          background: var(--#{$prefix}steps-inactive-color);
+        }
+      }
+    }
+  }
+
+  //
+  // Steps counter
+  //
+  .steps-counter {
+    --#{$prefix}steps-dot-size: 1.5rem;
+    counter-reset: steps;
+
+    .step-item {
+      counter-increment: steps;
+
+      &:before {
+        content: counter(steps);
+      }
+    }
+  }
+
+  //
+  // Steps vertical
+  //
+  .steps-vertical {
+    --#{$prefix}steps-dot-offset: 6px;
+    flex-direction: column;
+
+    &.steps-counter {
+      --#{$prefix}steps-dot-offset: -2px;
+    }
+
+    .step-item {
+      text-align: start;
+      padding-top: 0;
+      padding-inline-start: calc(var(--#{$prefix}steps-dot-size) + 1rem);
+      min-height: auto;
+
+      &:not(:first-child) {
+        margin-top: 1rem;
+      }
+
+      &:before {
         top: var(--#{$prefix}steps-dot-offset);
-        inset-inline-start: calc(var(--#{$prefix}steps-dot-size) * 0.5);
-        width: var(--#{$prefix}steps-border-width);
-        height: calc(100% + 1rem);
+        inset-inline-start: 0;
+        transform: translate(0, 0);
+      }
+
+      &:not(:last-child) {
+        &:after {
+          position: absolute;
+          content: '';
+          transform: translateX(-50%);
+          top: var(--#{$prefix}steps-dot-offset);
+          inset-inline-start: calc(var(--#{$prefix}steps-dot-size) * 0.5);
+          width: var(--#{$prefix}steps-border-width);
+          height: calc(100% + 1rem);
+        }
       }
     }
   }

--- a/core/scss/ui/_switch-icon.scss
+++ b/core/scss/ui/_switch-icon.scss
@@ -1,215 +1,217 @@
-.switch-icon {
-  display: inline-block;
-  line-height: 1;
-  border: 0;
-  padding: 0;
-  background: transparent;
-  width: $icon-size;
-  height: $icon-size;
-  vertical-align: bottom;
-  position: relative;
-  cursor: pointer;
+@layer components {
+  .switch-icon {
+    display: inline-block;
+    line-height: 1;
+    border: 0;
+    padding: 0;
+    background: transparent;
+    width: $icon-size;
+    height: $icon-size;
+    vertical-align: bottom;
+    position: relative;
+    cursor: pointer;
 
-  &.disabled {
-    pointer-events: none;
-    opacity: $btn-disabled-opacity;
-  }
+    &.disabled {
+      pointer-events: none;
+      opacity: $btn-disabled-opacity;
+    }
 
-  &:focus {
-    outline: none;
-  }
+    &:focus {
+      outline: none;
+    }
 
-  svg {
-    display: block;
-    width: 100%;
-    height: 100%;
-  }
+    svg {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
 
-  .switch-icon-a,
-  .switch-icon-b {
-    display: block;
-    width: 100%;
-    height: 100%;
-  }
+    .switch-icon-a,
+    .switch-icon-b {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
 
-  .switch-icon-a {
-    opacity: 1;
-  }
-
-  .switch-icon-b {
-    position: absolute;
-    top: 0;
-    inset-inline-start: 0;
-    opacity: 0;
-  }
-
-  &.active {
     .switch-icon-a {
+      opacity: 1;
+    }
+
+    .switch-icon-b {
+      position: absolute;
+      top: 0;
+      inset-inline-start: 0;
       opacity: 0;
     }
 
-    .switch-icon-b {
-      opacity: 1;
+    &.active {
+      .switch-icon-a {
+        opacity: 0;
+      }
+
+      .switch-icon-b {
+        opacity: 1;
+      }
     }
   }
-}
 
-// Fade variant
-.switch-icon-fade {
-  .switch-icon-a,
-  .switch-icon-b {
-    @include transition(opacity 0.5s);
-  }
-}
-
-// Scale variant
-.switch-icon-scale {
-  .switch-icon-a,
-  .switch-icon-b {
-    @include transition(opacity 0.5s, transform 0s 0.5s);
-  }
-
-  .switch-icon-b {
-    transform: scale(1.5);
-  }
-
-  &.active {
+  // Fade variant
+  .switch-icon-fade {
     .switch-icon-a,
     .switch-icon-b {
-      @include transition(opacity 0s, transform 0.5s);
+      @include transition(opacity 0.5s);
+    }
+  }
+
+  // Scale variant
+  .switch-icon-scale {
+    .switch-icon-a,
+    .switch-icon-b {
+      @include transition(opacity 0.5s, transform 0s 0.5s);
     }
 
     .switch-icon-b {
-      transform: scale(1);
+      transform: scale(1.5);
+    }
+
+    &.active {
+      .switch-icon-a,
+      .switch-icon-b {
+        @include transition(opacity 0s, transform 0.5s);
+      }
+
+      .switch-icon-b {
+        transform: scale(1);
+      }
     }
   }
-}
 
-// Flip variant
-.switch-icon-flip {
-  perspective: 10em;
+  // Flip variant
+  .switch-icon-flip {
+    perspective: 10em;
 
-  .switch-icon-a,
-  .switch-icon-b {
-    backface-visibility: hidden;
-    transform-style: preserve-3d;
-    @include transition(opacity 0s 0.2s, transform 0.4s ease-in-out);
-  }
+    .switch-icon-a,
+    .switch-icon-b {
+      backface-visibility: hidden;
+      transform-style: preserve-3d;
+      @include transition(opacity 0s 0.2s, transform 0.4s ease-in-out);
+    }
 
-  .switch-icon-a {
-    opacity: 1;
-    transform: rotateY(0deg);
-  }
-
-  .switch-icon-b {
-    opacity: 1;
-    transform: rotateY(-180deg);
-  }
-
-  &.active {
     .switch-icon-a {
-      opacity: 1;
-      transform: rotateY(180deg);
-    }
-
-    .switch-icon-b {
       opacity: 1;
       transform: rotateY(0deg);
     }
-  }
-}
-
-// Slide variant
-.switch-icon-slide-up,
-.switch-icon-slide-left,
-.switch-icon-slide-start,
-.switch-icon-slide-right,
-.switch-icon-slide-end,
-.switch-icon-slide-down {
-  overflow: hidden;
-
-  .switch-icon-a,
-  .switch-icon-b {
-    @include transition(opacity $transition-time, transform $transition-time);
-  }
-
-  .switch-icon-a {
-    transform: translateY(0);
-  }
-
-  .switch-icon-b {
-    transform: translateY(100%);
-  }
-
-  &.active {
-    .switch-icon-a {
-      transform: translateY(-100%);
-    }
 
     .switch-icon-b {
+      opacity: 1;
+      transform: rotateY(-180deg);
+    }
+
+    &.active {
+      .switch-icon-a {
+        opacity: 1;
+        transform: rotateY(180deg);
+      }
+
+      .switch-icon-b {
+        opacity: 1;
+        transform: rotateY(0deg);
+      }
+    }
+  }
+
+  // Slide variant
+  .switch-icon-slide-up,
+  .switch-icon-slide-left,
+  .switch-icon-slide-start,
+  .switch-icon-slide-right,
+  .switch-icon-slide-end,
+  .switch-icon-slide-down {
+    overflow: hidden;
+
+    .switch-icon-a,
+    .switch-icon-b {
+      @include transition(opacity $transition-time, transform $transition-time);
+    }
+
+    .switch-icon-a {
       transform: translateY(0);
     }
-  }
-}
-
-.switch-icon-slide-left,
-.switch-icon-slide-start {
-  .switch-icon-a {
-    transform: translateX(0);
-  }
-
-  .switch-icon-b {
-    transform: translateX(100%);
-  }
-
-  &.active {
-    .switch-icon-a {
-      transform: translateX(-100%);
-    }
 
     .switch-icon-b {
-      transform: translateX(0);
-    }
-  }
-}
-
-.switch-icon-slide-right,
-.switch-icon-slide-end {
-  .switch-icon-a {
-    transform: translateX(0);
-  }
-
-  .switch-icon-b {
-    transform: translateX(-100%);
-  }
-
-  &.active {
-    .switch-icon-a {
-      transform: translateX(100%);
-    }
-
-    .switch-icon-b {
-      transform: translateX(0);
-    }
-  }
-}
-
-.switch-icon-slide-down {
-  .switch-icon-a {
-    transform: translateY(0);
-  }
-
-  .switch-icon-b {
-    transform: translateY(-100%);
-  }
-
-  &.active {
-    .switch-icon-a {
       transform: translateY(100%);
     }
 
+    &.active {
+      .switch-icon-a {
+        transform: translateY(-100%);
+      }
+
+      .switch-icon-b {
+        transform: translateY(0);
+      }
+    }
+  }
+
+  .switch-icon-slide-left,
+  .switch-icon-slide-start {
+    .switch-icon-a {
+      transform: translateX(0);
+    }
+
     .switch-icon-b {
+      transform: translateX(100%);
+    }
+
+    &.active {
+      .switch-icon-a {
+        transform: translateX(-100%);
+      }
+
+      .switch-icon-b {
+        transform: translateX(0);
+      }
+    }
+  }
+
+  .switch-icon-slide-right,
+  .switch-icon-slide-end {
+    .switch-icon-a {
+      transform: translateX(0);
+    }
+
+    .switch-icon-b {
+      transform: translateX(-100%);
+    }
+
+    &.active {
+      .switch-icon-a {
+        transform: translateX(100%);
+      }
+
+      .switch-icon-b {
+        transform: translateX(0);
+      }
+    }
+  }
+
+  .switch-icon-slide-down {
+    .switch-icon-a {
       transform: translateY(0);
+    }
+
+    .switch-icon-b {
+      transform: translateY(-100%);
+    }
+
+    &.active {
+      .switch-icon-a {
+        transform: translateY(100%);
+      }
+
+      .switch-icon-b {
+        transform: translateY(0);
+      }
     }
   }
 }

--- a/core/scss/ui/_tables.scss
+++ b/core/scss/ui/_tables.scss
@@ -1,172 +1,174 @@
-.table {
-  font: inherit;
+@layer components {
+  .table {
+    font: inherit;
 
-  thead {
-    th {
-      background: $table-th-bg;
-      @include subheader;
-      padding-top: $table-th-padding-y;
-      padding-bottom: $table-th-padding-y;
-      white-space: nowrap;
+    thead {
+      th {
+        background: $table-th-bg;
+        @include subheader;
+        padding-top: $table-th-padding-y;
+        padding-bottom: $table-th-padding-y;
+        white-space: nowrap;
 
-      @include media-print {
+        @include media-print {
+          background: transparent;
+        }
+      }
+    }
+  }
+
+  .table-responsive {
+    .table {
+      margin-bottom: 0;
+    }
+  }
+
+  .table-transparent {
+    thead {
+      th {
         background: transparent;
       }
     }
   }
-}
 
-.table-responsive {
-  .table {
-    margin-bottom: 0;
+  .table-nowrap {
+    > :not(caption) > * > * {
+      white-space: nowrap;
+    }
   }
-}
 
-.table-transparent {
-  thead {
-    th {
+  .table-vcenter {
+    > :not(caption) > * > * {
+      vertical-align: middle;
+    }
+  }
+
+  .table-center {
+    > :not(caption) > * > * {
+      text-align: center;
+    }
+  }
+
+  .td-truncate {
+    max-width: 1px;
+    width: 100%;
+  }
+
+  .table-mobile {
+    @each $breakpoint, $breakpoint-max-widthin in $grid-breakpoints {
+      &#{breakpoint-infix($breakpoint)} {
+        @include media-breakpoint-down($breakpoint) {
+          display: block;
+
+          thead {
+            display: none;
+          }
+
+          tbody,
+          tr {
+            display: flex;
+            flex-direction: column;
+          }
+
+          td {
+            display: block;
+            padding: $table-cell-padding-x $table-cell-padding-y !important;
+            border: none;
+            color: var(--#{$prefix}body-color) !important;
+
+            &[data-label] {
+              &:before {
+                @include subheader;
+                content: attr(data-label);
+                display: block;
+              }
+            }
+          }
+
+          tr {
+            border-bottom: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $table-border-color;
+          }
+
+          .btn {
+            display: block;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+  Table sort
+   */
+  .table-sort {
+    font: inherit;
+    color: inherit;
+    text-transform: inherit;
+    letter-spacing: inherit;
+    border: 0;
+    background: inherit;
+    display: block;
+    width: 100%;
+    text-align: inherit;
+    margin: calc(-1 * $table-th-padding-y) calc(-1 * $table-th-padding-x);
+    padding: $table-th-padding-y $table-th-padding-x;
+    @include transition(color $transition-time);
+
+    &:hover,
+    &.asc,
+    &.desc {
+      color: var(--#{$prefix}body-color);
+    }
+
+    &:after {
+      content: '';
+      display: inline-flex;
+      width: 1rem;
+      height: 1rem;
+      vertical-align: bottom;
+      mask-image: $table-sort-bg-image;
+      background: currentColor;
+      margin-inline-start: 0.25rem;
+    }
+
+    &.asc:after {
+      mask-image: $table-sort-desc-bg-image;
+    }
+
+    &.desc:after {
+      mask-image: $table-sort-asc-bg-image;
+    }
+  }
+
+  .table-borderless {
+    thead th {
       background: transparent;
     }
   }
-}
 
-.table-nowrap {
-  > :not(caption) > * > * {
-    white-space: nowrap;
-  }
-}
-
-.table-vcenter {
-  > :not(caption) > * > * {
-    vertical-align: middle;
-  }
-}
-
-.table-center {
-  > :not(caption) > * > * {
-    text-align: center;
-  }
-}
-
-.td-truncate {
-  max-width: 1px;
-  width: 100%;
-}
-
-.table-mobile {
-  @each $breakpoint, $breakpoint-max-widthin in $grid-breakpoints {
-    &#{breakpoint-infix($breakpoint)} {
-      @include media-breakpoint-down($breakpoint) {
-        display: block;
-
-        thead {
-          display: none;
-        }
-
-        tbody,
-        tr {
-          display: flex;
-          flex-direction: column;
-        }
-
-        td {
-          display: block;
-          padding: $table-cell-padding-x $table-cell-padding-y !important;
-          border: none;
-          color: var(--#{$prefix}body-color) !important;
-
-          &[data-label] {
-            &:before {
-              @include subheader;
-              content: attr(data-label);
-              display: block;
-            }
-          }
-        }
-
-        tr {
-          border-bottom: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $table-border-color;
-        }
-
-        .btn {
-          display: block;
-        }
-      }
-    }
-  }
-}
-
-/**
-Table sort
- */
-.table-sort {
-  font: inherit;
-  color: inherit;
-  text-transform: inherit;
-  letter-spacing: inherit;
-  border: 0;
-  background: inherit;
-  display: block;
-  width: 100%;
-  text-align: inherit;
-  margin: calc(-1 * $table-th-padding-y) calc(-1 * $table-th-padding-x);
-  padding: $table-th-padding-y $table-th-padding-x;
-  @include transition(color $transition-time);
-
-  &:hover,
-  &.asc,
-  &.desc {
-    color: var(--#{$prefix}body-color);
-  }
-
-  &:after {
-    content: '';
-    display: inline-flex;
-    width: 1rem;
-    height: 1rem;
-    vertical-align: bottom;
-    mask-image: $table-sort-bg-image;
-    background: currentColor;
-    margin-inline-start: 0.25rem;
-  }
-
-  &.asc:after {
-    mask-image: $table-sort-desc-bg-image;
-  }
-
-  &.desc:after {
-    mask-image: $table-sort-asc-bg-image;
-  }
-}
-
-.table-borderless {
-  thead th {
-    background: transparent;
-  }
-}
-
-//
-// Table selectable
-//
-.table-selectable {
-  tbody tr {
-    .on-checked {
-      display: none;
-    }
-
-    .on-unchecked {
-      display: initial;
-    }
-
-    &:has(.table-selectable-check:checked) {
-      background-color: $table-active-bg;
-
+  //
+  // Table selectable
+  //
+  .table-selectable {
+    tbody tr {
       .on-checked {
-        display: initial;
+        display: none;
       }
 
       .on-unchecked {
-        display: none;
+        display: initial;
+      }
+
+      &:has(.table-selectable-check:checked) {
+        background-color: $table-active-bg;
+
+        .on-checked {
+          display: initial;
+        }
+
+        .on-unchecked {
+          display: none;
+        }
       }
     }
   }

--- a/core/scss/ui/_tags.scss
+++ b/core/scss/ui/_tags.scss
@@ -1,56 +1,58 @@
-.tag {
-  --#{$prefix}tag-height: 1.5rem;
-  border: $border-width solid var(--#{$prefix}border-color);
-  display: inline-flex;
-  align-items: center;
-  height: var(--#{$prefix}tag-height);
-  @include border-radius(var(--#{$prefix}border-radius));
-  padding: 0 0.5rem;
-  background: var(--#{$prefix}bg-surface);
-  box-shadow: var(--#{$prefix}shadow-input);
-  gap: 0.5rem;
+@layer components {
+  .tag {
+    --#{$prefix}tag-height: 1.5rem;
+    border: $border-width solid var(--#{$prefix}border-color);
+    display: inline-flex;
+    align-items: center;
+    height: var(--#{$prefix}tag-height);
+    @include border-radius(var(--#{$prefix}border-radius));
+    padding: 0 0.5rem;
+    background: var(--#{$prefix}bg-surface);
+    box-shadow: var(--#{$prefix}shadow-input);
+    gap: 0.5rem;
 
-  .btn-close {
+    .btn-close {
+      margin-inline-end: -0.25rem;
+      margin-inline-start: -0.125rem;
+      padding: 0;
+      width: 1rem;
+      height: 1rem;
+      font-size: 0.5rem;
+    }
+  }
+
+  .tag-badge {
+    --#{$prefix}badge-font-size: #{$h6-font-size};
+    --#{$prefix}badge-padding-x: 0.25rem;
+    --#{$prefix}badge-padding-y: 0.125rem;
     margin-inline-end: -0.25rem;
-    margin-inline-start: -0.125rem;
-    padding: 0;
+  }
+
+  .tag-avatar,
+  .tag-flag,
+  .tag-payment,
+  .tag-icon,
+  .tag-check {
+    margin-inline-start: -0.25rem;
+  }
+
+  .tag-icon {
+    color: var(--#{$prefix}secondary);
+    margin-inline-end: -0.125rem;
     width: 1rem;
     height: 1rem;
-    font-size: 0.5rem;
   }
-}
 
-.tag-badge {
-  --#{$prefix}badge-font-size: #{$h6-font-size};
-  --#{$prefix}badge-padding-x: 0.25rem;
-  --#{$prefix}badge-padding-y: 0.125rem;
-  margin-inline-end: -0.25rem;
-}
+  .tag-check {
+    width: 1rem;
+    height: 1rem;
+    background-size: 1rem;
+  }
 
-.tag-avatar,
-.tag-flag,
-.tag-payment,
-.tag-icon,
-.tag-check {
-  margin-inline-start: -0.25rem;
-}
-
-.tag-icon {
-  color: var(--#{$prefix}secondary);
-  margin-inline-end: -0.125rem;
-  width: 1rem;
-  height: 1rem;
-}
-
-.tag-check {
-  width: 1rem;
-  height: 1rem;
-  background-size: 1rem;
-}
-
-//
-// Tags list
-//
-.tags-list {
-  @include elements-list;
+  //
+  // Tags list
+  //
+  .tags-list {
+    @include elements-list;
+  }
 }

--- a/core/scss/ui/_timeline.scss
+++ b/core/scss/ui/_timeline.scss
@@ -1,61 +1,64 @@
 //
 // Timeline
 //
-.timeline {
-  --#{$prefix}timeline-icon-size: #{$avatar-size};
-  position: relative;
-  list-style: none;
-  padding: 0;
-}
 
-//
-// Timeline event
-//
-.timeline-event {
-  position: relative;
+@layer components {
+  .timeline {
+    --#{$prefix}timeline-icon-size: #{$avatar-size};
+    position: relative;
+    list-style: none;
+    padding: 0;
+  }
 
-  &:not(:last-child) {
-    margin-bottom: var(--#{$prefix}page-padding);
+  //
+  // Timeline event
+  //
+  .timeline-event {
+    position: relative;
 
-    &:before {
-      content: '';
-      position: absolute;
-      top: var(--#{$prefix}timeline-icon-size);
-      inset-inline-start: calc(var(--#{$prefix}timeline-icon-size) / 2);
-      bottom: calc(-1 * var(--#{$prefix}page-padding));
-      width: var(--#{$prefix}border-width);
-      background-color: var(--#{$prefix}border-color);
-      @include border-radius(var(--#{$prefix}border-radius));
+    &:not(:last-child) {
+      margin-bottom: var(--#{$prefix}page-padding);
+
+      &:before {
+        content: '';
+        position: absolute;
+        top: var(--#{$prefix}timeline-icon-size);
+        inset-inline-start: calc(var(--#{$prefix}timeline-icon-size) / 2);
+        bottom: calc(-1 * var(--#{$prefix}page-padding));
+        width: var(--#{$prefix}border-width);
+        background-color: var(--#{$prefix}border-color);
+        @include border-radius(var(--#{$prefix}border-radius));
+      }
     }
   }
-}
 
-.timeline-event-icon {
-  position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--#{$prefix}timeline-icon-size, $avatar-size);
-  height: var(--#{$prefix}timeline-icon-size, $avatar-size);
-  background: var(--#{$prefix}bg-surface-secondary);
-  color: var(--#{$prefix}secondary);
-  @include border-radius(var(--#{$prefix}border-radius));
-  z-index: 5;
-}
-
-.timeline-event-card {
-  margin-inline-start: calc(var(--#{$prefix}timeline-icon-size, $avatar-size) + var(--#{$prefix}page-padding));
-}
-
-//
-// Simple timeline
-//
-.timeline-simple {
   .timeline-event-icon {
-    display: none;
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--#{$prefix}timeline-icon-size, $avatar-size);
+    height: var(--#{$prefix}timeline-icon-size, $avatar-size);
+    background: var(--#{$prefix}bg-surface-secondary);
+    color: var(--#{$prefix}secondary);
+    @include border-radius(var(--#{$prefix}border-radius));
+    z-index: 5;
   }
 
   .timeline-event-card {
-    margin-inline-start: 0;
+    margin-inline-start: calc(var(--#{$prefix}timeline-icon-size, $avatar-size) + var(--#{$prefix}page-padding));
+  }
+
+  //
+  // Simple timeline
+  //
+  .timeline-simple {
+    .timeline-event-icon {
+      display: none;
+    }
+
+    .timeline-event-card {
+      margin-inline-start: 0;
+    }
   }
 }

--- a/core/scss/ui/_toasts.scss
+++ b/core/scss/ui/_toasts.scss
@@ -1,23 +1,25 @@
-.toast {
-  border: $alert-border-width var(--#{$prefix}border-style) $alert-border-color;
-  box-shadow: $alert-shadow;
+@layer components {
+  .toast {
+    border: $alert-border-width var(--#{$prefix}border-style) $alert-border-color;
+    box-shadow: $alert-shadow;
 
-  .toast-header {
-    user-select: none;
+    .toast-header {
+      user-select: none;
+    }
+
+    button[data-bs-dismiss='toast'],
+    button[data-dismiss='toast'] {
+      outline: none;
+    }
+
+    @include media-print {
+      display: none;
+    }
   }
 
-  button[data-bs-dismiss='toast'],
-  button[data-dismiss='toast'] {
-    outline: none;
-  }
-
-  @include media-print {
-    display: none;
-  }
-}
-
-@each $state, $value in $theme-colors {
-  .toast-#{$state} {
-    --#{$prefix}toast-color: #{$value};
+  @each $state, $value in $theme-colors {
+    .toast-#{$state} {
+      --#{$prefix}toast-color: #{$value};
+    }
   }
 }

--- a/core/scss/ui/_toolbar.scss
+++ b/core/scss/ui/_toolbar.scss
@@ -1,14 +1,16 @@
-.toolbar {
-  display: flex;
-  flex-wrap: nowrap;
-  flex-shrink: 0;
-  margin: 0 -0.5rem;
+@layer components {
+  .toolbar {
+    display: flex;
+    flex-wrap: nowrap;
+    flex-shrink: 0;
+    margin: 0 -0.5rem;
 
-  > * {
-    margin: 0 0.5rem;
-  }
+    > * {
+      margin: 0 0.5rem;
+    }
 
-  @include media-print {
-    display: none;
+    @include media-print {
+      display: none;
+    }
   }
 }

--- a/core/scss/ui/_tracking.scss
+++ b/core/scss/ui/_tracking.scss
@@ -1,29 +1,31 @@
-.tracking {
-  --#{$prefix}tracking-height: #{$tracking-height};
-  --#{$prefix}tracking-gap-width: #{$tracking-gap-width};
-  --#{$prefix}tracking-block-border-radius: #{$tracking-border-radius};
-  display: flex;
-  gap: var(--#{$prefix}tracking-gap-width);
-}
+@layer components {
+  .tracking {
+    --#{$prefix}tracking-height: #{$tracking-height};
+    --#{$prefix}tracking-gap-width: #{$tracking-gap-width};
+    --#{$prefix}tracking-block-border-radius: #{$tracking-border-radius};
+    display: flex;
+    gap: var(--#{$prefix}tracking-gap-width);
+  }
 
-.tracking-squares {
-  --#{$prefix}tracking-block-border-radius: var(--#{$prefix}border-radius-sm);
+  .tracking-squares {
+    --#{$prefix}tracking-block-border-radius: var(--#{$prefix}border-radius-sm);
 
-  .tracking-block {
-    height: auto;
+    .tracking-block {
+      height: auto;
 
-    &:before {
-      content: '';
-      display: block;
-      padding-top: 100%;
+      &:before {
+        content: '';
+        display: block;
+        padding-top: 100%;
+      }
     }
   }
-}
 
-.tracking-block {
-  flex: 1;
-  @include border-radius(var(--#{$prefix}tracking-block-border-radius));
-  height: var(--#{$prefix}tracking-height);
-  min-width: 0.25rem;
-  background: var(--#{$prefix}border-color);
+  .tracking-block {
+    flex: 1;
+    @include border-radius(var(--#{$prefix}tracking-block-border-radius));
+    height: var(--#{$prefix}tracking-height);
+    min-width: 0.25rem;
+    background: var(--#{$prefix}border-color);
+  }
 }

--- a/core/scss/ui/_type.scss
+++ b/core/scss/ui/_type.scss
@@ -1,329 +1,331 @@
 @import 'typo/hr';
 
-.lead {
-  color: var(--#{$prefix}secondary);
-  font-size: inherit;
-}
-
-a {
-  text-decoration-skip-ink: auto;
-  color: color-mix(in srgb, transparent, var(--#{$prefix}link-color) var(--#{$prefix}link-opacity, 100%));
-
-  &:hover {
-    color: color-mix(in srgb, transparent, var(--#{$prefix}link-hover-color) var(--#{$prefix}link-opacity, 100%));
+@layer components {
+  .lead {
+    color: var(--#{$prefix}secondary);
+    font-size: inherit;
   }
-}
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-.h1,
-.h2,
-.h3,
-.h4,
-.h5,
-.h6 {
   a {
-    color: inherit;
+    text-decoration-skip-ink: auto;
+    color: color-mix(in srgb, transparent, var(--#{$prefix}link-color) var(--#{$prefix}link-opacity, 100%));
 
     &:hover {
+      color: color-mix(in srgb, transparent, var(--#{$prefix}link-hover-color) var(--#{$prefix}link-opacity, 100%));
+    }
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  .h1,
+  .h2,
+  .h3,
+  .h4,
+  .h5,
+  .h6 {
+    a {
       color: inherit;
+
+      &:hover {
+        color: inherit;
+      }
     }
   }
-}
 
-h1,
-.h1 {
-  font-size: var(--#{$prefix}font-size-h1);
-  line-height: var(--#{$prefix}line-height-h1);
-}
-
-h2,
-.h2 {
-  font-size: var(--#{$prefix}font-size-h2);
-  line-height: var(--#{$prefix}line-height-h2);
-}
-
-h3,
-.h3 {
-  font-size: var(--#{$prefix}font-size-h3);
-  line-height: var(--#{$prefix}line-height-h3);
-}
-
-h4,
-.h4 {
-  font-size: var(--#{$prefix}font-size-h4);
-  line-height: var(--#{$prefix}line-height-h4);
-}
-
-h5,
-.h5 {
-  font-size: var(--#{$prefix}font-size-h5);
-  line-height: var(--#{$prefix}line-height-h5);
-}
-
-h6,
-.h6 {
-  font-size: var(--#{$prefix}font-size-h6);
-  line-height: var(--#{$prefix}line-height-h6);
-}
-
-.fs-base {
-  font-size: var(--#{$prefix}body-font-size);
-}
-
-strong,
-.strong,
-b {
-  font-weight: $headings-font-weight;
-}
-
-blockquote {
-  padding: 1rem 1rem 1rem;
-  border-inline-start: 2px var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-
-  p {
-    margin-bottom: 1rem;
+  h1,
+  .h1 {
+    font-size: var(--#{$prefix}font-size-h1);
+    line-height: var(--#{$prefix}line-height-h1);
   }
 
-  cite {
-    display: block;
-    text-align: end;
+  h2,
+  .h2 {
+    font-size: var(--#{$prefix}font-size-h2);
+    line-height: var(--#{$prefix}line-height-h2);
+  }
 
-    &:before {
-      content: '— ';
+  h3,
+  .h3 {
+    font-size: var(--#{$prefix}font-size-h3);
+    line-height: var(--#{$prefix}line-height-h3);
+  }
+
+  h4,
+  .h4 {
+    font-size: var(--#{$prefix}font-size-h4);
+    line-height: var(--#{$prefix}line-height-h4);
+  }
+
+  h5,
+  .h5 {
+    font-size: var(--#{$prefix}font-size-h5);
+    line-height: var(--#{$prefix}line-height-h5);
+  }
+
+  h6,
+  .h6 {
+    font-size: var(--#{$prefix}font-size-h6);
+    line-height: var(--#{$prefix}line-height-h6);
+  }
+
+  .fs-base {
+    font-size: var(--#{$prefix}body-font-size);
+  }
+
+  strong,
+  .strong,
+  b {
+    font-weight: $headings-font-weight;
+  }
+
+  blockquote {
+    padding: 1rem 1rem 1rem;
+    border-inline-start: 2px var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+
+    p {
+      margin-bottom: 1rem;
+    }
+
+    cite {
+      display: block;
+      text-align: end;
+
+      &:before {
+        content: '— ';
+      }
     }
   }
-}
 
-ul,
-ol {
-  padding-inline-start: 1.5rem;
-}
+  ul,
+  ol {
+    padding-inline-start: 1.5rem;
+  }
 
-hr {
-  margin: 2rem 0;
-}
+  hr {
+    margin: 2rem 0;
+  }
 
-dl {
-  dd {
-    &:last-child {
+  dl {
+    dd {
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  pre {
+    --#{$prefix}scrollbar-color: #{$pre-color};
+    padding: $pre-padding;
+    background: $pre-bg;
+    color: $pre-color;
+    @include border-radius(var(--#{$prefix}border-radius));
+    line-height: $line-height-base;
+
+    @include scrollbar;
+
+    code {
+      background: transparent;
+      padding: 0;
+    }
+  }
+
+  code {
+    background: var(--#{$prefix}code-bg);
+    padding: 2px 4px;
+    @include border-radius(var(--#{$prefix}border-radius));
+  }
+
+  abbr {
+    text-decoration: underline dotted;
+    cursor: help;
+    text-decoration-skip-ink: none;
+  }
+
+  kbd,
+  .kbd {
+    border: $kbd-border;
+    display: inline-block;
+    box-sizing: border-box;
+    max-width: 100%;
+    font-size: $kbd-font-size;
+    font-weight: $kbd-font-weight;
+    line-height: 1;
+    vertical-align: baseline;
+    @include border-radius($kbd-border-radius);
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  .list-unstyled {
+    margin-inline-start: 0;
+  }
+
+  /**
+  Selection
+   */
+  ::selection,
+  .text-selected {
+    background-color: $selection-bg;
+  }
+
+  .text-selected {
+    display: inline-block;
+  }
+
+  /**
+  Links
+   */
+  [class^='link-'],
+  [class*=' link-'] {
+    &.disabled {
+      color: $nav-link-disabled-color !important;
+      pointer-events: none;
+    }
+  }
+
+  a:hover:has(.icon) {
+    text-decoration: none;
+  }
+
+  .link-hoverable {
+    @include border-radius(var(--#{$prefix}border-radius));
+    transition: background-color 0.15s ease-in-out;
+
+    &:hover {
+      text-decoration: none;
+      color: var(--#{$prefix}primary);
+      background: color-transparent(var(--#{$prefix}secondary), 0.04);
+    }
+  }
+
+  /**
+  Subheader
+   */
+  .subheader {
+    @include subheader;
+  }
+
+  /**
+  Mentions
+   */
+  .mention {
+    display: inline-block;
+    box-shadow: var(--#{$prefix}shadow-border);
+    @include border-radius(var(--#{$prefix}border-radius-pill));
+    line-height: calc(16em / 12);
+    font-size: calc(12em / 14);
+    color: var(--#{$prefix}body-color);
+    background: var(--#{$prefix}bg-surface-tertiary);
+    padding: calc(2em / 12) calc(8em / 12);
+    font-weight: var(--#{$prefix}font-weight-medium);
+
+    @at-root a#{&} {
+      cursor: pointer;
+
+      &:hover,
+      &.hover {
+        background: var(--#{$prefix}bg-surface-secondary);
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .mention-avatar,
+  .mention-app,
+  .mention-color {
+    width: calc(14em / 12);
+    height: calc(14em / 12);
+    @include border-radius(var(--#{$prefix}border-radius-pill));
+    margin: calc(-2em / 12) calc(4em / 12) 0 calc(-4em / 12);
+    display: inline-flex;
+    background: no-repeat center center/cover;
+    box-shadow: var(--#{$prefix}shadow-border);
+    vertical-align: middle;
+    text-align: center;
+  }
+
+  .mention-app {
+    box-shadow: none;
+    background: none;
+    border-radius: 0;
+  }
+
+  .mention-count {
+    color: var(--#{$prefix}secondary);
+    margin-inline-start: calc(8em / 12);
+  }
+
+  $text-variants: (
+    incorrect: var(--#{$prefix}red),
+    correct: var(--#{$prefix}green),
+  );
+
+  @each $variant, $color in $text-variants {
+    .text-#{$variant} {
+      background: color-transparent($color, 0.04);
+      background: color-transparent($color, 4%);
+      text-decoration: underline;
+      text-decoration-thickness: 1px;
+      text-decoration-color: $color;
+    }
+  }
+
+  .steps {
+    --#{$prefix}steps-padding: 2rem;
+    --#{$prefix}steps-item-size: 1.5rem;
+    margin-inline-start: 1rem;
+    padding-inline-start: var(--#{$prefix}steps-padding);
+    counter-reset: step;
+    border-inline-start: 1px solid var(--#{$prefix}border-color);
+    margin-bottom: 2rem;
+
+    h3 {
+      counter-increment: step;
+
+      &:not(:first-child) {
+        margin-top: 2.5rem !important;
+      }
+
+      &:before {
+        content: counter(step);
+        display: inline-block;
+        position: absolute;
+        margin-top: 1px;
+        margin-inline-start: calc(-1 * var(--#{$prefix}steps-padding) - var(--#{$prefix}steps-item-size) / 2);
+        width: var(--#{$prefix}steps-item-size);
+        height: var(--#{$prefix}steps-item-size);
+        text-align: center;
+        color: var(--#{$prefix}body-color);
+        border: 1px solid var(--#{$prefix}border-color);
+        background: var(--#{$prefix}bg-surface);
+        @include border-radius(var(--#{$prefix}border-radius));
+        line-height: calc(var(--#{$prefix}steps-item-size) - 2px);
+        font-size: var(--#{$prefix}font-size-h4);
+        font-weight: var(--#{$prefix}font-weight-semibold);
+      }
+    }
+
+    > :last-child {
       margin-bottom: 0;
     }
   }
-}
 
-pre {
-  --#{$prefix}scrollbar-color: #{$pre-color};
-  padding: $pre-padding;
-  background: $pre-bg;
-  color: $pre-color;
-  @include border-radius(var(--#{$prefix}border-radius));
-  line-height: $line-height-base;
+  .callout {
+    margin-bottom: 1.5rem;
+    border: 1px solid var(--#{$prefix}primary-200);
+    @include border-radius(var(--#{$prefix}border-radius));
+    padding: 0.5rem 1rem;
+    background: var(--#{$prefix}primary-lt);
 
-  @include scrollbar;
-
-  code {
-    background: transparent;
-    padding: 0;
-  }
-}
-
-code {
-  background: var(--#{$prefix}code-bg);
-  padding: 2px 4px;
-  @include border-radius(var(--#{$prefix}border-radius));
-}
-
-abbr {
-  text-decoration: underline dotted;
-  cursor: help;
-  text-decoration-skip-ink: none;
-}
-
-kbd,
-.kbd {
-  border: $kbd-border;
-  display: inline-block;
-  box-sizing: border-box;
-  max-width: 100%;
-  font-size: $kbd-font-size;
-  font-weight: $kbd-font-weight;
-  line-height: 1;
-  vertical-align: baseline;
-  @include border-radius($kbd-border-radius);
-}
-
-img {
-  max-width: 100%;
-  height: auto;
-}
-
-.list-unstyled {
-  margin-inline-start: 0;
-}
-
-/**
-Selection
- */
-::selection,
-.text-selected {
-  background-color: $selection-bg;
-}
-
-.text-selected {
-  display: inline-block;
-}
-
-/**
-Links
- */
-[class^='link-'],
-[class*=' link-'] {
-  &.disabled {
-    color: $nav-link-disabled-color !important;
-    pointer-events: none;
-  }
-}
-
-a:hover:has(.icon) {
-  text-decoration: none;
-}
-
-.link-hoverable {
-  @include border-radius(var(--#{$prefix}border-radius));
-  transition: background-color 0.15s ease-in-out;
-
-  &:hover {
-    text-decoration: none;
-    color: var(--#{$prefix}primary);
-    background: color-transparent(var(--#{$prefix}secondary), 0.04);
-  }
-}
-
-/**
-Subheader
- */
-.subheader {
-  @include subheader;
-}
-
-/**
-Mentions
- */
-.mention {
-  display: inline-block;
-  box-shadow: var(--#{$prefix}shadow-border);
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-  line-height: calc(16em / 12);
-  font-size: calc(12em / 14);
-  color: var(--#{$prefix}body-color);
-  background: var(--#{$prefix}bg-surface-tertiary);
-  padding: calc(2em / 12) calc(8em / 12);
-  font-weight: var(--#{$prefix}font-weight-medium);
-
-  @at-root a#{&} {
-    cursor: pointer;
-
-    &:hover,
-    &.hover {
-      background: var(--#{$prefix}bg-surface-secondary);
-      text-decoration: underline;
+    & > :last-child {
+      margin-bottom: 0;
     }
-  }
-}
-
-.mention-avatar,
-.mention-app,
-.mention-color {
-  width: calc(14em / 12);
-  height: calc(14em / 12);
-  @include border-radius(var(--#{$prefix}border-radius-pill));
-  margin: calc(-2em / 12) calc(4em / 12) 0 calc(-4em / 12);
-  display: inline-flex;
-  background: no-repeat center center/cover;
-  box-shadow: var(--#{$prefix}shadow-border);
-  vertical-align: middle;
-  text-align: center;
-}
-
-.mention-app {
-  box-shadow: none;
-  background: none;
-  border-radius: 0;
-}
-
-.mention-count {
-  color: var(--#{$prefix}secondary);
-  margin-inline-start: calc(8em / 12);
-}
-
-$text-variants: (
-  incorrect: var(--#{$prefix}red),
-  correct: var(--#{$prefix}green),
-);
-
-@each $variant, $color in $text-variants {
-  .text-#{$variant} {
-    background: color-transparent($color, 0.04);
-    background: color-transparent($color, 4%);
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-decoration-color: $color;
-  }
-}
-
-.steps {
-  --#{$prefix}steps-padding: 2rem;
-  --#{$prefix}steps-item-size: 1.5rem;
-  margin-inline-start: 1rem;
-  padding-inline-start: var(--#{$prefix}steps-padding);
-  counter-reset: step;
-  border-inline-start: 1px solid var(--#{$prefix}border-color);
-  margin-bottom: 2rem;
-
-  h3 {
-    counter-increment: step;
-
-    &:not(:first-child) {
-      margin-top: 2.5rem !important;
-    }
-
-    &:before {
-      content: counter(step);
-      display: inline-block;
-      position: absolute;
-      margin-top: 1px;
-      margin-inline-start: calc(-1 * var(--#{$prefix}steps-padding) - var(--#{$prefix}steps-item-size) / 2);
-      width: var(--#{$prefix}steps-item-size);
-      height: var(--#{$prefix}steps-item-size);
-      text-align: center;
-      color: var(--#{$prefix}body-color);
-      border: 1px solid var(--#{$prefix}border-color);
-      background: var(--#{$prefix}bg-surface);
-      @include border-radius(var(--#{$prefix}border-radius));
-      line-height: calc(var(--#{$prefix}steps-item-size) - 2px);
-      font-size: var(--#{$prefix}font-size-h4);
-      font-weight: var(--#{$prefix}font-weight-semibold);
-    }
-  }
-
-  > :last-child {
-    margin-bottom: 0;
-  }
-}
-
-.callout {
-  margin-bottom: 1.5rem;
-  border: 1px solid var(--#{$prefix}primary-200);
-  @include border-radius(var(--#{$prefix}border-radius));
-  padding: 0.5rem 1rem;
-  background: var(--#{$prefix}primary-lt);
-
-  & > :last-child {
-    margin-bottom: 0;
   }
 }

--- a/core/scss/ui/forms/_form-check.scss
+++ b/core/scss/ui/forms/_form-check.scss
@@ -1,85 +1,88 @@
 /*
 Form check
  */
-.form-check {
-  user-select: none;
 
-  &.form-check-highlight .form-check-input:not(:checked) ~ .form-check-label {
-    color: var(--#{$prefix}secondary);
-  }
+@layer components {
+  .form-check {
+    user-select: none;
 
-  .form-check-label-off {
-    color: var(--#{$prefix}secondary);
-  }
+    &.form-check-highlight .form-check-input:not(:checked) ~ .form-check-label {
+      color: var(--#{$prefix}secondary);
+    }
 
-  .form-check-input:checked ~ .form-check-label-off {
-    display: none;
-  }
+    .form-check-label-off {
+      color: var(--#{$prefix}secondary);
+    }
 
-  .form-check-input:not(:checked) ~ .form-check-label-on {
-    display: none;
-  }
-}
+    .form-check-input:checked ~ .form-check-label-off {
+      display: none;
+    }
 
-.form-check-input {
-  background-size: $form-check-input-width;
-  margin-top: ($form-check-min-height - $form-check-input-width) * 0.5;
-  box-shadow: $form-check-input-box-shadow;
-
-  .form-switch & {
-    @include transition(background-color$transition-time, background-position $transition-time);
-  }
-}
-
-.form-check-label {
-  display: block;
-
-  &.required {
-    &:after {
-      content: '*';
-      margin-inline-start: 0.25rem;
-      color: $red;
+    .form-check-input:not(:checked) ~ .form-check-label-on {
+      display: none;
     }
   }
-}
-
-.form-check-description {
-  display: block;
-  color: var(--#{$prefix}secondary);
-  font-size: $h5-font-size;
-  margin-top: 0.25rem;
-}
-
-.form-check-single {
-  margin: 0;
 
   .form-check-input {
-    margin: 0;
-  }
-}
+    background-size: $form-check-input-width;
+    margin-top: ($form-check-min-height - $form-check-input-width) * 0.5;
+    box-shadow: $form-check-input-box-shadow;
 
-/*
-Form switch
- */
-.form-switch {
-  .form-check-input {
-    height: $form-switch-height;
-    margin-top: ($form-check-min-height - $form-switch-height) * 0.5;
-  }
-}
-
-.form-switch-lg {
-  padding-inline-start: 3.5rem;
-  min-height: 1.5rem;
-
-  .form-check-input {
-    height: 1.5rem;
-    width: 2.75rem;
-    background-size: 1.5rem;
-    margin-inline-start: -3.5rem;
+    .form-switch & {
+      @include transition(background-color$transition-time, background-position $transition-time);
+    }
   }
 
   .form-check-label {
-    padding-top: 0.125rem;
+    display: block;
+
+    &.required {
+      &:after {
+        content: '*';
+        margin-inline-start: 0.25rem;
+        color: $red;
+      }
+    }
+  }
+
+  .form-check-description {
+    display: block;
+    color: var(--#{$prefix}secondary);
+    font-size: $h5-font-size;
+    margin-top: 0.25rem;
+  }
+
+  .form-check-single {
+    margin: 0;
+
+    .form-check-input {
+      margin: 0;
+    }
+  }
+
+  /*
+  Form switch
+   */
+  .form-switch {
+    .form-check-input {
+      height: $form-switch-height;
+      margin-top: ($form-check-min-height - $form-switch-height) * 0.5;
+    }
+  }
+
+  .form-switch-lg {
+    padding-inline-start: 3.5rem;
+    min-height: 1.5rem;
+
+    .form-check-input {
+      height: 1.5rem;
+      width: 2.75rem;
+      background-size: 1.5rem;
+      margin-inline-start: -3.5rem;
+    }
+
+    .form-check-label {
+      padding-top: 0.125rem;
+    }
   }
 }

--- a/core/scss/ui/forms/_form-colorinput.scss
+++ b/core/scss/ui/forms/_form-colorinput.scss
@@ -1,54 +1,57 @@
 /*
 Color Input
  */
-.form-colorinput {
-  position: relative;
-  display: inline-block;
-  margin: 0;
-  line-height: 1;
-  cursor: pointer;
-}
 
-.form-colorinput-input {
-  position: absolute;
-  z-index: -1;
-  opacity: 0;
-}
+@layer components {
+  .form-colorinput {
+    position: relative;
+    display: inline-block;
+    margin: 0;
+    line-height: 1;
+    cursor: pointer;
+  }
 
-.form-colorinput-color {
-  display: block;
-  width: 1.5rem;
-  height: 1.5rem;
-  color: $white;
-  border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $input-border-color-translucent;
-  @include border-radius(var(--#{$prefix}border-radius));
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-
-  &:before {
+  .form-colorinput-input {
     position: absolute;
-    top: 0;
-    inset-inline-start: 0;
-    width: 100%;
-    height: 100%;
-    content: '';
-    background: no-repeat center center/$form-check-input-checked-bg-size;
-    background-image: escape-svg($form-check-input-checked-bg-image);
+    z-index: -1;
     opacity: 0;
-    @include transition(opacity $transition-time);
-
-    .form-colorinput-input:checked ~ & {
-      opacity: 1;
-    }
   }
 
-  .form-colorinput-input:focus ~ & {
-    border-color: var(--#{$prefix}primary);
-    box-shadow: $input-btn-focus-box-shadow;
-  }
+  .form-colorinput-color {
+    display: block;
+    width: 1.5rem;
+    height: 1.5rem;
+    color: $white;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $input-border-color-translucent;
+    @include border-radius(var(--#{$prefix}border-radius));
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
 
-  @at-root .form-colorinput-light & {
     &:before {
-      background-image: escape-svg($form-check-input-checked-bg-image-dark);
+      position: absolute;
+      top: 0;
+      inset-inline-start: 0;
+      width: 100%;
+      height: 100%;
+      content: '';
+      background: no-repeat center center/$form-check-input-checked-bg-size;
+      background-image: escape-svg($form-check-input-checked-bg-image);
+      opacity: 0;
+      @include transition(opacity $transition-time);
+
+      .form-colorinput-input:checked ~ & {
+        opacity: 1;
+      }
+    }
+
+    .form-colorinput-input:focus ~ & {
+      border-color: var(--#{$prefix}primary);
+      box-shadow: $input-btn-focus-box-shadow;
+    }
+
+    @at-root .form-colorinput-light & {
+      &:before {
+        background-image: escape-svg($form-check-input-checked-bg-image-dark);
+      }
     }
   }
 }

--- a/core/scss/ui/forms/_form-custom.scss
+++ b/core/scss/ui/forms/_form-custom.scss
@@ -1,28 +1,31 @@
 /**
 Bootstrap color input
  */
-.form-control-color {
-  &::-webkit-color-swatch {
-    border: none;
-  }
-}
 
-/**
-Remove the cancel buttons in Chrome and Safari on macOS.
- */
-[type='search']::-webkit-search-cancel-button {
-  -webkit-appearance: none;
-}
-
-/**
-Form control dark theme fix
- */
-.form-control {
-  &::file-selector-button {
-    background-color: var(--#{$prefix}btn-color, #{$form-file-button-bg});
+@layer components {
+  .form-control-color {
+    &::-webkit-color-swatch {
+      border: none;
+    }
   }
 
-  &:hover:not(:disabled):not([readonly])::file-selector-button {
-    background-color: var(--#{$prefix}btn-color, #{$form-file-button-hover-bg});
+  /**
+  Remove the cancel buttons in Chrome and Safari on macOS.
+   */
+  [type='search']::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+  }
+
+  /**
+  Form control dark theme fix
+   */
+  .form-control {
+    &::file-selector-button {
+      background-color: var(--#{$prefix}btn-color, #{$form-file-button-bg});
+    }
+
+    &:hover:not(:disabled):not([readonly])::file-selector-button {
+      background-color: var(--#{$prefix}btn-color, #{$form-file-button-hover-bg});
+    }
   }
 }

--- a/core/scss/ui/forms/_form-icon.scss
+++ b/core/scss/ui/forms/_form-icon.scss
@@ -1,37 +1,40 @@
 /**
 Icon input
  */
-.input-icon {
-  position: relative;
 
-  .form-control:not(:last-child),
-  .form-select:not(:last-child) {
-    padding-inline-end: 2.5rem;
+@layer components {
+  .input-icon {
+    position: relative;
+
+    .form-control:not(:last-child),
+    .form-select:not(:last-child) {
+      padding-inline-end: 2.5rem;
+    }
+
+    .form-control:not(:first-child),
+    .form-select:not(:last-child) {
+      padding-inline-start: 2.5rem;
+    }
   }
 
-  .form-control:not(:first-child),
-  .form-select:not(:last-child) {
-    padding-inline-start: 2.5rem;
-  }
-}
+  .input-icon-addon {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    inset-inline-start: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.5rem;
+    height: $input-height;
+    color: var(--#{$prefix}icon-color);
+    pointer-events: none;
+    font-size: 1.2em;
 
-.input-icon-addon {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  inset-inline-start: 0;
-  z-index: 10;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 2.5rem;
-  height: $input-height;
-  color: var(--#{$prefix}icon-color);
-  pointer-events: none;
-  font-size: 1.2em;
-
-  &:last-child {
-    inset-inline-end: 0;
-    inset-inline-start: auto;
+    &:last-child {
+      inset-inline-end: 0;
+      inset-inline-start: auto;
+    }
   }
 }

--- a/core/scss/ui/forms/_form-imagecheck.scss
+++ b/core/scss/ui/forms/_form-imagecheck.scss
@@ -1,105 +1,108 @@
 /**
 Image check
  */
-.form-imagecheck {
-  --#{$prefix}form-imagecheck-radius: var(--#{$prefix}border-radius);
-  position: relative;
-  margin: 0;
-  cursor: pointer;
-}
 
-.form-imagecheck-input {
-  position: absolute;
-  z-index: -1;
-  opacity: 0;
-}
-
-.form-imagecheck-figure {
-  position: relative;
-  display: block;
-  margin: 0;
-  user-select: none;
-  border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-  @include border-radius(var(--#{$prefix}form-imagecheck-radius));
-
-  .form-imagecheck-input:focus ~ & {
-    border-color: var(--#{$prefix}primary);
-    box-shadow: $input-btn-focus-box-shadow;
+@layer components {
+  .form-imagecheck {
+    --#{$prefix}form-imagecheck-radius: var(--#{$prefix}border-radius);
+    position: relative;
+    margin: 0;
+    cursor: pointer;
   }
 
-  .form-imagecheck-input:checked ~ & {
-    border-color: var(--#{$prefix}primary);
-  }
-
-  &:before {
+  .form-imagecheck-input {
     position: absolute;
-    top: 0.25rem;
-    inset-inline-start: 0.25rem;
-    z-index: 1;
+    z-index: -1;
+    opacity: 0;
+  }
+
+  .form-imagecheck-figure {
+    position: relative;
     display: block;
-    width: $form-check-input-width;
-    height: $form-check-input-width;
-    color: $white;
-    pointer-events: none;
-    content: '';
+    margin: 0;
     user-select: none;
-    background: $form-check-input-bg;
     border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
-    @include border-radius($form-check-input-border-radius);
-    @include transition(opacity $transition-time);
+    @include border-radius(var(--#{$prefix}form-imagecheck-radius));
+
+    .form-imagecheck-input:focus ~ & {
+      border-color: var(--#{$prefix}primary);
+      box-shadow: $input-btn-focus-box-shadow;
+    }
 
     .form-imagecheck-input:checked ~ & {
-      background-color: $form-check-input-checked-bg-color;
-      background-image: escape-svg($form-check-input-checked-bg-image);
-      background-repeat: $form-check-input-checked-bg-repeat;
-      background-position: center;
-      background-size: $form-check-input-checked-bg-size;
-      border-color: $form-check-input-checked-border-color;
+      border-color: var(--#{$prefix}primary);
     }
 
-    .form-imagecheck-input[type='radio'] ~ & {
-      @include border-radius($form-check-radio-border-radius);
+    &:before {
+      position: absolute;
+      top: 0.25rem;
+      inset-inline-start: 0.25rem;
+      z-index: 1;
+      display: block;
+      width: $form-check-input-width;
+      height: $form-check-input-width;
+      color: $white;
+      pointer-events: none;
+      content: '';
+      user-select: none;
+      background: $form-check-input-bg;
+      border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+      @include border-radius($form-check-input-border-radius);
+      @include transition(opacity $transition-time);
+
+      .form-imagecheck-input:checked ~ & {
+        background-color: $form-check-input-checked-bg-color;
+        background-image: escape-svg($form-check-input-checked-bg-image);
+        background-repeat: $form-check-input-checked-bg-repeat;
+        background-position: center;
+        background-size: $form-check-input-checked-bg-size;
+        border-color: $form-check-input-checked-border-color;
+      }
+
+      .form-imagecheck-input[type='radio'] ~ & {
+        @include border-radius($form-check-radio-border-radius);
+      }
+
+      .form-imagecheck-input[type='radio']:checked ~ & {
+        background-image: escape-svg($form-check-radio-checked-bg-image);
+      }
+    }
+  }
+
+  .form-imagecheck-image {
+    max-width: 100%;
+    display: block;
+    opacity: 0.64;
+    @include transition(opacity $transition-time);
+
+    &:first-child {
+      border-start-start-radius: calc(var(--#{$prefix}form-imagecheck-radius) - 1px);
+      border-start-end-radius: calc(var(--#{$prefix}form-imagecheck-radius) - 1px);
     }
 
-    .form-imagecheck-input[type='radio']:checked ~ & {
-      background-image: escape-svg($form-check-radio-checked-bg-image);
+    &:last-child {
+      border-end-end-radius: calc(var(--#{$prefix}form-imagecheck-radius) - 1px);
+      border-end-start-radius: calc(var(--#{$prefix}form-imagecheck-radius) - 1px);
+    }
+
+    .form-imagecheck:hover &,
+    .form-imagecheck-input:focus ~ .form-imagecheck-figure &,
+    .form-imagecheck-input:checked ~ .form-imagecheck-figure & {
+      opacity: 1;
     }
   }
-}
 
-.form-imagecheck-image {
-  max-width: 100%;
-  display: block;
-  opacity: 0.64;
-  @include transition(opacity $transition-time);
+  .form-imagecheck-caption {
+    padding: 0.25rem;
+    font-size: $font-size-sm;
+    color: var(--#{$prefix}secondary);
+    text-align: center;
+    @include transition(color $transition-time);
 
-  &:first-child {
-    border-start-start-radius: calc(var(--#{$prefix}form-imagecheck-radius) - 1px);
-    border-start-end-radius: calc(var(--#{$prefix}form-imagecheck-radius) - 1px);
-  }
-
-  &:last-child {
-    border-end-end-radius: calc(var(--#{$prefix}form-imagecheck-radius) - 1px);
-    border-end-start-radius: calc(var(--#{$prefix}form-imagecheck-radius) - 1px);
-  }
-
-  .form-imagecheck:hover &,
-  .form-imagecheck-input:focus ~ .form-imagecheck-figure &,
-  .form-imagecheck-input:checked ~ .form-imagecheck-figure & {
-    opacity: 1;
-  }
-}
-
-.form-imagecheck-caption {
-  padding: 0.25rem;
-  font-size: $font-size-sm;
-  color: var(--#{$prefix}secondary);
-  text-align: center;
-  @include transition(color $transition-time);
-
-  .form-imagecheck:hover &,
-  .form-imagecheck-input:focus ~ .form-imagecheck-figure &,
-  .form-imagecheck-input:checked ~ .form-imagecheck-figure & {
-    color: var(--#{$prefix}body-color);
+    .form-imagecheck:hover &,
+    .form-imagecheck-input:focus ~ .form-imagecheck-figure &,
+    .form-imagecheck-input:checked ~ .form-imagecheck-figure & {
+      color: var(--#{$prefix}body-color);
+    }
   }
 }

--- a/core/scss/ui/forms/_form-selectgroup.scss
+++ b/core/scss/ui/forms/_form-selectgroup.scss
@@ -1,154 +1,157 @@
 /*
 Select group
  */
-.form-selectgroup {
-  display: inline-flex;
-  margin: 0;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+
+@layer components {
+  .form-selectgroup {
+    display: inline-flex;
+    margin: 0;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+
+    .form-selectgroup-item {
+      margin: 0;
+    }
+  }
+
+  .form-selectgroup-vertical {
+    flex-direction: column;
+  }
 
   .form-selectgroup-item {
-    margin: 0;
-  }
-}
-
-.form-selectgroup-vertical {
-  flex-direction: column;
-}
-
-.form-selectgroup-item {
-  display: block;
-  position: relative;
-}
-
-.form-selectgroup-input {
-  position: absolute;
-  top: 0;
-  inset-inline-start: 0;
-  z-index: -1;
-  opacity: 0;
-}
-
-.form-selectgroup-label {
-  position: relative;
-  display: block;
-  min-width: $input-height;
-  margin: 0;
-  padding: $input-btn-padding-y $input-btn-padding-x;
-  font-size: $input-btn-font-size;
-  line-height: $input-line-height;
-  color: var(--#{$prefix}secondary);
-  background: $form-check-input-bg;
-  text-align: center;
-  cursor: pointer;
-  user-select: none;
-  border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $input-border-color;
-  @include border-radius(var(--#{$prefix}border-radius));
-  box-shadow: $input-box-shadow;
-  @include transition(border-color $transition-time, background $transition-time, color $transition-time);
-
-  .icon:only-child {
-    margin: 0 -0.25rem;
+    display: block;
+    position: relative;
   }
 
-  &:hover {
-    color: var(--#{$prefix}body-color);
-  }
-}
-
-.form-selectgroup-check {
-  display: inline-block;
-  width: $form-check-input-width;
-  height: $form-check-input-width;
-  border: $form-check-input-border;
-  vertical-align: middle;
-  box-shadow: $form-check-input-box-shadow;
-
-  .form-selectgroup-input[type='checkbox'] + .form-selectgroup-label & {
-    @include border-radius($form-check-input-border-radius);
+  .form-selectgroup-input {
+    position: absolute;
+    top: 0;
+    inset-inline-start: 0;
+    z-index: -1;
+    opacity: 0;
   }
 
-  .form-selectgroup-input[type='radio'] + .form-selectgroup-label & {
-    @include border-radius($form-check-radio-border-radius);
-  }
-
-  .form-selectgroup-input:checked + .form-selectgroup-label & {
-    background-color: $form-check-input-checked-bg-color;
-    background-repeat: $form-check-input-checked-bg-repeat;
-    background-position: center;
-    background-size: $form-check-input-checked-bg-size;
-    border-color: $form-check-input-checked-border-color;
-  }
-
-  .form-selectgroup-input[type='checkbox']:checked + .form-selectgroup-label & {
-    background-image: escape-svg($form-check-input-checked-bg-image);
-  }
-
-  .form-selectgroup-input[type='radio']:checked + .form-selectgroup-label & {
-    background-image: escape-svg($form-check-radio-checked-bg-image);
-  }
-}
-
-.form-selectgroup-check-floated {
-  position: absolute;
-  top: $input-btn-padding-y;
-  inset-inline-end: $input-btn-padding-y;
-}
-
-.form-selectgroup-input:checked + .form-selectgroup-label {
-  z-index: 1;
-  color: #{$active-color};
-  background: #{$active-bg};
-  border-color: #{$active-border-color};
-}
-
-.form-selectgroup-input:focus + .form-selectgroup-label {
-  z-index: 2;
-  color: var(--#{$prefix}primary);
-  border-color: var(--#{$prefix}primary);
-  box-shadow: $input-btn-focus-box-shadow;
-}
-
-.form-selectgroup-label-content {
-}
-
-/**
-Alternate version of form select group
- */
-.form-selectgroup-boxes {
   .form-selectgroup-label {
-    text-align: start;
-    padding: $card-spacer-x $card-spacer-y;
-    color: inherit;
+    position: relative;
+    display: block;
+    min-width: $input-height;
+    margin: 0;
+    padding: $input-btn-padding-y $input-btn-padding-x;
+    font-size: $input-btn-font-size;
+    line-height: $input-line-height;
+    color: var(--#{$prefix}secondary);
+    background: $form-check-input-bg;
+    text-align: center;
+    cursor: pointer;
+    user-select: none;
+    border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $input-border-color;
+    @include border-radius(var(--#{$prefix}border-radius));
+    box-shadow: $input-box-shadow;
+    @include transition(border-color $transition-time, background $transition-time, color $transition-time);
+
+    .icon:only-child {
+      margin: 0 -0.25rem;
+    }
+
+    &:hover {
+      color: var(--#{$prefix}body-color);
+    }
   }
 
-  .form-selectgroup-input:checked {
-    + .form-selectgroup-label {
+  .form-selectgroup-check {
+    display: inline-block;
+    width: $form-check-input-width;
+    height: $form-check-input-width;
+    border: $form-check-input-border;
+    vertical-align: middle;
+    box-shadow: $form-check-input-box-shadow;
+
+    .form-selectgroup-input[type='checkbox'] + .form-selectgroup-label & {
+      @include border-radius($form-check-input-border-radius);
+    }
+
+    .form-selectgroup-input[type='radio'] + .form-selectgroup-label & {
+      @include border-radius($form-check-radio-border-radius);
+    }
+
+    .form-selectgroup-input:checked + .form-selectgroup-label & {
+      background-color: $form-check-input-checked-bg-color;
+      background-repeat: $form-check-input-checked-bg-repeat;
+      background-position: center;
+      background-size: $form-check-input-checked-bg-size;
+      border-color: $form-check-input-checked-border-color;
+    }
+
+    .form-selectgroup-input[type='checkbox']:checked + .form-selectgroup-label & {
+      background-image: escape-svg($form-check-input-checked-bg-image);
+    }
+
+    .form-selectgroup-input[type='radio']:checked + .form-selectgroup-label & {
+      background-image: escape-svg($form-check-radio-checked-bg-image);
+    }
+  }
+
+  .form-selectgroup-check-floated {
+    position: absolute;
+    top: $input-btn-padding-y;
+    inset-inline-end: $input-btn-padding-y;
+  }
+
+  .form-selectgroup-input:checked + .form-selectgroup-label {
+    z-index: 1;
+    color: #{$active-color};
+    background: #{$active-bg};
+    border-color: #{$active-border-color};
+  }
+
+  .form-selectgroup-input:focus + .form-selectgroup-label {
+    z-index: 2;
+    color: var(--#{$prefix}primary);
+    border-color: var(--#{$prefix}primary);
+    box-shadow: $input-btn-focus-box-shadow;
+  }
+
+  .form-selectgroup-label-content {
+  }
+
+  /**
+  Alternate version of form select group
+   */
+  .form-selectgroup-boxes {
+    .form-selectgroup-label {
+      text-align: start;
+      padding: $card-spacer-x $card-spacer-y;
       color: inherit;
+    }
 
-      .form-selectgroup-title {
-        color: var(--#{$prefix}primary);
-      }
+    .form-selectgroup-input:checked {
+      + .form-selectgroup-label {
+        color: inherit;
 
-      .form-selectgroup-label-content {
-        opacity: 1;
+        .form-selectgroup-title {
+          color: var(--#{$prefix}primary);
+        }
+
+        .form-selectgroup-label-content {
+          opacity: 1;
+        }
       }
     }
   }
-}
 
-/**
-Select group
- */
-.form-selectgroup-pills {
-  flex-wrap: wrap;
-  align-items: start;
+  /**
+  Select group
+   */
+  .form-selectgroup-pills {
+    flex-wrap: wrap;
+    align-items: start;
 
-  .form-selectgroup-item {
-    flex-grow: 0;
-  }
+    .form-selectgroup-item {
+      flex-grow: 0;
+    }
 
-  .form-selectgroup-label {
-    @include border-radius(var(--#{$prefix}border-radius-pill));
+    .form-selectgroup-label {
+      @include border-radius(var(--#{$prefix}border-radius-pill));
+    }
   }
 }

--- a/core/scss/ui/forms/_validation.scss
+++ b/core/scss/ui/forms/_validation.scss
@@ -1,13 +1,15 @@
-%validation-lite {
-  border-color: var(--#{$prefix}border-color) !important;
-}
-
-@each $state, $data in $form-validation-states {
-  .form-control.is-#{$state}-lite {
-    @extend %validation-lite;
+@layer components {
+  %validation-lite {
+    border-color: var(--#{$prefix}border-color) !important;
   }
 
-  .form-select.is-#{$state}-lite {
-    @extend %validation-lite;
+  @each $state, $data in $form-validation-states {
+    .form-control.is-#{$state}-lite {
+      @extend %validation-lite;
+    }
+
+    .form-select.is-#{$state}-lite {
+      @extend %validation-lite;
+    }
   }
 }

--- a/core/scss/ui/typo/_hr.scss
+++ b/core/scss/ui/typo/_hr.scss
@@ -1,76 +1,79 @@
 /**
 Horizontal rules
  */
-.hr {
-  @extend hr;
-}
 
-/**
-Hr text
- */
-.hr-text {
-  display: flex;
-  align-items: center;
-  margin: $hr-margin-y 0;
-  @include subheader;
-  height: 1px;
+@layer components {
+  .hr {
+    @extend hr;
+  }
 
-  &:after,
-  &:before {
-    flex: 1 1 auto;
+  /**
+  Hr text
+   */
+  .hr-text {
+    display: flex;
+    align-items: center;
+    margin: $hr-margin-y 0;
+    @include subheader;
     height: 1px;
-    background-color: var(--#{$prefix}border-color);
-  }
 
-  &:before {
-    content: '';
-    margin-inline-end: 0.5rem;
-  }
-
-  &:after {
-    content: '';
-    margin-inline-start: 0.5rem;
-  }
-
-  > *:first-child {
-    padding-inline-end: 0.5rem;
-    padding-inline-start: 0;
-    color: var(--#{$prefix}secondary);
-  }
-
-  &.hr-text-left,
-  &.hr-text-start {
+    &:after,
     &:before {
-      content: none;
+      flex: 1 1 auto;
+      height: 1px;
+      background-color: var(--#{$prefix}border-color);
     }
 
-    & > *:first-child {
-      padding-inline-end: 0.5rem;
-      padding-inline-start: 0.5rem;
-    }
-  }
-
-  &.hr-text-right,
-  &.hr-text-end {
     &:before {
       content: '';
+      margin-inline-end: 0.5rem;
     }
 
     &:after {
-      content: none;
+      content: '';
+      margin-inline-start: 0.5rem;
     }
 
-    & > *:first-child {
-      padding-inline-end: 0;
-      padding-inline-start: 0.5rem;
+    > *:first-child {
+      padding-inline-end: 0.5rem;
+      padding-inline-start: 0;
+      color: var(--#{$prefix}secondary);
+    }
+
+    &.hr-text-left,
+    &.hr-text-start {
+      &:before {
+        content: none;
+      }
+
+      & > *:first-child {
+        padding-inline-end: 0.5rem;
+        padding-inline-start: 0.5rem;
+      }
+    }
+
+    &.hr-text-right,
+    &.hr-text-end {
+      &:before {
+        content: '';
+      }
+
+      &:after {
+        content: none;
+      }
+
+      & > *:first-child {
+        padding-inline-end: 0;
+        padding-inline-start: 0.5rem;
+      }
+    }
+
+    .card > & {
+      margin: 0;
     }
   }
 
-  .card > & {
-    margin: 0;
+  .hr-text-spaceless {
+    margin: -0.5rem 0;
   }
-}
-
-.hr-text-spaceless {
-  margin: -0.5rem 0;
 }

--- a/core/scss/utils/_background.scss
+++ b/core/scss/utils/_background.scss
@@ -1,15 +1,17 @@
-.bg-white-overlay {
-  color: $white;
-  background-color: rgba($light, 0.24);
-}
+@layer utilities {
+  .bg-white-overlay {
+    color: $white;
+    background-color: rgba($light, 0.24);
+  }
 
-.bg-dark-overlay {
-  color: $white;
-  background-color: rgba($dark, 0.24);
-}
+  .bg-dark-overlay {
+    color: $white;
+    background-color: rgba($dark, 0.24);
+  }
 
-.bg-cover {
-  background-repeat: no-repeat;
-  background-size: cover;
-  background-position: center;
+  .bg-cover {
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
+  }
 }

--- a/core/scss/utils/_colors.scss
+++ b/core/scss/utils/_colors.scss
@@ -1,110 +1,113 @@
 @use 'sass:map';
 
 // All colors
-@each $color,
-  $value
-    in map.merge(
-      $theme-colors,
-      (
-        white: $white,
+
+@layer utilities {
+  @each $color,
+    $value
+      in map.merge(
+        $theme-colors,
+        (
+          white: $white,
+        )
       )
-    )
-{
-  .bg-#{'' + $color} {
-    background-color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}bg-opacity, 1) * 100%), transparent) !important;
-  }
+  {
+    .bg-#{'' + $color} {
+      background-color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}bg-opacity, 1) * 100%), transparent) !important;
+    }
 
-  .bg-#{'' + $color}-lt {
-    color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}text-opacity, 1) * 100%), transparent) !important;
-    background-color: color-mix(in srgb, var(--#{$prefix}#{$color}-lt) calc(var(--#{$prefix}bg-opacity, 1) * 100%), transparent) !important;
-  }
+    .bg-#{'' + $color}-lt {
+      color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}text-opacity, 1) * 100%), transparent) !important;
+      background-color: color-mix(in srgb, var(--#{$prefix}#{$color}-lt) calc(var(--#{$prefix}bg-opacity, 1) * 100%), transparent) !important;
+    }
 
-  .border-#{'' + $color} {
-    border-color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}border-opacity, 1) * 100%), transparent) !important;
-  }
+    .border-#{'' + $color} {
+      border-color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}border-opacity, 1) * 100%), transparent) !important;
+    }
 
-  .bg-gradient-from-#{'' + $color} {
-    --#{$prefix}gradient-from: var(--#{$prefix}#{$color});
-  }
+    .bg-gradient-from-#{'' + $color} {
+      --#{$prefix}gradient-from: var(--#{$prefix}#{$color});
+    }
 
-  .bg-gradient-to-#{'' + $color} {
-    --#{$prefix}gradient-to: var(--#{$prefix}#{$color});
-  }
+    .bg-gradient-to-#{'' + $color} {
+      --#{$prefix}gradient-to: var(--#{$prefix}#{$color});
+    }
 
-  .bg-gradient-via-#{'' + $color} {
-    --#{$prefix}gradient-via: var(--#{$prefix}#{$color});
-    --#{$prefix}gradient-stops: var(--#{$prefix}gradient-from, transparent), var(--#{$prefix}gradient-via, transparent), var(--#{$prefix}gradient-to, transparent);
-  }
+    .bg-gradient-via-#{'' + $color} {
+      --#{$prefix}gradient-via: var(--#{$prefix}#{$color});
+      --#{$prefix}gradient-stops: var(--#{$prefix}gradient-from, transparent), var(--#{$prefix}gradient-via, transparent), var(--#{$prefix}gradient-to, transparent);
+    }
 
-  .text-bg-#{'' + $color} {
-    color: color-contrast($value) if(sass($enable-important-utilities): !important; else: null);
-    background-color: RGBA(var(--#{$prefix}#{$color}-rgb), var(--#{$prefix}bg-opacity, 1)) if(sass($enable-important-utilities): !important; else: null);
-  }
+    .text-bg-#{'' + $color} {
+      color: color-contrast($value) if(sass($enable-important-utilities): !important; else: null);
+      background-color: RGBA(var(--#{$prefix}#{$color}-rgb), var(--#{$prefix}bg-opacity, 1)) if(sass($enable-important-utilities): !important; else: null);
+    }
 
-  .link-#{'' + $color} {
-    color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}link-opacity, 1) * 100%), transparent) !important;
-    text-decoration-color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}link-underline-opacity, 1) * 100%), transparent) !important;
+    .link-#{'' + $color} {
+      color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}link-opacity, 1) * 100%), transparent) !important;
+      text-decoration-color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}link-underline-opacity, 1) * 100%), transparent) !important;
 
-    @if $link-shade-percentage != 0 {
-      &:hover,
-      &:focus {
-        $hover-color: if(sass(color-contrast($value) == $color-contrast-light): shade-color($value, $link-shade-percentage); else: tint-color($value, $link-shade-percentage));
-        color: RGBA(#{to-rgb($hover-color)}, var(--#{$prefix}link-opacity, 1)) if(sass($enable-important-utilities): !important; else: null);
-        text-decoration-color: RGBA(to-rgb($hover-color), var(--#{$prefix}link-underline-opacity, 1)) if(sass($enable-important-utilities): !important; else: null);
+      @if $link-shade-percentage != 0 {
+        &:hover,
+        &:focus {
+          $hover-color: if(sass(color-contrast($value) == $color-contrast-light): shade-color($value, $link-shade-percentage); else: tint-color($value, $link-shade-percentage));
+          color: RGBA(#{to-rgb($hover-color)}, var(--#{$prefix}link-opacity, 1)) if(sass($enable-important-utilities): !important; else: null);
+          text-decoration-color: RGBA(to-rgb($hover-color), var(--#{$prefix}link-underline-opacity, 1)) if(sass($enable-important-utilities): !important; else: null);
+        }
       }
     }
   }
-}
 
-@each $color, $value in $theme-colors {
-  .text-#{'' + $color} {
-    --#{$prefix}text-opacity: 1;
-    color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}text-opacity) * 100%), transparent) !important;
+  @each $color, $value in $theme-colors {
+    .text-#{'' + $color} {
+      --#{$prefix}text-opacity: 1;
+      color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}text-opacity) * 100%), transparent) !important;
+    }
+
+    .text-#{'' + $color}-fg {
+      color: var(--#{$prefix}#{$color}-fg) !important;
+    }
   }
 
-  .text-#{'' + $color}-fg {
-    color: var(--#{$prefix}#{$color}-fg) !important;
-  }
-}
+  @each $color, $value in $gray-colors {
+    .bg-#{'' + $color} {
+      --#{$prefix}bg-opacity: 1;
+      background-color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}bg-opacity) * 100%), transparent) !important;
+    }
 
-@each $color, $value in $gray-colors {
-  .bg-#{'' + $color} {
+    .text-#{'' + $color}-fg {
+      color: var(--#{$prefix}#{$color}-fg) !important;
+    }
+  }
+
+  @each $color, $value in $social-colors {
+    .bg-#{'' + $color} {
+      --#{$prefix}bg-opacity: 1;
+      background-color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}bg-opacity) * 100%), transparent) !important;
+    }
+
+    .text-#{'' + $color}-fg {
+      color: var(--#{$prefix}#{$color}-fg) !important;
+    }
+  }
+
+  .bg-inverted {
     --#{$prefix}bg-opacity: 1;
-    background-color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}bg-opacity) * 100%), transparent) !important;
+    background-color: color-mix(in srgb, var(--#{$prefix}bg-surface-inverted) calc(var(--#{$prefix}bg-opacity) * 100%), transparent) !important;
+  }
+  .bg-surface {
+    background-color: var(--#{$prefix}bg-surface) !important;
   }
 
-  .text-#{'' + $color}-fg {
-    color: var(--#{$prefix}#{$color}-fg) !important;
-  }
-}
-
-@each $color, $value in $social-colors {
-  .bg-#{'' + $color} {
-    --#{$prefix}bg-opacity: 1;
-    background-color: color-mix(in srgb, var(--#{$prefix}#{$color}) calc(var(--#{$prefix}bg-opacity) * 100%), transparent) !important;
+  .bg-surface-secondary {
+    background-color: var(--#{$prefix}bg-surface-secondary) !important;
   }
 
-  .text-#{'' + $color}-fg {
-    color: var(--#{$prefix}#{$color}-fg) !important;
+  .bg-surface-tertiary {
+    background-color: var(--#{$prefix}bg-surface-tertiary) !important;
   }
-}
 
-.bg-inverted {
-  --#{$prefix}bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--#{$prefix}bg-surface-inverted) calc(var(--#{$prefix}bg-opacity) * 100%), transparent) !important;
-}
-.bg-surface {
-  background-color: var(--#{$prefix}bg-surface) !important;
-}
-
-.bg-surface-secondary {
-  background-color: var(--#{$prefix}bg-surface-secondary) !important;
-}
-
-.bg-surface-tertiary {
-  background-color: var(--#{$prefix}bg-surface-tertiary) !important;
-}
-
-.bg-surface-backdrop {
-  background-color: color-transparent($modal-backdrop-bg, $modal-backdrop-opacity) !important;
+  .bg-surface-backdrop {
+    background-color: color-transparent($modal-backdrop-bg, $modal-backdrop-opacity) !important;
+  }
 }

--- a/core/scss/utils/_hover.scss
+++ b/core/scss/utils/_hover.scss
@@ -1,47 +1,49 @@
-%hover-animation {
-  transition: transform 0.3s ease;
+@layer utilities {
+  %hover-animation {
+    transition: transform 0.3s ease;
 
-  &:hover {
-    will-change: transform;
+    &:hover {
+      will-change: transform;
+    }
   }
-}
 
-.hover-elevate-up {
-  @extend %hover-animation;
+  .hover-elevate-up {
+    @extend %hover-animation;
 
-  &:hover {
-    transform: translateY(-4px);
+    &:hover {
+      transform: translateY(-4px);
+    }
   }
-}
 
-.hover-elevate-down {
-  @extend %hover-animation;
+  .hover-elevate-down {
+    @extend %hover-animation;
 
-  &:hover {
-    transform: translateY(4px);
+    &:hover {
+      transform: translateY(4px);
+    }
   }
-}
 
-.hover-scale {
-  @extend %hover-animation;
+  .hover-scale {
+    @extend %hover-animation;
 
-  &:hover {
-    transform: scale(1.1);
+    &:hover {
+      transform: scale(1.1);
+    }
   }
-}
 
-.hover-rotate-end {
-  @extend %hover-animation;
+  .hover-rotate-end {
+    @extend %hover-animation;
 
-  &:hover {
-    transform: rotate(4deg);
+    &:hover {
+      transform: rotate(4deg);
+    }
   }
-}
 
-.hover-rotate-start {
-  @extend %hover-animation;
+  .hover-rotate-start {
+    @extend %hover-animation;
 
-  &:hover {
-    transform: rotate(-4deg);
+    &:hover {
+      transform: rotate(-4deg);
+    }
   }
 }

--- a/core/scss/utils/_opacity.scss
+++ b/core/scss/utils/_opacity.scss
@@ -1,7 +1,9 @@
 // stylelint-disable declaration-no-important
 
-@for $i from 0 through 20 {
-  .opacity-#{$i * 5} {
-    opacity: calc(#{$i * 5} / 100) !important;
+@layer utilities {
+  @for $i from 0 through 20 {
+    .opacity-#{$i * 5} {
+      opacity: calc(#{$i * 5} / 100) !important;
+    }
   }
 }

--- a/core/scss/utils/_scroll.scss
+++ b/core/scss/utils/_scroll.scss
@@ -1,45 +1,48 @@
 /*
 Scrollable
 */
-.scrollable {
-  overflow-x: hidden;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
 
-  &.hover {
-    overflow-y: hidden;
+@layer utilities {
+  .scrollable {
+    overflow-x: hidden;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
 
-    > * {
-      margin-top: -1px;
+    &.hover {
+      overflow-y: hidden;
+
+      > * {
+        margin-top: -1px;
+      }
+
+      &:hover,
+      &:focus,
+      &:active {
+        overflow: visible;
+        overflow-y: auto;
+      }
     }
 
-    &:hover,
-    &:focus,
-    &:active {
-      overflow: visible;
-      overflow-y: auto;
+    .touch & {
+      overflow-y: auto !important;
     }
   }
 
-  .touch & {
-    overflow-y: auto !important;
+  .scroll-x,
+  .scroll-y {
+    overflow: hidden;
+    -webkit-overflow-scrolling: touch;
   }
-}
 
-.scroll-x,
-.scroll-y {
-  overflow: hidden;
-  -webkit-overflow-scrolling: touch;
-}
+  .scroll-y {
+    overflow-y: auto;
+  }
 
-.scroll-y {
-  overflow-y: auto;
-}
+  .scroll-x {
+    overflow-x: auto;
+  }
 
-.scroll-x {
-  overflow-x: auto;
-}
-
-.no-scroll {
-  overflow: hidden;
+  .no-scroll {
+    overflow: hidden;
+  }
 }

--- a/core/scss/utils/_shadow.scss
+++ b/core/scss/utils/_shadow.scss
@@ -1,17 +1,19 @@
 // stylelint-disable declaration-no-important
 
-.hover-shadow-sm:hover {
-  box-shadow: $box-shadow-sm !important;
-}
+@layer utilities {
+  .hover-shadow-sm:hover {
+    box-shadow: $box-shadow-sm !important;
+  }
 
-.hover-shadow:hover {
-  box-shadow: $box-shadow !important;
-}
+  .hover-shadow:hover {
+    box-shadow: $box-shadow !important;
+  }
 
-.hover-shadow-lg:hover {
-  box-shadow: $box-shadow-lg !important;
-}
+  .hover-shadow-lg:hover {
+    box-shadow: $box-shadow-lg !important;
+  }
 
-.hover-shadow-none:hover {
-  box-shadow: none !important;
+  .hover-shadow-none:hover {
+    box-shadow: none !important;
+  }
 }

--- a/core/scss/utils/_sizing.scss
+++ b/core/scss/utils/_sizing.scss
@@ -1,12 +1,14 @@
 // stylelint-disable declaration-no-important
 
-@use "sass:map";
+@use 'sass:map';
 
-@each $size-name, $size in map.merge($spacers, $size-spacers) {
-  .w-#{$size-name} {
-    width: $size !important;
-  }
-  .h-#{$size-name} {
-    height: $size !important;
+@layer utilities {
+  @each $size-name, $size in map.merge($spacers, $size-spacers) {
+    .w-#{$size-name} {
+      width: $size !important;
+    }
+    .h-#{$size-name} {
+      height: $size !important;
+    }
   }
 }

--- a/core/scss/utils/_text.scss
+++ b/core/scss/utils/_text.scss
@@ -3,12 +3,15 @@
 /**
 Antialiasing
  */
-.antialiased {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
 
-.subpixel-antialiased {
-  -webkit-font-smoothing: auto;
-  -moz-osx-font-smoothing: auto;
+@layer utilities {
+  .antialiased {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  .subpixel-antialiased {
+    -webkit-font-smoothing: auto;
+    -moz-osx-font-smoothing: auto;
+  }
 }


### PR DESCRIPTION
## Summary

- Move Tabler core SCSS to the Sass module system (`@use` / `@forward`) instead of `@import`.
- Add `_extends.scss` so cross-module `@extend` rules (headings, `.hr`, markdown tables, dark-mode light scopes) still work and load last from `tabler.scss`.
- Extract a parameterized `utilities-api` mixin so the marketing bundle can emit its own utilities map without relying on a shared global `$utilities`.

## Preview

- **URL:** [preview](https://tabler-git-scss-module-migration-tabler-io.vercel.app/)
- **How to test:** Build `@tabler/core` CSS and open the preview home page. Spot-check typography helpers (`.h1`–`.h6`, `.small`, `.mark`, `.hr`), a markdown/prose table, dark mode with a nested light scope, and a marketing page that uses marketing utilities. Confirm compiled CSS still looks the same as on `dev`.