### PR TITLE
Fix barely visible checkbox borders in dark theme

### DIFF
--- a/.changeset/fix-checkbox-dark-border.md
+++ b/.changeset/fix-checkbox-dark-border.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed barely visible checkbox and radio borders in dark theme by using `$input-border-color` instead of translucent border color for `.form-check-input`.

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -1812,7 +1812,7 @@ $form-check-input-width: 1.25rem !default;
 $form-check-min-height: $font-size-base * $line-height-base !default;
 $form-check-input-active-filter: brightness(90%) !default;
 $form-check-input-bg: var(--#{$prefix}bg-forms) !default;
-$form-check-input-border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $input-border-color-translucent !default;
+$form-check-input-border: var(--#{$prefix}border-width) var(--#{$prefix}border-style) $input-border-color !default;
 $form-check-input-border-radius: var(--#{$prefix}border-radius) !default;
 $form-check-radio-border-radius: 50% !default;
 $form-check-input-focus-border: $input-focus-border-color !default;


### PR DESCRIPTION
## Summary

- Makes unchecked checkbox and radio borders easier to see in dark theme.
- Switches `$form-check-input-border` from the translucent border color to `$input-border-color` (same as text inputs).
- Fixes the issue on dark `.form-fieldset` surfaces where the old border almost disappeared.

Closes #2543

## Preview

- **URL:** [form-elements.html](https://tabler-git-fix-2543-tabler-io.vercel.app/form-elements.html?theme=dark)
- **How to test:** Open the page in dark theme and scroll to the form fieldset with the “I agree…” checkbox. The unchecked checkbox border should be clearly visible against the fieldset background. Also check other checkboxes and radios on the page.