### PR TITLE
Fix `.icon` so transform animations work on webfont icons

### DIFF
--- a/.changeset/fix-icon-transform-animations.md
+++ b/.changeset/fix-icon-transform-animations.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed transform animations (`.icon-pulse`, `.icon-tada`, `.icon-rotate`) not working on webfont icons by adding `display: inline-block` and `transform-origin: center` to `.icon`.

--- a/core/scss/ui/_icons.scss
+++ b/core/scss/ui/_icons.scss
@@ -9,6 +9,8 @@
   height: var(--#{$prefix}icon-size);
   font-size: var(--#{$prefix}icon-size);
   vertical-align: bottom;
+  display: inline-block;
+  transform-origin: center;
 
   @if $icon-stroke-width {
     stroke-width: $icon-stroke-width;


### PR DESCRIPTION
## Summary

- Webfont icons (`<i>`, `<span>`) are `display: inline` by default, and CSS ignores `transform` on inline elements. That silently broke `.icon-pulse`, `.icon-tada`, and `.icon-rotate` on webfont icons, even though the same animations already worked on inline `<svg>` icons.
- Added `display: inline-block` and `transform-origin: center` to `.icon` in `core/scss/ui/_icons.scss`, so transforms apply and pivot from the icon's center.
- SVG icons are unaffected — this only changes behavior for elements that were previously `display: inline` (webfont icons).

## Preview

- Vercel needs a maintainer to authorize this external contributor's deployment first (see the bot comment on this PR). Once authorized: open a preview page with icon animations (e.g. `/icons.html`) and check that a webfont icon like `<i class="ti ti-heart icon icon-pulse">` now animates the same way the SVG version does.

## Notes / rollout

- Closes #2713.