### PR TITLE
Unify workspace lint, format, and type-check quality gates

### DIFF
--- a/.changeset/format-lint-tooling-sync.md
+++ b/.changeset/format-lint-tooling-sync.md
@@ -1,0 +1,7 @@
+---
+"@tabler/core": patch
+"@tabler/docs": patch
+"@tabler/preview": patch
+---
+
+Unified local and CI quality gates: added root-level `lint-prettier`/`format-prettier` scripts covering `core`, `preview`, and `shared`, wired `check` to run lint and type-check together, and updated the lint workflow to run both. Reformatted the covered files with Prettier.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Install pnpm dependencies
         run: pnpm install
 
-      - name: Lint Markdown
+      - name: Lint
         run: pnpm run lint
+
+      - name: Type Check
+        run: pnpm run type-check

--- a/core/js/src/bootstrap.ts
+++ b/core/js/src/bootstrap.ts
@@ -38,5 +38,5 @@ export const bootstrap = {
   ScrollSpy,
   Tab,
   Toast,
-  Tooltip
+  Tooltip,
 }

--- a/core/js/src/bootstrap/base-component.ts
+++ b/core/js/src/bootstrap/base-component.ts
@@ -38,7 +38,7 @@ class BaseComponent extends Config {
     EventHandler.off(this._element, ctor.EVENT_KEY)
 
     for (const propertyName of Object.getOwnPropertyNames(this)) {
-      (this as Record<string, unknown>)[propertyName] = null
+      ;(this as Record<string, unknown>)[propertyName] = null
     }
   }
 

--- a/core/js/src/bootstrap/carousel.ts
+++ b/core/js/src/bootstrap/carousel.ts
@@ -9,13 +9,7 @@ import BaseComponent from './base-component'
 import EventHandler from './dom/event-handler'
 import Manipulator from './dom/manipulator'
 import SelectorEngine from './dom/selector-engine'
-import {
-  getNextActiveElement,
-  isRTL,
-  isVisible,
-  reflow,
-  triggerTransitionEnd
-} from './util/index'
+import { getNextActiveElement, isRTL, isVisible, reflow, triggerTransitionEnd } from './util/index'
 import Swipe from './util/swipe'
 import type { ComponentConfig, ComponentConfigType } from './types'
 
@@ -60,7 +54,7 @@ const SELECTOR_DATA_RIDE = '[data-bs-ride="carousel"], [data-tblr-ride="carousel
 
 const KEY_TO_DIRECTION: Record<string, string> = {
   [ARROW_LEFT_KEY]: DIRECTION_RIGHT,
-  [ARROW_RIGHT_KEY]: DIRECTION_LEFT
+  [ARROW_RIGHT_KEY]: DIRECTION_LEFT,
 }
 
 const Default: ComponentConfig = {
@@ -69,7 +63,7 @@ const Default: ComponentConfig = {
   pause: 'hover',
   ride: false,
   touch: true,
-  wrap: true
+  wrap: true,
 }
 
 const DefaultType: ComponentConfigType = {
@@ -78,7 +72,7 @@ const DefaultType: ComponentConfigType = {
   pause: '(string|boolean)',
   ride: '(boolean|string)',
   touch: 'boolean',
-  wrap: 'boolean'
+  wrap: 'boolean',
 }
 
 class Carousel extends BaseComponent {
@@ -230,7 +224,7 @@ class Carousel extends BaseComponent {
     const swipeConfig = {
       leftCallback: () => this._slide(this._directionToOrder(DIRECTION_LEFT)),
       rightCallback: () => this._slide(this._directionToOrder(DIRECTION_RIGHT)),
-      endCallback: endCallBack
+      endCallback: endCallBack,
     }
 
     this._swipeHelper = new Swipe(this._element, swipeConfig)
@@ -289,7 +283,7 @@ class Carousel extends BaseComponent {
 
     const activeElement = this._getActive()
     const isNext = order === ORDER_NEXT
-    const nextElement = element || getNextActiveElement(this._getItems(), activeElement!, isNext, this._config.wrap as boolean) as HTMLElement
+    const nextElement = element || (getNextActiveElement(this._getItems(), activeElement!, isNext, this._config.wrap as boolean) as HTMLElement)
 
     if (nextElement === activeElement) {
       return
@@ -302,7 +296,7 @@ class Carousel extends BaseComponent {
         relatedTarget: nextElement,
         direction: this._orderToDirection(order),
         from: this._getItemIndex(activeElement!),
-        to: nextElementIndex
+        to: nextElementIndex,
       })
     }
 

--- a/core/js/src/bootstrap/collapse.ts
+++ b/core/js/src/bootstrap/collapse.ts
@@ -37,12 +37,12 @@ const SELECTOR_DATA_TOGGLE = '[data-bs-toggle="collapse"], [data-tblr-toggle="co
 
 const Default: ComponentConfig = {
   parent: null,
-  toggle: true
+  toggle: true,
 }
 
 const DefaultType: ComponentConfigType = {
   parent: '(null|element)',
-  toggle: 'boolean'
+  toggle: 'boolean',
 }
 
 class Collapse extends BaseComponent {
@@ -59,8 +59,7 @@ class Collapse extends BaseComponent {
 
     for (const elem of toggleList) {
       const selector = SelectorEngine.getSelectorFromElement(elem)
-      const filterElement = SelectorEngine.find(selector!)
-        .filter(foundElement => foundElement === this._element)
+      const filterElement = SelectorEngine.find(selector!).filter((foundElement) => foundElement === this._element)
 
       if (selector !== null && filterElement.length) {
         this._triggerArray.push(elem)
@@ -107,8 +106,8 @@ class Collapse extends BaseComponent {
 
     if (this._config.parent) {
       activeChildren = this._getFirstLevelChildren(SELECTOR_ACTIVES)
-        .filter(element => element !== this._element)
-        .map(element => Collapse.getOrCreateInstance(element, { toggle: false }) as Collapse)
+        .filter((element) => element !== this._element)
+        .map((element) => Collapse.getOrCreateInstance(element, { toggle: false }) as Collapse)
     }
 
     if (activeChildren.length && activeChildren[0]._isTransitioning) {
@@ -225,7 +224,7 @@ class Collapse extends BaseComponent {
 
   _getFirstLevelChildren(selector: string): HTMLElement[] {
     const children = SelectorEngine.find(CLASS_NAME_DEEPER_CHILDREN, this._config.parent as HTMLElement)
-    return SelectorEngine.find(selector, this._config.parent as HTMLElement).filter(element => !children.includes(element))
+    return SelectorEngine.find(selector, this._config.parent as HTMLElement).filter((element) => !children.includes(element))
   }
 
   _addAriaAndCollapsedClass(triggerArray: HTMLElement[], isOpen: boolean): void {
@@ -246,7 +245,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
   }
 
   for (const element of SelectorEngine.getMultipleElementsFromSelector(this)) {
-    (Collapse.getOrCreateInstance(element, { toggle: false }) as Collapse).toggle()
+    ;(Collapse.getOrCreateInstance(element, { toggle: false }) as Collapse).toggle()
   }
 })
 

--- a/core/js/src/bootstrap/dom/data.ts
+++ b/core/js/src/bootstrap/dom/data.ts
@@ -44,7 +44,7 @@ const Data = {
     if (instanceMap.size === 0) {
       elementMap.delete(element)
     }
-  }
+  },
 }
 
 export default Data

--- a/core/js/src/bootstrap/dom/event-handler.ts
+++ b/core/js/src/bootstrap/dom/event-handler.ts
@@ -26,7 +26,7 @@ const eventRegistry: Record<string | number, Record<string, Record<string | numb
 let uidEvent = 1
 const customEvents: Record<string, string> = {
   mouseenter: 'mouseover',
-  mouseleave: 'mouseout'
+  mouseleave: 'mouseout',
 }
 
 const nativeEvents = new Set([
@@ -75,7 +75,7 @@ const nativeEvents = new Set([
   'readystatechange',
   'error',
   'abort',
-  'scroll'
+  'scroll',
 ])
 
 function makeEventUid(element: EventableElement | EventCallback, uid?: string): string | number {
@@ -125,20 +125,11 @@ function bootstrapDelegationHandler(element: EventTarget, selector: string, fn: 
   } as BootstrapHandler
 }
 
-function findHandler(
-  events: Record<string | number, BootstrapHandler>,
-  callable: EventCallback,
-  delegationSelector: string | null = null
-): BootstrapHandler | undefined {
-  return Object.values(events)
-    .find(event => event.callable === callable && event.delegationSelector === delegationSelector)
+function findHandler(events: Record<string | number, BootstrapHandler>, callable: EventCallback, delegationSelector: string | null = null): BootstrapHandler | undefined {
+  return Object.values(events).find((event) => event.callable === callable && event.delegationSelector === delegationSelector)
 }
 
-function normalizeParameters(
-  originalTypeEvent: string,
-  handler: string | EventCallback | undefined,
-  delegationFunction: EventCallback | undefined
-): [boolean, EventCallback, string] {
+function normalizeParameters(originalTypeEvent: string, handler: string | EventCallback | undefined, delegationFunction: EventCallback | undefined): [boolean, EventCallback, string] {
   const isDelegated = typeof handler === 'string'
   const callable = isDelegated ? delegationFunction! : (handler || delegationFunction)!
   let typeEvent = getTypeEvent(originalTypeEvent)
@@ -150,13 +141,7 @@ function normalizeParameters(
   return [isDelegated, callable, typeEvent]
 }
 
-function addHandler(
-  element: EventTarget | null,
-  originalTypeEvent: string,
-  handler: string | EventCallback | undefined,
-  delegationFunction: EventCallback | undefined,
-  oneOff: boolean
-): void {
+function addHandler(element: EventTarget | null, originalTypeEvent: string, handler: string | EventCallback | undefined, delegationFunction: EventCallback | undefined, oneOff: boolean): void {
   if (typeof originalTypeEvent !== 'string' || !element) {
     return
   }
@@ -178,7 +163,7 @@ function addHandler(
 
   const events = getElementEvents(element)
   const handlers = events[typeEvent] || (events[typeEvent] = {})
-  const previousFunction = findHandler(handlers, callable, isDelegated ? handler as string : null)
+  const previousFunction = findHandler(handlers, callable, isDelegated ? (handler as string) : null)
 
   if (previousFunction) {
     previousFunction.oneOff = previousFunction.oneOff && oneOff
@@ -187,11 +172,9 @@ function addHandler(
   }
 
   const uid = makeEventUid(callable, originalTypeEvent.replace(namespaceRegex, ''))
-  const fn: BootstrapHandler = isDelegated ?
-    bootstrapDelegationHandler(element, handler as string, callable) :
-    bootstrapHandler(element, callable)
+  const fn: BootstrapHandler = isDelegated ? bootstrapDelegationHandler(element, handler as string, callable) : bootstrapHandler(element, callable)
 
-  fn.delegationSelector = isDelegated ? handler as string : null
+  fn.delegationSelector = isDelegated ? (handler as string) : null
   fn.callable = callable
   fn.oneOff = oneOff
   fn.uidEvent = uid
@@ -200,13 +183,7 @@ function addHandler(
   element.addEventListener(typeEvent, fn, isDelegated)
 }
 
-function removeHandler(
-  element: EventTarget,
-  events: Record<string, Record<string | number, BootstrapHandler>>,
-  typeEvent: string,
-  handler: EventCallback,
-  delegationSelector?: string | null
-): void {
+function removeHandler(element: EventTarget, events: Record<string, Record<string | number, BootstrapHandler>>, typeEvent: string, handler: EventCallback, delegationSelector?: string | null): void {
   const fn = findHandler(events[typeEvent], handler, delegationSelector ?? null)
 
   if (!fn) {
@@ -217,12 +194,7 @@ function removeHandler(
   delete events[typeEvent][fn.uidEvent!]
 }
 
-function removeNamespacedHandlers(
-  element: EventTarget,
-  events: Record<string, Record<string | number, BootstrapHandler>>,
-  typeEvent: string,
-  namespace: string
-): void {
+function removeNamespacedHandlers(element: EventTarget, events: Record<string, Record<string | number, BootstrapHandler>>, typeEvent: string, namespace: string): void {
   const storeElementEvent = events[typeEvent] || {}
 
   for (const [handlerKey, event] of Object.entries(storeElementEvent)) {
@@ -262,7 +234,7 @@ const EventHandler = {
         return
       }
 
-      removeHandler(element, events, typeEvent, callable, isDelegated ? handler as string : null)
+      removeHandler(element, events, typeEvent, callable, isDelegated ? (handler as string) : null)
       return
     }
 
@@ -291,19 +263,19 @@ const EventHandler = {
     element.dispatchEvent(evt)
 
     return evt
-  }
+  },
 }
 
 function hydrateObj<T extends object>(obj: T, meta: Record<string, unknown> = {}): T {
   for (const [key, value] of Object.entries(meta)) {
     try {
-      (obj as Record<string, unknown>)[key] = value
+      ;(obj as Record<string, unknown>)[key] = value
     } catch {
       Object.defineProperty(obj, key, {
         configurable: true,
         get() {
           return value
-        }
+        },
       })
     }
   }

--- a/core/js/src/bootstrap/dom/manipulator.ts
+++ b/core/js/src/bootstrap/dom/manipulator.ts
@@ -36,7 +36,7 @@ function normalizeData(value: string): DataValue {
 }
 
 function normalizeDataKey(key: string): string {
-  return key.replace(/[A-Z]/g, chr => `-${chr.toLowerCase()}`)
+  return key.replace(/[A-Z]/g, (chr) => `-${chr.toLowerCase()}`)
 }
 
 const PREFIXES = ['tblr', 'bs'] as const
@@ -60,7 +60,7 @@ const Manipulator = {
     const attributes: Record<string, DataValue> = {}
 
     for (const prefix of PREFIXES) {
-      const keys = Object.keys(element.dataset).filter(key => key.startsWith(prefix) && !key.startsWith(`${prefix}Config`))
+      const keys = Object.keys(element.dataset).filter((key) => key.startsWith(prefix) && !key.startsWith(`${prefix}Config`))
 
       for (const key of keys) {
         let pureKey = key.replace(new RegExp(`^${prefix}`), '')
@@ -83,7 +83,7 @@ const Manipulator = {
     }
 
     return null
-  }
+  },
 }
 
 export default Manipulator

--- a/core/js/src/bootstrap/dom/selector-engine.ts
+++ b/core/js/src/bootstrap/dom/selector-engine.ts
@@ -24,7 +24,12 @@ const getSelector = (element: HTMLElement): string | null => {
     selector = hrefAttribute && hrefAttribute !== '#' ? hrefAttribute.trim() : null
   }
 
-  return selector ? selector.split(',').map(sel => parseSelector(sel)).join(',') : null
+  return selector
+    ? selector
+        .split(',')
+        .map((sel) => parseSelector(sel))
+        .join(',')
+    : null
 }
 
 const SelectorEngine = {
@@ -37,7 +42,7 @@ const SelectorEngine = {
   },
 
   children(element: HTMLElement, selector: string): HTMLElement[] {
-    return Array.from(element.children).filter(child => child.matches(selector)) as HTMLElement[]
+    return Array.from(element.children).filter((child) => child.matches(selector)) as HTMLElement[]
   },
 
   parents(element: HTMLElement, selector: string): HTMLElement[] {
@@ -81,18 +86,9 @@ const SelectorEngine = {
   },
 
   focusableChildren(element: HTMLElement): HTMLElement[] {
-    const focusables = [
-      'a',
-      'button',
-      'input',
-      'textarea',
-      'select',
-      'details',
-      '[tabindex]',
-      '[contenteditable="true"]'
-    ].map(selector => `${selector}:not([tabindex^="-"])`).join(',')
+    const focusables = ['a', 'button', 'input', 'textarea', 'select', 'details', '[tabindex]', '[contenteditable="true"]'].map((selector) => `${selector}:not([tabindex^="-"])`).join(',')
 
-    return this.find(focusables, element).filter(el => !isDisabled(el) && isVisible(el))
+    return this.find(focusables, element).filter((el) => !isDisabled(el) && isVisible(el))
   },
 
   getSelectorFromElement(element: HTMLElement): string | null {
@@ -115,7 +111,7 @@ const SelectorEngine = {
     const selector = getSelector(element)
 
     return selector ? SelectorEngine.find(selector) : []
-  }
+  },
 }
 
 export default SelectorEngine

--- a/core/js/src/bootstrap/dropdown.ts
+++ b/core/js/src/bootstrap/dropdown.ts
@@ -10,16 +10,7 @@ import BaseComponent from './base-component'
 import EventHandler from './dom/event-handler'
 import Manipulator from './dom/manipulator'
 import SelectorEngine from './dom/selector-engine'
-import {
-  execute,
-  getElement,
-  getNextActiveElement,
-  isDisabled,
-  isElement,
-  isRTL,
-  isVisible,
-  noop
-} from './util/index'
+import { execute, getElement, getNextActiveElement, isDisabled, isElement, isRTL, isVisible, noop } from './util/index'
 import type { ComponentConfig, ComponentConfigType } from './types'
 
 const NAME = 'dropdown'
@@ -70,7 +61,7 @@ const Default: ComponentConfig = {
   display: 'dynamic',
   offset: [0, 2],
   popperConfig: null,
-  reference: 'toggle'
+  reference: 'toggle',
 }
 
 const DefaultType: ComponentConfigType = {
@@ -79,7 +70,7 @@ const DefaultType: ComponentConfigType = {
   display: 'string',
   offset: '(array|string|function)',
   popperConfig: '(null|object|function)',
-  reference: '(string|element|object)'
+  reference: '(string|element|object)',
 }
 
 class Dropdown extends BaseComponent {
@@ -93,9 +84,7 @@ class Dropdown extends BaseComponent {
 
     this._popper = null
     this._parent = this._element.parentNode as HTMLElement
-    this._menu = SelectorEngine.next(this._element, SELECTOR_MENU)[0] ||
-      SelectorEngine.prev(this._element, SELECTOR_MENU)[0] ||
-      SelectorEngine.findOne(SELECTOR_MENU, this._parent)!
+    this._menu = SelectorEngine.next(this._element, SELECTOR_MENU)[0] || SelectorEngine.prev(this._element, SELECTOR_MENU)[0] || SelectorEngine.findOne(SELECTOR_MENU, this._parent)!
     this._inNavbar = this._detectNavbar()
   }
 
@@ -121,7 +110,7 @@ class Dropdown extends BaseComponent {
     }
 
     const relatedTarget = {
-      relatedTarget: this._element
+      relatedTarget: this._element,
     }
 
     const showEvent = EventHandler.trigger(this._element, EVENT_SHOW, relatedTarget)
@@ -152,7 +141,7 @@ class Dropdown extends BaseComponent {
     }
 
     const relatedTarget = {
-      relatedTarget: this._element
+      relatedTarget: this._element,
     }
 
     this._completeHide(relatedTarget)
@@ -199,9 +188,7 @@ class Dropdown extends BaseComponent {
   _getConfig(config: Partial<ComponentConfig>): ComponentConfig {
     config = super._getConfig(config)
 
-    if (typeof config.reference === 'object' && !isElement(config.reference) &&
-      typeof (config.reference as any).getBoundingClientRect !== 'function'
-    ) {
+    if (typeof config.reference === 'object' && !isElement(config.reference) && typeof (config.reference as any).getBoundingClientRect !== 'function') {
       throw new TypeError(`${NAME.toUpperCase()}: Option "reference" provided type "object" without a required "getBoundingClientRect" method.`)
     }
 
@@ -210,7 +197,7 @@ class Dropdown extends BaseComponent {
 
   _createPopper(): void {
     if (typeof Popper === 'undefined') {
-      throw new TypeError('Bootstrap\'s dropdowns require Popper (https://popper.js.org/docs/v2/)')
+      throw new TypeError("Bootstrap's dropdowns require Popper (https://popper.js.org/docs/v2/)")
     }
 
     let referenceElement: HTMLElement | Popper.VirtualElement = this._element
@@ -267,7 +254,7 @@ class Dropdown extends BaseComponent {
     const { offset } = this._config
 
     if (typeof offset === 'string') {
-      return offset.split(',').map(value => Number.parseInt(value, 10))
+      return offset.split(',').map((value) => Number.parseInt(value, 10))
     }
 
     if (typeof offset === 'function') {
@@ -280,37 +267,41 @@ class Dropdown extends BaseComponent {
   _getPopperConfig(): Partial<Popper.Options> {
     const defaultBsPopperConfig: Partial<Popper.Options> = {
       placement: this._getPlacement() as Popper.Placement,
-      modifiers: [{
-        name: 'preventOverflow',
-        options: {
-          boundary: this._config.boundary
-        }
-      },
-      {
-        name: 'offset',
-        options: {
-          offset: this._getOffset()
-        }
-      }]
+      modifiers: [
+        {
+          name: 'preventOverflow',
+          options: {
+            boundary: this._config.boundary,
+          },
+        },
+        {
+          name: 'offset',
+          options: {
+            offset: this._getOffset(),
+          },
+        },
+      ],
     }
 
     if (this._inNavbar || this._config.display === 'static') {
       Manipulator.setDataAttribute(this._menu, 'popper', 'static')
-      defaultBsPopperConfig.modifiers = [{
-        name: 'applyStyles',
-        enabled: false
-      }]
+      defaultBsPopperConfig.modifiers = [
+        {
+          name: 'applyStyles',
+          enabled: false,
+        },
+      ]
     }
 
     const popperConfig = execute(this._config.popperConfig, [undefined, defaultBsPopperConfig])
     return {
       ...defaultBsPopperConfig,
-      ...(typeof popperConfig === 'object' && popperConfig !== null ? popperConfig : {})
+      ...(typeof popperConfig === 'object' && popperConfig !== null ? popperConfig : {}),
     }
   }
 
   _selectMenuItem({ key, target }: { key: string; target: HTMLElement }): void {
-    const items = SelectorEngine.find(SELECTOR_VISIBLE_ITEMS, this._menu).filter(element => isVisible(element))
+    const items = SelectorEngine.find(SELECTOR_VISIBLE_ITEMS, this._menu).filter((element) => isVisible(element))
 
     if (!items.length) {
       return
@@ -334,11 +325,7 @@ class Dropdown extends BaseComponent {
 
       const composedPath = event.composedPath()
       const isMenuTarget = composedPath.includes(context._menu)
-      if (
-        composedPath.includes(context._element) ||
-        (context._config.autoClose === 'inside' && !isMenuTarget) ||
-        (context._config.autoClose === 'outside' && isMenuTarget)
-      ) {
+      if (composedPath.includes(context._element) || (context._config.autoClose === 'inside' && !isMenuTarget) || (context._config.autoClose === 'outside' && isMenuTarget)) {
         continue
       }
 
@@ -371,11 +358,7 @@ class Dropdown extends BaseComponent {
 
     event.preventDefault()
 
-    const getToggleButton = this.matches(SELECTOR_DATA_TOGGLE) ?
-      this :
-      (SelectorEngine.prev(this, SELECTOR_DATA_TOGGLE)[0] ||
-        SelectorEngine.next(this, SELECTOR_DATA_TOGGLE)[0] ||
-        SelectorEngine.findOne(SELECTOR_DATA_TOGGLE, (event as any).delegateTarget.parentNode))
+    const getToggleButton = this.matches(SELECTOR_DATA_TOGGLE) ? this : SelectorEngine.prev(this, SELECTOR_DATA_TOGGLE)[0] || SelectorEngine.next(this, SELECTOR_DATA_TOGGLE)[0] || SelectorEngine.findOne(SELECTOR_DATA_TOGGLE, (event as any).delegateTarget.parentNode)
 
     const instance = Dropdown.getOrCreateInstance(getToggleButton!) as Dropdown
 

--- a/core/js/src/bootstrap/modal.ts
+++ b/core/js/src/bootstrap/modal.ts
@@ -11,9 +11,7 @@ import SelectorEngine from './dom/selector-engine'
 import Backdrop from './util/backdrop'
 import { enableDismissTrigger } from './util/component-functions'
 import FocusTrap from './util/focustrap'
-import {
-  isRTL, isVisible, reflow
-} from './util/index'
+import { isRTL, isVisible, reflow } from './util/index'
 import ScrollBarHelper from './util/scrollbar'
 
 /**
@@ -58,13 +56,13 @@ interface ComponentConfigType {
 const Default: ComponentConfig = {
   backdrop: true,
   focus: true,
-  keyboard: true
+  keyboard: true,
 }
 
 const DefaultType: ComponentConfigType = {
   backdrop: '(boolean|string)',
   focus: 'boolean',
-  keyboard: 'boolean'
+  keyboard: 'boolean',
 }
 
 /**
@@ -114,7 +112,7 @@ class Modal extends BaseComponent {
     }
 
     const showEvent = EventHandler.trigger(this._element, EVENT_SHOW, {
-      relatedTarget
+      relatedTarget,
     })
 
     if (showEvent.defaultPrevented) {
@@ -170,13 +168,13 @@ class Modal extends BaseComponent {
   _initializeBackDrop(): Backdrop {
     return new Backdrop({
       isVisible: Boolean(this._config.backdrop),
-      isAnimated: this._isAnimated()
+      isAnimated: this._isAnimated(),
     })
   }
 
   _initializeFocusTrap(): FocusTrap {
     return new FocusTrap({
-      trapElement: this._element
+      trapElement: this._element,
     })
   }
 
@@ -207,7 +205,7 @@ class Modal extends BaseComponent {
 
       this._isTransitioning = false
       EventHandler.trigger(this._element, EVENT_SHOWN, {
-        relatedTarget
+        relatedTarget,
       })
     }
 

--- a/core/js/src/bootstrap/offcanvas.ts
+++ b/core/js/src/bootstrap/offcanvas.ts
@@ -53,13 +53,13 @@ interface ComponentConfigType {
 const Default: ComponentConfig = {
   backdrop: true,
   keyboard: true,
-  scroll: false
+  scroll: false,
 }
 
 const DefaultType: ComponentConfigType = {
   backdrop: '(boolean|string)',
   keyboard: 'boolean',
-  scroll: 'boolean'
+  scroll: 'boolean',
 }
 
 /**
@@ -186,13 +186,13 @@ class Offcanvas extends BaseComponent {
       isVisible: isBackdropVisible,
       isAnimated: true,
       rootElement: this._element.parentNode as HTMLElement,
-      clickCallback: isBackdropVisible ? clickCallback : null
+      clickCallback: isBackdropVisible ? clickCallback : null,
     })
   }
 
   _initializeFocusTrap(): FocusTrap {
     return new FocusTrap({
-      trapElement: this._element
+      trapElement: this._element,
     })
   }
 

--- a/core/js/src/bootstrap/popover.ts
+++ b/core/js/src/bootstrap/popover.ts
@@ -29,17 +29,13 @@ const Default: ComponentConfig = {
   content: '',
   offset: [0, 8],
   placement: 'right',
-  template: '<div class="popover" role="tooltip">' +
-    '<div class="popover-arrow"></div>' +
-    '<h3 class="popover-header"></h3>' +
-    '<div class="popover-body"></div>' +
-    '</div>',
-  trigger: 'click'
+  template: '<div class="popover" role="tooltip">' + '<div class="popover-arrow"></div>' + '<h3 class="popover-header"></h3>' + '<div class="popover-body"></div>' + '</div>',
+  trigger: 'click',
 }
 
 const DefaultType: ComponentConfigType = {
   ...Tooltip.DefaultType,
-  content: '(null|string|element|function)'
+  content: '(null|string|element|function)',
 }
 
 /**
@@ -66,7 +62,7 @@ class Popover extends Tooltip {
   _getContentForTemplate(): Record<string, any> {
     return {
       [SELECTOR_TITLE]: this._getTitle(),
-      [SELECTOR_CONTENT]: this._getContent()
+      [SELECTOR_CONTENT]: this._getContent(),
     }
   }
 

--- a/core/js/src/bootstrap/scrollspy.ts
+++ b/core/js/src/bootstrap/scrollspy.ts
@@ -38,7 +38,7 @@ const Default: ComponentConfig = {
   rootMargin: '0px 0px -25%',
   smoothScroll: false,
   target: null,
-  threshold: [0.1, 0.5, 1]
+  threshold: [0.1, 0.5, 1],
 }
 
 const DefaultType: ComponentConfigType = {
@@ -46,7 +46,7 @@ const DefaultType: ComponentConfigType = {
   rootMargin: 'string',
   smoothScroll: 'boolean',
   target: 'element',
-  threshold: 'array'
+  threshold: 'array',
 }
 
 class ScrollSpy extends BaseComponent {
@@ -70,7 +70,7 @@ class ScrollSpy extends BaseComponent {
     this._observer = null
     this._previousScrollData = {
       visibleEntryTop: 0,
-      parentScrollTop: 0
+      parentScrollTop: 0,
     }
     this.refresh()
   }
@@ -137,7 +137,7 @@ class ScrollSpy extends BaseComponent {
           return
         }
 
-        (root as HTMLElement).scrollTop = height
+        ;(root as HTMLElement).scrollTop = height
       }
     })
   }
@@ -146,10 +146,10 @@ class ScrollSpy extends BaseComponent {
     const options: IntersectionObserverInit = {
       root: this._rootElement,
       threshold: this._config.threshold as number[],
-      rootMargin: this._config.rootMargin as string
+      rootMargin: this._config.rootMargin as string,
     }
 
-    return new IntersectionObserver(entries => this._observerCallback(entries), options)
+    return new IntersectionObserver((entries) => this._observerCallback(entries), options)
   }
 
   _observerCallback(entries: IntersectionObserverEntry[]): void {
@@ -222,8 +222,7 @@ class ScrollSpy extends BaseComponent {
 
   _activateParents(target: HTMLElement): void {
     if (target.classList.contains(CLASS_NAME_DROPDOWN_ITEM)) {
-      SelectorEngine.findOne(SELECTOR_DROPDOWN_TOGGLE, target.closest(SELECTOR_DROPDOWN)!)!
-        .classList.add(CLASS_NAME_ACTIVE)
+      SelectorEngine.findOne(SELECTOR_DROPDOWN_TOGGLE, target.closest(SELECTOR_DROPDOWN)!)!.classList.add(CLASS_NAME_ACTIVE)
       return
     }
 

--- a/core/js/src/bootstrap/tab.ts
+++ b/core/js/src/bootstrap/tab.ts
@@ -74,9 +74,7 @@ class Tab extends BaseComponent {
 
     const active = this._getActiveElem()
 
-    const hideEvent = active ?
-      EventHandler.trigger(active, EVENT_HIDE, { relatedTarget: innerElem }) :
-      null
+    const hideEvent = active ? EventHandler.trigger(active, EVENT_HIDE, { relatedTarget: innerElem }) : null
 
     const showEvent = EventHandler.trigger(innerElem, EVENT_SHOW, { relatedTarget: active })
 
@@ -107,7 +105,7 @@ class Tab extends BaseComponent {
       element.setAttribute('aria-selected', 'true')
       this._toggleDropDown(element, true)
       EventHandler.trigger(element, EVENT_SHOWN, {
-        relatedTarget: relatedElem
+        relatedTarget: relatedElem,
       })
     }
 
@@ -140,14 +138,14 @@ class Tab extends BaseComponent {
   }
 
   _keydown(event: KeyboardEvent): void {
-    if (!([ARROW_LEFT_KEY, ARROW_RIGHT_KEY, ARROW_UP_KEY, ARROW_DOWN_KEY, HOME_KEY, END_KEY].includes(event.key))) {
+    if (![ARROW_LEFT_KEY, ARROW_RIGHT_KEY, ARROW_UP_KEY, ARROW_DOWN_KEY, HOME_KEY, END_KEY].includes(event.key)) {
       return
     }
 
     event.stopPropagation()
     event.preventDefault()
 
-    const children = this._getChildren().filter(element => !isDisabled(element))
+    const children = this._getChildren().filter((element) => !isDisabled(element))
     let nextActiveElement: HTMLElement | undefined
 
     if ([HOME_KEY, END_KEY].includes(event.key)) {
@@ -168,7 +166,7 @@ class Tab extends BaseComponent {
   }
 
   _getActiveElem(): HTMLElement | null {
-    return this._getChildren().find(child => this._elemIsActive(child)) || null
+    return this._getChildren().find((child) => this._elemIsActive(child)) || null
   }
 
   _setInitialAttributes(parent: HTMLElement, children: HTMLElement[]): void {

--- a/core/js/src/bootstrap/toast.ts
+++ b/core/js/src/bootstrap/toast.ts
@@ -32,13 +32,13 @@ const CLASS_NAME_SHOWING = 'showing'
 const DefaultType: ComponentConfigType = {
   animation: 'boolean',
   autohide: 'boolean',
-  delay: 'number'
+  delay: 'number',
 }
 
 const Default: ComponentConfig = {
   animation: true,
   autohide: true,
-  delay: 5000
+  delay: 5000,
 }
 
 class Toast extends BaseComponent {

--- a/core/js/src/bootstrap/tooltip.ts
+++ b/core/js/src/bootstrap/tooltip.ts
@@ -58,7 +58,7 @@ const AttachmentMap: Record<string, string> = {
   TOP: 'top',
   RIGHT: isRTL() ? 'left' : 'right',
   BOTTOM: 'bottom',
-  LEFT: isRTL() ? 'right' : 'left'
+  LEFT: isRTL() ? 'right' : 'left',
 }
 
 const Default: ComponentConfig = {
@@ -76,12 +76,9 @@ const Default: ComponentConfig = {
   sanitize: true,
   sanitizeFn: null,
   selector: false,
-  template: '<div class="tooltip" role="tooltip">' +
-            '<div class="tooltip-arrow"></div>' +
-            '<div class="tooltip-inner"></div>' +
-            '</div>',
+  template: '<div class="tooltip" role="tooltip">' + '<div class="tooltip-arrow"></div>' + '<div class="tooltip-inner"></div>' + '</div>',
   title: '',
-  trigger: 'hover focus'
+  trigger: 'hover focus',
 }
 
 const DefaultType: ComponentConfigType = {
@@ -101,7 +98,7 @@ const DefaultType: ComponentConfigType = {
   selector: '(string|boolean)',
   template: 'string',
   title: '(string|element|function)',
-  trigger: 'string'
+  trigger: 'string',
 }
 
 /**
@@ -121,7 +118,7 @@ class Tooltip extends BaseComponent {
 
   constructor(element: HTMLElement | string, config?: Partial<ComponentConfig>) {
     if (typeof Popper === 'undefined') {
-      throw new TypeError('Bootstrap\'s tooltips require Popper (https://popper.js.org/docs/v2/)')
+      throw new TypeError("Bootstrap's tooltips require Popper (https://popper.js.org/docs/v2/)")
     }
 
     super(element, config)
@@ -187,9 +184,7 @@ class Tooltip extends BaseComponent {
     EventHandler.off(this._element.closest(SELECTOR_MODAL), EVENT_MODAL_HIDE, this._hideModalHandler)
 
     if (this._element.getAttribute('data-bs-original-title') || this._element.getAttribute('data-tblr-original-title')) {
-      this._element.setAttribute('title',
-        this._element.getAttribute('data-bs-original-title') ||
-        this._element.getAttribute('data-tblr-original-title') || '')
+      this._element.setAttribute('title', this._element.getAttribute('data-bs-original-title') || this._element.getAttribute('data-tblr-original-title') || '')
     }
 
     this._disposePopper()
@@ -343,7 +338,7 @@ class Tooltip extends BaseComponent {
       this._templateFactory = new TemplateFactory({
         ...this._config,
         content,
-        extraClass: this._resolvePossibleFunction(this._config.customClass)
+        extraClass: this._resolvePossibleFunction(this._config.customClass),
       })
     }
 
@@ -352,14 +347,12 @@ class Tooltip extends BaseComponent {
 
   _getContentForTemplate(): Record<string, any> {
     return {
-      [SELECTOR_TOOLTIP_INNER]: this._getTitle()
+      [SELECTOR_TOOLTIP_INNER]: this._getTitle(),
     }
   }
 
   _getTitle(): string {
-    return this._resolvePossibleFunction(this._config.title) ||
-      this._element.getAttribute('data-bs-original-title') ||
-      this._element.getAttribute('data-tblr-original-title') || ''
+    return this._resolvePossibleFunction(this._config.title) || this._element.getAttribute('data-bs-original-title') || this._element.getAttribute('data-tblr-original-title') || ''
   }
 
   _initializeOnDelegatedTarget(event: Event & { delegateTarget?: HTMLElement }): Tooltip {
@@ -405,26 +398,26 @@ class Tooltip extends BaseComponent {
         {
           name: 'flip',
           options: {
-            fallbackPlacements: this._config.fallbackPlacements
-          }
+            fallbackPlacements: this._config.fallbackPlacements,
+          },
         },
         {
           name: 'offset',
           options: {
-            offset: this._getOffset()
-          }
+            offset: this._getOffset(),
+          },
         },
         {
           name: 'preventOverflow',
           options: {
-            boundary: this._config.boundary
-          }
+            boundary: this._config.boundary,
+          },
         },
         {
           name: 'arrow',
           options: {
-            element: `.${(this.constructor as typeof Tooltip).NAME}-arrow`
-          }
+            element: `.${(this.constructor as typeof Tooltip).NAME}-arrow`,
+          },
         },
         {
           name: 'preSetPlacement',
@@ -432,15 +425,15 @@ class Tooltip extends BaseComponent {
           phase: 'beforeMain',
           fn: (data: any) => {
             this._getTipElement()!.setAttribute('data-popper-placement', data.state.placement)
-          }
-        }
-      ]
+          },
+        },
+      ],
     }
 
     const popperConfig = execute(this._config.popperConfig, [undefined, defaultBsPopperConfig])
     return {
       ...defaultBsPopperConfig,
-      ...(typeof popperConfig === 'object' && popperConfig !== null ? popperConfig : {})
+      ...(typeof popperConfig === 'object' && popperConfig !== null ? popperConfig : {}),
     }
   }
 
@@ -455,12 +448,8 @@ class Tooltip extends BaseComponent {
           context.toggle()
         })
       } else if (trigger !== TRIGGER_MANUAL) {
-        const eventIn = trigger === TRIGGER_HOVER ?
-          (this.constructor as typeof Tooltip).eventName(EVENT_MOUSEENTER) :
-          (this.constructor as typeof Tooltip).eventName(EVENT_FOCUSIN)
-        const eventOut = trigger === TRIGGER_HOVER ?
-          (this.constructor as typeof Tooltip).eventName(EVENT_MOUSELEAVE) :
-          (this.constructor as typeof Tooltip).eventName(EVENT_FOCUSOUT)
+        const eventIn = trigger === TRIGGER_HOVER ? (this.constructor as typeof Tooltip).eventName(EVENT_MOUSEENTER) : (this.constructor as typeof Tooltip).eventName(EVENT_FOCUSIN)
+        const eventOut = trigger === TRIGGER_HOVER ? (this.constructor as typeof Tooltip).eventName(EVENT_MOUSELEAVE) : (this.constructor as typeof Tooltip).eventName(EVENT_FOCUSOUT)
 
         EventHandler.on(this._element, eventIn, this._config.selector, (event: Event) => {
           const context = this._initializeOnDelegatedTarget(event)
@@ -469,8 +458,7 @@ class Tooltip extends BaseComponent {
         })
         EventHandler.on(this._element, eventOut, this._config.selector, (event: Event & { relatedTarget?: HTMLElement }) => {
           const context = this._initializeOnDelegatedTarget(event)
-          context._activeTrigger[event.type === 'focusout' ? TRIGGER_FOCUS : TRIGGER_HOVER] =
-            context._element.contains(event.relatedTarget as Node)
+          context._activeTrigger[event.type === 'focusout' ? TRIGGER_FOCUS : TRIGGER_HOVER] = context._element.contains(event.relatedTarget as Node)
 
           context._leave()
         })
@@ -550,7 +538,7 @@ class Tooltip extends BaseComponent {
 
     config = {
       ...dataAttributes,
-      ...(typeof config === 'object' && config ? config : {})
+      ...(typeof config === 'object' && config ? config : {}),
     }
     config = this._mergeConfigObj(config)
     config = this._configAfterMerge(config)
@@ -564,7 +552,7 @@ class Tooltip extends BaseComponent {
     if (typeof config.delay === 'number') {
       config.delay = {
         show: config.delay,
-        hide: config.delay
+        hide: config.delay,
       }
     }
 

--- a/core/js/src/bootstrap/util/backdrop.ts
+++ b/core/js/src/bootstrap/util/backdrop.ts
@@ -7,9 +7,7 @@
 
 import EventHandler from '../dom/event-handler.js'
 import Config from './config'
-import {
-  execute, executeAfterTransition, getElement, reflow
-} from './index'
+import { execute, executeAfterTransition, getElement, reflow } from './index'
 import type { ComponentConfig, ComponentConfigType } from '../types'
 
 const NAME = 'backdrop'
@@ -30,7 +28,7 @@ const Default: BackdropConfig = {
   clickCallback: null,
   isAnimated: false,
   isVisible: true,
-  rootElement: 'body'
+  rootElement: 'body',
 }
 
 const DefaultType: ComponentConfigType = {
@@ -38,7 +36,7 @@ const DefaultType: ComponentConfigType = {
   clickCallback: '(function|null)',
   isAnimated: 'boolean',
   isVisible: 'boolean',
-  rootElement: '(element|string)'
+  rootElement: '(element|string)',
 }
 
 class Backdrop extends Config {

--- a/core/js/src/bootstrap/util/component-functions.ts
+++ b/core/js/src/bootstrap/util/component-functions.ts
@@ -36,6 +36,4 @@ const enableDismissTrigger = (component: DismissibleComponent, method = 'hide'):
   })
 }
 
-export {
-  enableDismissTrigger
-}
+export { enableDismissTrigger }

--- a/core/js/src/bootstrap/util/config.ts
+++ b/core/js/src/bootstrap/util/config.ts
@@ -41,7 +41,7 @@ class Config {
       ...ctor.Default,
       ...(typeof jsonConfig === 'object' ? jsonConfig : {}),
       ...(isElement(element) ? Manipulator.getDataAttributes(element!) : {}),
-      ...(typeof config === 'object' ? config : {})
+      ...(typeof config === 'object' ? config : {}),
     }
   }
 
@@ -54,9 +54,7 @@ class Config {
       const valueType = isElement(value) ? 'element' : toType(value)
 
       if (!new RegExp(expectedTypes).test(valueType)) {
-        throw new TypeError(
-          `${ctor.NAME.toUpperCase()}: Option "${property}" provided type "${valueType}" but expected type "${expectedTypes}".`
-        )
+        throw new TypeError(`${ctor.NAME.toUpperCase()}: Option "${property}" provided type "${valueType}" but expected type "${expectedTypes}".`)
       }
     }
   }

--- a/core/js/src/bootstrap/util/focustrap.ts
+++ b/core/js/src/bootstrap/util/focustrap.ts
@@ -27,12 +27,12 @@ interface FocusTrapConfig {
 
 const Default: FocusTrapConfig = {
   autofocus: true,
-  trapElement: null
+  trapElement: null,
 }
 
 const DefaultType: ComponentConfigType = {
   autofocus: 'boolean',
-  trapElement: 'element'
+  trapElement: 'element',
 }
 
 class FocusTrap extends Config {

--- a/core/js/src/bootstrap/util/index.ts
+++ b/core/js/src/bootstrap/util/index.ts
@@ -22,7 +22,10 @@ const toType = (object: unknown): string => {
     return `${object}`
   }
 
-  return Object.prototype.toString.call(object).match(/\s([a-z]+)/i)![1].toLowerCase()
+  return Object.prototype.toString
+    .call(object)
+    .match(/\s([a-z]+)/i)![1]
+    .toLowerCase()
 }
 
 const getUID = (prefix: string): string => {
@@ -203,21 +206,4 @@ const getNextActiveElement = <T>(list: T[], activeElement: T, shouldGetNext: boo
   return list[Math.max(0, Math.min(index, listLength - 1))]
 }
 
-export {
-  execute,
-  executeAfterTransition,
-  findShadowRoot,
-  getElement,
-  getNextActiveElement,
-  getTransitionDurationFromElement,
-  getUID,
-  isDisabled,
-  isElement,
-  isRTL,
-  isVisible,
-  noop,
-  parseSelector,
-  reflow,
-  triggerTransitionEnd,
-  toType
-}
+export { execute, executeAfterTransition, findShadowRoot, getElement, getNextActiveElement, getTransitionDurationFromElement, getUID, isDisabled, isElement, isRTL, isVisible, noop, parseSelector, reflow, triggerTransitionEnd, toType }

--- a/core/js/src/bootstrap/util/sanitizer.ts
+++ b/core/js/src/bootstrap/util/sanitizer.ts
@@ -12,51 +12,42 @@ const ARIA_ATTRIBUTE_PATTERN = /^aria-[\w-]*$/i
 
 export const DefaultAllowlist: AllowList = {
   '*': ['class', 'dir', 'id', 'lang', 'role', ARIA_ATTRIBUTE_PATTERN],
-  a: ['target', 'href', 'title', 'rel'],
-  area: [],
-  b: [],
-  br: [],
-  col: [],
-  code: [],
-  dd: [],
-  div: [],
-  dl: [],
-  dt: [],
-  em: [],
-  hr: [],
-  h1: [],
-  h2: [],
-  h3: [],
-  h4: [],
-  h5: [],
-  h6: [],
-  i: [],
-  img: ['src', 'srcset', 'alt', 'title', 'width', 'height'],
-  li: [],
-  ol: [],
-  p: [],
-  pre: [],
-  s: [],
-  small: [],
-  span: [],
-  sub: [],
-  sup: [],
-  strong: [],
-  u: [],
-  ul: []
+  'a': ['target', 'href', 'title', 'rel'],
+  'area': [],
+  'b': [],
+  'br': [],
+  'col': [],
+  'code': [],
+  'dd': [],
+  'div': [],
+  'dl': [],
+  'dt': [],
+  'em': [],
+  'hr': [],
+  'h1': [],
+  'h2': [],
+  'h3': [],
+  'h4': [],
+  'h5': [],
+  'h6': [],
+  'i': [],
+  'img': ['src', 'srcset', 'alt', 'title', 'width', 'height'],
+  'li': [],
+  'ol': [],
+  'p': [],
+  'pre': [],
+  's': [],
+  'small': [],
+  'span': [],
+  'sub': [],
+  'sup': [],
+  'strong': [],
+  'u': [],
+  'ul': [],
 }
 // js-docs-end allow-list
 
-const uriAttributes = new Set([
-  'background',
-  'cite',
-  'href',
-  'itemtype',
-  'longdesc',
-  'poster',
-  'src',
-  'xlink:href'
-])
+const uriAttributes = new Set(['background', 'cite', 'href', 'itemtype', 'longdesc', 'poster', 'src', 'xlink:href'])
 
 const SAFE_URL_PATTERN = /^(?!javascript:)(?:[a-z0-9+.-]+:|[^&:/?#]*(?:[/?#]|$))/i
 
@@ -71,8 +62,7 @@ const allowedAttribute = (attribute: Attr, allowedAttributeList: (string | RegEx
     return true
   }
 
-  return allowedAttributeList.filter(attributeRegex => attributeRegex instanceof RegExp)
-    .some(regex => (regex as RegExp).test(attributeName))
+  return allowedAttributeList.filter((attributeRegex) => attributeRegex instanceof RegExp).some((regex) => (regex as RegExp).test(attributeName))
 }
 
 export function sanitizeHtml(unsafeHtml: string, allowList: AllowList, sanitizeFunction?: SanitizeFn): string {

--- a/core/js/src/bootstrap/util/scrollbar.ts
+++ b/core/js/src/bootstrap/util/scrollbar.ts
@@ -29,9 +29,9 @@ class ScrollBarHelper {
   hide(): void {
     const width = this.getWidth()
     this._disableOverFlow()
-    this._setElementAttributes(this._element, PROPERTY_PADDING, calculatedValue => calculatedValue + width)
-    this._setElementAttributes(SELECTOR_FIXED_CONTENT, PROPERTY_PADDING, calculatedValue => calculatedValue + width)
-    this._setElementAttributes(SELECTOR_STICKY_CONTENT, PROPERTY_MARGIN, calculatedValue => calculatedValue - width)
+    this._setElementAttributes(this._element, PROPERTY_PADDING, (calculatedValue) => calculatedValue + width)
+    this._setElementAttributes(SELECTOR_FIXED_CONTENT, PROPERTY_PADDING, (calculatedValue) => calculatedValue + width)
+    this._setElementAttributes(SELECTOR_STICKY_CONTENT, PROPERTY_MARGIN, (calculatedValue) => calculatedValue - width)
   }
 
   reset(): void {

--- a/core/js/src/bootstrap/util/swipe.ts
+++ b/core/js/src/bootstrap/util/swipe.ts
@@ -31,13 +31,13 @@ interface SwipeConfig {
 const Default: SwipeConfig = {
   endCallback: null,
   leftCallback: null,
-  rightCallback: null
+  rightCallback: null,
 }
 
 const DefaultType: ComponentConfigType = {
   endCallback: '(function|null)',
   leftCallback: '(function|null)',
-  rightCallback: '(function|null)'
+  rightCallback: '(function|null)',
 }
 
 class Swipe extends Config {
@@ -97,9 +97,7 @@ class Swipe extends Config {
   }
 
   _move(event: Event): void {
-    this._deltaX = (event as TouchEvent).touches && (event as TouchEvent).touches.length > 1 ?
-      0 :
-      (event as TouchEvent).touches[0].clientX - this._deltaX
+    this._deltaX = (event as TouchEvent).touches && (event as TouchEvent).touches.length > 1 ? 0 : (event as TouchEvent).touches[0].clientX - this._deltaX
   }
 
   _handleSwipe(): void {

--- a/core/js/src/bootstrap/util/template-factory.ts
+++ b/core/js/src/bootstrap/util/template-factory.ts
@@ -30,7 +30,7 @@ const Default: TemplateFactoryConfig = {
   html: false,
   sanitize: true,
   sanitizeFn: null,
-  template: '<div></div>'
+  template: '<div></div>',
 }
 
 const DefaultType: ComponentConfigType = {
@@ -40,12 +40,12 @@ const DefaultType: ComponentConfigType = {
   html: 'boolean',
   sanitize: 'boolean',
   sanitizeFn: '(null|function)',
-  template: 'string'
+  template: 'string',
 }
 
 const DefaultContentType: ComponentConfigType = {
   entry: '(string|element|function|null)',
-  selector: '(string|element)'
+  selector: '(string|element)',
 }
 
 class TemplateFactory extends Config {
@@ -70,7 +70,7 @@ class TemplateFactory extends Config {
 
   getContent(): unknown[] {
     return Object.values(this._config.content)
-      .map(config => this._resolvePossibleFunction(config))
+      .map((config) => this._resolvePossibleFunction(config))
       .filter(Boolean)
   }
 

--- a/core/js/src/global.d.ts
+++ b/core/js/src/global.d.ts
@@ -3,7 +3,11 @@
 interface Window {
   autosize?: (element: HTMLElement | HTMLTextAreaElement) => void
   countUp?: {
-    CountUp: new (target: HTMLElement, endVal: number, options?: any) => {
+    CountUp: new (
+      target: HTMLElement,
+      endVal: number,
+      options?: any,
+    ) => {
       error: boolean
       start: () => void
     }
@@ -11,4 +15,3 @@ interface Window {
   IMask?: new (element: HTMLElement, options: { mask: string; lazy?: boolean }) => any
   Sortable?: new (element: HTMLElement, options?: any) => any
 }
-

--- a/core/js/tests/unit/alert.spec.ts
+++ b/core/js/tests/unit/alert.spec.ts
@@ -36,11 +36,7 @@ describe('Alert', () => {
 
   describe('data-api', () => {
     it('should close an alert without instantiating manually', () => {
-      fixtureEl.innerHTML = [
-        '<div class="alert">',
-        '  <button type="button" data-bs-dismiss="alert">x</button>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="alert">', '  <button type="button" data-bs-dismiss="alert">x</button>', '</div>'].join('')
 
       const button = document.querySelector('button')!
       button.click()
@@ -48,11 +44,7 @@ describe('Alert', () => {
     })
 
     it('should close an alert with parent selector', () => {
-      fixtureEl.innerHTML = [
-        '<div class="alert">',
-        '  <button type="button" data-bs-target=".alert" data-bs-dismiss="alert">x</button>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="alert">', '  <button type="button" data-bs-target=".alert" data-bs-dismiss="alert">x</button>', '</div>'].join('')
 
       const button = document.querySelector('button')!
       button.click()
@@ -60,11 +52,7 @@ describe('Alert', () => {
     })
 
     it('should close an alert via data-tblr-dismiss', () => {
-      fixtureEl.innerHTML = [
-        '<div class="alert">',
-        '  <button type="button" data-tblr-dismiss="alert">x</button>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="alert">', '  <button type="button" data-tblr-dismiss="alert">x</button>', '</div>'].join('')
 
       const button = document.querySelector('button')!
       button.click()
@@ -72,11 +60,7 @@ describe('Alert', () => {
     })
 
     it('should close an alert via data-tblr-dismiss with data-tblr-target', () => {
-      fixtureEl.innerHTML = [
-        '<div class="alert">',
-        '  <button type="button" data-tblr-target=".alert" data-tblr-dismiss="alert">x</button>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="alert">', '  <button type="button" data-tblr-target=".alert" data-tblr-dismiss="alert">x</button>', '</div>'].join('')
 
       const button = document.querySelector('button')!
       button.click()
@@ -86,7 +70,7 @@ describe('Alert', () => {
 
   describe('close', () => {
     it('should close an alert', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<div class="alert"></div>'
 
         const alertEl = document.querySelector('.alert')!
@@ -102,7 +86,7 @@ describe('Alert', () => {
     })
 
     it('should close alert with fade class', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<div class="alert fade"></div>'
 
         const alertEl = document.querySelector('.alert')!
@@ -118,13 +102,13 @@ describe('Alert', () => {
     })
 
     it('should not remove alert if close event is prevented', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<div class="alert"></div>'
 
         const alertEl = document.querySelector('.alert')!
         const alert = new Alert(alertEl)
 
-        alertEl.addEventListener('close.bs.alert', event => {
+        alertEl.addEventListener('close.bs.alert', (event) => {
           event.preventDefault()
           setTimeout(() => {
             expect(document.querySelector('.alert')).not.toBeNull()

--- a/core/js/tests/unit/button.spec.ts
+++ b/core/js/tests/unit/button.spec.ts
@@ -37,10 +37,7 @@ describe('Button', () => {
 
   describe('data-api', () => {
     it('should toggle active class on click', () => {
-      fixtureEl.innerHTML = [
-        '<button class="btn" data-bs-toggle="button">btn</button>',
-        '<button class="btn testParent" data-bs-toggle="button"><div class="test"></div></button>'
-      ].join('')
+      fixtureEl.innerHTML = ['<button class="btn" data-bs-toggle="button">btn</button>', '<button class="btn testParent" data-bs-toggle="button"><div class="test"></div></button>'].join('')
 
       const btn = fixtureEl.querySelector('.btn') as HTMLElement
       const divTest = fixtureEl.querySelector('.test') as HTMLElement

--- a/core/js/tests/unit/carousel.spec.ts
+++ b/core/js/tests/unit/carousel.spec.ts
@@ -61,16 +61,8 @@ describe('Carousel', () => {
     })
 
     it('should go to next item on right arrow key', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div id="myCarousel" class="carousel slide">',
-          '  <div class="carousel-inner">',
-          '    <div class="carousel-item active">item 1</div>',
-          '    <div id="item2" class="carousel-item">item 2</div>',
-          '    <div class="carousel-item">item 3</div>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div class="carousel-item active">item 1</div>', '    <div id="item2" class="carousel-item">item 2</div>', '    <div class="carousel-item">item 3</div>', '  </div>', '</div>'].join('')
 
         const carouselEl = fixtureEl.querySelector('#myCarousel')!
         const carousel = new Carousel(carouselEl, { keyboard: true })
@@ -87,16 +79,8 @@ describe('Carousel', () => {
     })
 
     it('should go to previous item on left arrow key', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div id="myCarousel" class="carousel slide">',
-          '  <div class="carousel-inner">',
-          '    <div id="item1" class="carousel-item">item 1</div>',
-          '    <div class="carousel-item active">item 2</div>',
-          '    <div class="carousel-item">item 3</div>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div id="item1" class="carousel-item">item 1</div>', '    <div class="carousel-item active">item 2</div>', '    <div class="carousel-item">item 3</div>', '  </div>', '</div>'].join('')
 
         const carouselEl = fixtureEl.querySelector('#myCarousel')!
         const carousel = new Carousel(carouselEl, { keyboard: true })
@@ -113,14 +97,7 @@ describe('Carousel', () => {
     })
 
     it('should not prevent keydown for non-arrow keys', () => {
-      fixtureEl.innerHTML = [
-        '<div id="myCarousel" class="carousel slide">',
-        '  <div class="carousel-inner">',
-        '    <div class="carousel-item active">item 1</div>',
-        '    <div class="carousel-item">item 2</div>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div class="carousel-item active">item 1</div>', '    <div class="carousel-item">item 2</div>', '  </div>', '</div>'].join('')
 
       const carouselEl = fixtureEl.querySelector('#myCarousel')!
       new Carousel(carouselEl, { keyboard: true })
@@ -133,14 +110,7 @@ describe('Carousel', () => {
     })
 
     it('should ignore keyboard in input/textarea', () => {
-      fixtureEl.innerHTML = [
-        '<div id="myCarousel" class="carousel slide">',
-        '  <div class="carousel-inner">',
-        '    <div class="carousel-item active"><input type="text"></div>',
-        '    <div class="carousel-item">item 2</div>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div class="carousel-item active"><input type="text"></div>', '    <div class="carousel-item">item 2</div>', '  </div>', '</div>'].join('')
 
       const carouselEl = fixtureEl.querySelector('#myCarousel')!
       const carousel = new Carousel(carouselEl, { keyboard: true })
@@ -172,15 +142,8 @@ describe('Carousel', () => {
 
   describe('next', () => {
     it('should slide to next item', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div id="myCarousel" class="carousel slide">',
-          '  <div class="carousel-inner">',
-          '    <div class="carousel-item active">item 1</div>',
-          '    <div id="item2" class="carousel-item">item 2</div>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div class="carousel-item active">item 1</div>', '    <div id="item2" class="carousel-item">item 2</div>', '  </div>', '</div>'].join('')
 
         const carouselEl = fixtureEl.querySelector('#myCarousel')!
         const carousel = new Carousel(carouselEl)
@@ -199,14 +162,7 @@ describe('Carousel', () => {
   describe('prev', () => {
     it('should stay at start when wrap is false', () => {
       return new Promise<void>((resolve, reject) => {
-        fixtureEl.innerHTML = [
-          '<div id="myCarousel" class="carousel slide">',
-          '  <div class="carousel-inner">',
-          '    <div id="one" class="carousel-item active"></div>',
-          '    <div id="two" class="carousel-item"></div>',
-          '  </div>',
-          '</div>'
-        ].join('')
+        fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div id="one" class="carousel-item active"></div>', '    <div id="two" class="carousel-item"></div>', '  </div>', '</div>'].join('')
 
         const carouselEl = fixtureEl.querySelector('#myCarousel')!
         const carousel = new Carousel(carouselEl, { wrap: false })
@@ -255,16 +211,8 @@ describe('Carousel', () => {
 
   describe('to', () => {
     it('should go to specific index', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div id="myCarousel" class="carousel slide">',
-          '  <div class="carousel-inner">',
-          '    <div class="carousel-item active">item 1</div>',
-          '    <div id="item2" class="carousel-item">item 2</div>',
-          '    <div id="item3" class="carousel-item">item 3</div>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div class="carousel-item active">item 1</div>', '    <div id="item2" class="carousel-item">item 2</div>', '    <div id="item3" class="carousel-item">item 3</div>', '  </div>', '</div>'].join('')
 
         const carouselEl = fixtureEl.querySelector('#myCarousel')!
         const carousel = new Carousel(carouselEl)
@@ -280,14 +228,7 @@ describe('Carousel', () => {
     })
 
     it('should ignore invalid index', () => {
-      fixtureEl.innerHTML = [
-        '<div id="myCarousel" class="carousel slide">',
-        '  <div class="carousel-inner">',
-        '    <div class="carousel-item active">item 1</div>',
-        '    <div class="carousel-item">item 2</div>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div class="carousel-item active">item 1</div>', '    <div class="carousel-item">item 2</div>', '  </div>', '</div>'].join('')
 
       const carouselEl = fixtureEl.querySelector('#myCarousel')!
       const carousel = new Carousel(carouselEl)
@@ -352,14 +293,7 @@ describe('Carousel', () => {
 
   describe('_updateInterval', () => {
     it('should use data-bs-interval from active element', () => {
-      fixtureEl.innerHTML = [
-        '<div id="myCarousel" class="carousel slide">',
-        '  <div class="carousel-inner">',
-        '    <div class="carousel-item active" data-bs-interval="2000">item 1</div>',
-        '    <div class="carousel-item">item 2</div>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div class="carousel-item active" data-bs-interval="2000">item 1</div>', '    <div class="carousel-item">item 2</div>', '  </div>', '</div>'].join('')
 
       const carouselEl = fixtureEl.querySelector('#myCarousel')!
       const carousel = new Carousel(carouselEl)
@@ -369,14 +303,7 @@ describe('Carousel', () => {
     })
 
     it('should use data-tblr-interval from active element', () => {
-      fixtureEl.innerHTML = [
-        '<div id="myCarousel" class="carousel slide">',
-        '  <div class="carousel-inner">',
-        '    <div class="carousel-item active" data-tblr-interval="3000">item 1</div>',
-        '    <div class="carousel-item">item 2</div>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div class="carousel-item active" data-tblr-interval="3000">item 1</div>', '    <div class="carousel-item">item 2</div>', '  </div>', '</div>'].join('')
 
       const carouselEl = fixtureEl.querySelector('#myCarousel')!
       const carousel = new Carousel(carouselEl)
@@ -386,13 +313,7 @@ describe('Carousel', () => {
     })
 
     it('should fall back to defaultInterval if no data-interval', () => {
-      fixtureEl.innerHTML = [
-        '<div id="myCarousel" class="carousel slide">',
-        '  <div class="carousel-inner">',
-        '    <div class="carousel-item active">item 1</div>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div class="carousel-item active">item 1</div>', '  </div>', '</div>'].join('')
 
       const carouselEl = fixtureEl.querySelector('#myCarousel')!
       const carousel = new Carousel(carouselEl)
@@ -414,7 +335,7 @@ describe('Carousel', () => {
         '    <div class="carousel-item active">item 1</div>',
         '    <div class="carousel-item">item 2</div>',
         '  </div>',
-        '</div>'
+        '</div>',
       ].join('')
 
       const carouselEl = fixtureEl.querySelector('#myCarousel')!
@@ -439,7 +360,7 @@ describe('Carousel', () => {
         '    <div class="carousel-item active">item 1</div>',
         '    <div class="carousel-item">item 2</div>',
         '  </div>',
-        '</div>'
+        '</div>',
       ].join('')
 
       const carouselEl = fixtureEl.querySelector('#myCarousel')!
@@ -453,13 +374,7 @@ describe('Carousel', () => {
     })
 
     it('should skip if no indicators element', () => {
-      fixtureEl.innerHTML = [
-        '<div id="myCarousel" class="carousel slide">',
-        '  <div class="carousel-inner">',
-        '    <div class="carousel-item active">item 1</div>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div class="carousel-item active">item 1</div>', '  </div>', '</div>'].join('')
 
       const carouselEl = fixtureEl.querySelector('#myCarousel')!
       const carousel = new Carousel(carouselEl)
@@ -493,16 +408,8 @@ describe('Carousel', () => {
 
   describe('wrap', () => {
     it('should wrap from end to start', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div id="myCarousel" class="carousel slide">',
-          '  <div class="carousel-inner">',
-          '    <div id="one" class="carousel-item active"></div>',
-          '    <div id="two" class="carousel-item"></div>',
-          '    <div id="three" class="carousel-item"></div>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div id="myCarousel" class="carousel slide">', '  <div class="carousel-inner">', '    <div id="one" class="carousel-item active"></div>', '    <div id="two" class="carousel-item"></div>', '    <div id="three" class="carousel-item"></div>', '  </div>', '</div>'].join('')
 
         const carouselEl = fixtureEl.querySelector('#myCarousel')!
         const carousel = new Carousel(carouselEl, { wrap: true })
@@ -562,7 +469,7 @@ describe('Carousel', () => {
     })
 
     it('should navigate via data-tblr-slide="next"', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<div id="myCarousel" class="carousel slide">',
           '  <div class="carousel-inner">',
@@ -570,7 +477,7 @@ describe('Carousel', () => {
           '    <div id="item2" class="carousel-item">item 2</div>',
           '  </div>',
           '  <button data-tblr-slide="next" data-bs-target="#myCarousel">Next</button>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const carouselEl = fixtureEl.querySelector('#myCarousel')!
@@ -586,7 +493,7 @@ describe('Carousel', () => {
     })
 
     it('should navigate via data-tblr-slide="prev"', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<div id="myCarousel" class="carousel slide">',
           '  <div class="carousel-inner">',
@@ -594,7 +501,7 @@ describe('Carousel', () => {
           '    <div class="carousel-item active">item 2</div>',
           '  </div>',
           '  <button data-tblr-slide="prev" data-bs-target="#myCarousel">Prev</button>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const carouselEl = fixtureEl.querySelector('#myCarousel')!
@@ -610,7 +517,7 @@ describe('Carousel', () => {
     })
 
     it('should handle data-tblr-slide-to in indicators', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<div id="myCarousel" class="carousel slide">',
           '  <div class="carousel-indicators">',
@@ -621,7 +528,7 @@ describe('Carousel', () => {
           '    <div class="carousel-item active">item 1</div>',
           '    <div id="item2" class="carousel-item">item 2</div>',
           '  </div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const carouselEl = fixtureEl.querySelector('#myCarousel')!

--- a/core/js/tests/unit/collapse.spec.ts
+++ b/core/js/tests/unit/collapse.spec.ts
@@ -46,14 +46,7 @@ describe('Collapse', () => {
     })
 
     it('should allow DOM element in parent config', () => {
-      fixtureEl.innerHTML = [
-        '<div class="my-collapse">',
-        '  <div class="item">',
-        '    <a data-bs-toggle="collapse" href="#">Toggle</a>',
-        '    <div class="collapse">Lorem ipsum</div>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="my-collapse">', '  <div class="item">', '    <a data-bs-toggle="collapse" href="#">Toggle</a>', '    <div class="collapse">Lorem ipsum</div>', '  </div>', '</div>'].join('')
 
       const collapseEl = fixtureEl.querySelector('div.collapse')!
       const myCollapseEl = fixtureEl.querySelector('.my-collapse')!
@@ -63,14 +56,7 @@ describe('Collapse', () => {
     })
 
     it('should allow string selector in parent config', () => {
-      fixtureEl.innerHTML = [
-        '<div class="my-collapse">',
-        '  <div class="item">',
-        '    <a data-bs-toggle="collapse" href="#">Toggle</a>',
-        '    <div class="collapse">Lorem ipsum</div>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="my-collapse">', '  <div class="item">', '    <a data-bs-toggle="collapse" href="#">Toggle</a>', '    <div class="collapse">Lorem ipsum</div>', '  </div>', '</div>'].join('')
 
       const collapseEl = fixtureEl.querySelector('div.collapse')!
       const myCollapseEl = fixtureEl.querySelector('.my-collapse')!
@@ -104,7 +90,7 @@ describe('Collapse', () => {
     })
 
     it('should collapse children with parent', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<div class="my-collapse">',
           '  <div class="item">',
@@ -115,15 +101,14 @@ describe('Collapse', () => {
           '    <a data-bs-toggle="collapse" href="#">Toggle 2</a>',
           '    <div id="collapse2" class="collapse">Lorem ipsum 2</div>',
           '  </div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const parent = fixtureEl.querySelector('.my-collapse')!
         const collapseEl1 = fixtureEl.querySelector('#collapse1')!
         const collapseEl2 = fixtureEl.querySelector('#collapse2')!
 
-        const collapseList = Array.from(fixtureEl.querySelectorAll('.collapse'))
-          .map(el => new Collapse(el, { parent, toggle: false }))
+        const collapseList = Array.from(fixtureEl.querySelectorAll('.collapse')).map((el) => new Collapse(el, { parent, toggle: false }))
 
         collapseEl2.addEventListener('shown.bs.collapse', () => {
           expect(collapseEl2.classList.contains('show')).toBe(true)
@@ -162,7 +147,7 @@ describe('Collapse', () => {
     })
 
     it('should show a collapsed element', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<div class="collapse" style="height: 0px;"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')!
@@ -183,7 +168,7 @@ describe('Collapse', () => {
     })
 
     it('should show a collapsed element on width', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<div class="collapse collapse-horizontal" style="width: 0px;"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')!
@@ -204,15 +189,8 @@ describe('Collapse', () => {
     })
 
     it('should collapse only the first collapse', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="card" id="accordion1">',
-          '  <div id="collapse1" class="collapse"></div>',
-          '</div>',
-          '<div class="card" id="accordion2">',
-          '  <div id="collapse2" class="collapse show"></div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="card" id="accordion1">', '  <div id="collapse1" class="collapse"></div>', '</div>', '<div class="card" id="accordion2">', '  <div id="collapse2" class="collapse show"></div>', '</div>'].join('')
 
         const el1 = fixtureEl.querySelector('#collapse1')!
         const el2 = fixtureEl.querySelector('#collapse2')!
@@ -229,7 +207,7 @@ describe('Collapse', () => {
     })
 
     it('should handle toggling children siblings in accordion', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<div id="parentGroup" class="accordion">',
           '  <div class="accordion-header">',
@@ -249,7 +227,7 @@ describe('Collapse', () => {
           '      </div>',
           '    </div>',
           '  </div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const el = (s: string) => fixtureEl.querySelector(s) as HTMLElement
@@ -282,12 +260,7 @@ describe('Collapse', () => {
     })
 
     it('should not show if active children are transitioning', () => {
-      fixtureEl.innerHTML = [
-        '<div id="accordion">',
-        '  <div id="collapse1" class="collapse show" data-bs-parent="#accordion"></div>',
-        '  <div id="collapse2" class="collapse" data-bs-parent="#accordion"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="accordion">', '  <div id="collapse1" class="collapse show" data-bs-parent="#accordion"></div>', '  <div id="collapse2" class="collapse" data-bs-parent="#accordion"></div>', '</div>'].join('')
 
       const el1 = fixtureEl.querySelector('#collapse1')!
       const el2 = fixtureEl.querySelector('#collapse2')!
@@ -310,7 +283,7 @@ describe('Collapse', () => {
         const collapseEl = fixtureEl.querySelector('div')!
         const collapse = new Collapse(collapseEl, { toggle: false })
 
-        collapseEl.addEventListener('show.bs.collapse', event => {
+        collapseEl.addEventListener('show.bs.collapse', (event) => {
           event.preventDefault()
           setTimeout(() => {
             resolve()
@@ -352,7 +325,7 @@ describe('Collapse', () => {
     })
 
     it('should hide a collapse element', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<div class="collapse show"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')!
@@ -375,7 +348,7 @@ describe('Collapse', () => {
         const collapseEl = fixtureEl.querySelector('div')!
         const collapse = new Collapse(collapseEl, { toggle: false })
 
-        collapseEl.addEventListener('hide.bs.collapse', event => {
+        collapseEl.addEventListener('hide.bs.collapse', (event) => {
           event.preventDefault()
           setTimeout(resolve, 10)
         })
@@ -406,20 +379,15 @@ describe('Collapse', () => {
 
   describe('data-api', () => {
     it('should prevent url change on nested elements', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<a role="button" data-bs-toggle="collapse" class="collapsed" href="#collapse">',
-          '  <span id="nested"></span>',
-          '</a>',
-          '<div id="collapse" class="collapse"></div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<a role="button" data-bs-toggle="collapse" class="collapsed" href="#collapse">', '  <span id="nested"></span>', '</a>', '<div id="collapse" class="collapse"></div>'].join('')
 
         const triggerEl = fixtureEl.querySelector('a')!
         const nestedTriggerEl = fixtureEl.querySelector('#nested')!
 
         const spy = vi.spyOn(Event.prototype, 'preventDefault')
 
-        triggerEl.addEventListener('click', event => {
+        triggerEl.addEventListener('click', (event) => {
           expect((event.target as Element).isEqualNode(nestedTriggerEl)).toBe(true)
           expect(spy).toHaveBeenCalled()
           resolve()
@@ -430,12 +398,8 @@ describe('Collapse', () => {
     })
 
     it('should show multiple collapsed elements', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<a role="button" data-bs-toggle="collapse" class="collapsed" href=".multi"></a>',
-          '<div id="collapse1" class="collapse multi"></div>',
-          '<div id="collapse2" class="collapse multi"></div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<a role="button" data-bs-toggle="collapse" class="collapsed" href=".multi"></a>', '<div id="collapse1" class="collapse multi"></div>', '<div id="collapse2" class="collapse multi"></div>'].join('')
 
         const trigger = fixtureEl.querySelector('a')!
         const collapse1 = fixtureEl.querySelector('#collapse1')!
@@ -454,12 +418,8 @@ describe('Collapse', () => {
     })
 
     it('should hide multiple collapsed elements', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<a role="button" data-bs-toggle="collapse" href=".multi"></a>',
-          '<div id="collapse1" class="collapse multi show"></div>',
-          '<div id="collapse2" class="collapse multi show"></div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<a role="button" data-bs-toggle="collapse" href=".multi"></a>', '<div id="collapse1" class="collapse multi show"></div>', '<div id="collapse2" class="collapse multi show"></div>'].join('')
 
         const trigger = fixtureEl.querySelector('a')!
         const collapse1 = fixtureEl.querySelector('#collapse1')!
@@ -478,11 +438,8 @@ describe('Collapse', () => {
     })
 
     it('should show collapse via data-tblr-target', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<a role="button" data-bs-toggle="collapse" class="collapsed" data-tblr-target="#test1"></a>',
-          '<div id="test1" class="collapse"></div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<a role="button" data-bs-toggle="collapse" class="collapsed" data-tblr-target="#test1"></a>', '<div id="test1" class="collapse"></div>'].join('')
 
         const trigger = fixtureEl.querySelector('a') as HTMLElement
         const collapseEl = fixtureEl.querySelector('#test1')!
@@ -499,11 +456,8 @@ describe('Collapse', () => {
     })
 
     it('should hide collapse via data-tblr-target', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<a role="button" data-bs-toggle="collapse" data-tblr-target="#test1"></a>',
-          '<div id="test1" class="collapse show"></div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<a role="button" data-bs-toggle="collapse" data-tblr-target="#test1"></a>', '<div id="test1" class="collapse show"></div>'].join('')
 
         const trigger = fixtureEl.querySelector('a') as HTMLElement
         const collapseEl = fixtureEl.querySelector('#test1')!
@@ -520,12 +474,8 @@ describe('Collapse', () => {
     })
 
     it('should remove collapsed class from trigger on show', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<a id="link1" role="button" data-bs-toggle="collapse" class="collapsed" href="#" data-bs-target="#test1"></a>',
-          '<a id="link2" role="button" data-bs-toggle="collapse" class="collapsed" href="#" data-bs-target="#test1"></a>',
-          '<div id="test1"></div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<a id="link1" role="button" data-bs-toggle="collapse" class="collapsed" href="#" data-bs-target="#test1"></a>', '<a id="link2" role="button" data-bs-toggle="collapse" class="collapsed" href="#" data-bs-target="#test1"></a>', '<div id="test1"></div>'].join('')
 
         const link1 = fixtureEl.querySelector('#link1')!
         const link2 = fixtureEl.querySelector('#link2')!
@@ -544,12 +494,8 @@ describe('Collapse', () => {
     })
 
     it('should add collapsed class to trigger on hide', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<a id="link1" role="button" data-bs-toggle="collapse" href="#" data-bs-target="#test1"></a>',
-          '<a id="link2" role="button" data-bs-toggle="collapse" href="#" data-bs-target="#test1"></a>',
-          '<div id="test1" class="show"></div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<a id="link1" role="button" data-bs-toggle="collapse" href="#" data-bs-target="#test1"></a>', '<a id="link2" role="button" data-bs-toggle="collapse" href="#" data-bs-target="#test1"></a>', '<div id="test1" class="show"></div>'].join('')
 
         const link1 = fixtureEl.querySelector('#link1')!
         const link2 = fixtureEl.querySelector('#link2')!
@@ -568,7 +514,7 @@ describe('Collapse', () => {
     })
 
     it('should allow accordion with non-card children', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<div id="accordion">',
           '  <div class="item">',
@@ -579,7 +525,7 @@ describe('Collapse', () => {
           '    <a id="linkTriggerTwo" data-bs-toggle="collapse" href="#collapseTwo"></a>',
           '    <div id="collapseTwo" class="collapse show" data-bs-parent="#accordion"></div>',
           '  </div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const trigger = fixtureEl.querySelector('#linkTrigger') as HTMLElement
@@ -605,11 +551,8 @@ describe('Collapse', () => {
     })
 
     it('should not prevent event for input', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<input type="checkbox" data-bs-toggle="collapse" data-bs-target="#collapsediv1">',
-          '<div id="collapsediv1"></div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<input type="checkbox" data-bs-toggle="collapse" data-bs-target="#collapsediv1">', '<div id="collapsediv1"></div>'].join('')
 
         const target = fixtureEl.querySelector('input') as HTMLInputElement
         const collapseEl = fixtureEl.querySelector('#collapsediv1')!
@@ -625,7 +568,7 @@ describe('Collapse', () => {
     })
 
     it('should allow accordion with nested elements', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<div id="accordion">',
           '  <div class="row">',
@@ -642,7 +585,7 @@ describe('Collapse', () => {
           '      </div>',
           '    </div>',
           '  </div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const triggerEl = fixtureEl.querySelector('#linkTrigger') as HTMLElement
@@ -678,7 +621,7 @@ describe('Collapse', () => {
     })
 
     it('should collapse accordion children but not nested accordion', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<div id="accordion">',
           '  <div class="item">',
@@ -696,7 +639,7 @@ describe('Collapse', () => {
           '    <a id="linkTriggerTwo" data-bs-toggle="collapse" href="#collapseTwo"></a>',
           '    <div id="collapseTwo" data-bs-parent="#accordion" class="collapse show"></div>',
           '  </div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const trigger = fixtureEl.querySelector('#linkTrigger') as HTMLElement
@@ -798,11 +741,8 @@ describe('Collapse', () => {
 
   describe('data-tblr-toggle', () => {
     it('should show collapse via data-tblr-toggle="collapse"', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<button data-tblr-toggle="collapse" data-bs-target="#test1">Toggle</button>',
-          '<div id="test1" class="collapse">Content</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<button data-tblr-toggle="collapse" data-bs-target="#test1">Toggle</button>', '<div id="test1" class="collapse">Content</div>'].join('')
 
         const target = fixtureEl.querySelector('#test1')!
         const btn = fixtureEl.querySelector('[data-tblr-toggle="collapse"]') as HTMLElement
@@ -817,11 +757,8 @@ describe('Collapse', () => {
     })
 
     it('should hide collapse via data-tblr-toggle="collapse"', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<button data-tblr-toggle="collapse" data-bs-target="#test1">Toggle</button>',
-          '<div id="test1" class="collapse show">Content</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<button data-tblr-toggle="collapse" data-bs-target="#test1">Toggle</button>', '<div id="test1" class="collapse show">Content</div>'].join('')
 
         const target = fixtureEl.querySelector('#test1')!
         const btn = fixtureEl.querySelector('[data-tblr-toggle="collapse"]') as HTMLElement
@@ -836,11 +773,8 @@ describe('Collapse', () => {
     })
 
     it('should show collapse via data-tblr-toggle with data-tblr-target', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<button data-tblr-toggle="collapse" data-tblr-target="#test1">Toggle</button>',
-          '<div id="test1" class="collapse">Content</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<button data-tblr-toggle="collapse" data-tblr-target="#test1">Toggle</button>', '<div id="test1" class="collapse">Content</div>'].join('')
 
         const target = fixtureEl.querySelector('#test1')!
         const btn = fixtureEl.querySelector('[data-tblr-toggle="collapse"]') as HTMLElement

--- a/core/js/tests/unit/dom/data.spec.ts
+++ b/core/js/tests/unit/dom/data.spec.ts
@@ -95,9 +95,7 @@ describe('Data', () => {
     Data.set(div, TEST_KEY, { ...TEST_DATA })
     Data.set(div, UNKNOWN_KEY, { ...TEST_DATA })
 
-    expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining(TEST_KEY)
-    )
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining(TEST_KEY))
 
     spy.mockRestore()
   })

--- a/core/js/tests/unit/dom/event-handler.spec.ts
+++ b/core/js/tests/unit/dom/event-handler.spec.ts
@@ -222,7 +222,7 @@ describe('EventHandler', () => {
 
     it('should allow preventing the default action', () => {
       EventHandler.on(div, 'show.bs.test', (event: unknown) => {
-        (event as Event).preventDefault()
+        ;(event as Event).preventDefault()
       })
 
       const evt = EventHandler.trigger(div, 'show.bs.test')
@@ -351,7 +351,7 @@ describe('EventHandler', () => {
 
       const mouseoverEvent = new MouseEvent('mouseover', {
         bubbles: true,
-        relatedTarget: document.body
+        relatedTarget: document.body,
       })
       div.dispatchEvent(mouseoverEvent)
 
@@ -368,7 +368,7 @@ describe('EventHandler', () => {
 
       const mouseoverEvent = new MouseEvent('mouseover', {
         bubbles: true,
-        relatedTarget: btn
+        relatedTarget: btn,
       })
       div.dispatchEvent(mouseoverEvent)
 
@@ -384,7 +384,7 @@ describe('EventHandler', () => {
 
       const mouseoverEvent = new MouseEvent('mouseover', {
         bubbles: true,
-        relatedTarget: null
+        relatedTarget: null,
       })
       div.dispatchEvent(mouseoverEvent)
 

--- a/core/js/tests/unit/dom/selector-engine.spec.ts
+++ b/core/js/tests/unit/dom/selector-engine.spec.ts
@@ -6,7 +6,7 @@ vi.mock('../../../src/bootstrap/util/index', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../src/bootstrap/util/index')>()
   return {
     ...actual,
-    isVisible: () => true
+    isVisible: () => true,
   }
 })
 
@@ -72,7 +72,7 @@ describe('SelectorEngine', () => {
       const result = SelectorEngine.children(parent, 'span')
 
       expect(result).toHaveLength(2)
-      result.forEach(el => expect(el.tagName).toBe('SPAN'))
+      result.forEach((el) => expect(el.tagName).toBe('SPAN'))
     })
 
     it('should return an empty array when no children match', () => {
@@ -167,7 +167,7 @@ describe('SelectorEngine', () => {
       const result = SelectorEngine.focusableChildren(parent)
 
       expect(result.length).toBeGreaterThanOrEqual(1)
-      const tags = result.map(el => el.tagName)
+      const tags = result.map((el) => el.tagName)
       expect(tags).toContain('BUTTON')
       expect(tags).toContain('INPUT')
       expect(tags).not.toContain('SPAN')
@@ -178,7 +178,7 @@ describe('SelectorEngine', () => {
       const parent = fixtureEl.querySelector('div')!
 
       const result = SelectorEngine.focusableChildren(parent)
-      const texts = result.map(el => el.textContent)
+      const texts = result.map((el) => el.textContent)
 
       expect(texts).toContain('Yes')
       expect(texts).not.toContain('No')
@@ -189,7 +189,7 @@ describe('SelectorEngine', () => {
       const parent = fixtureEl.querySelector('div')!
 
       const result = SelectorEngine.focusableChildren(parent)
-      const texts = result.map(el => el.textContent)
+      const texts = result.map((el) => el.textContent)
 
       expect(texts).toContain('Visible')
       expect(texts).not.toContain('Hidden')

--- a/core/js/tests/unit/dropdown.spec.ts
+++ b/core/js/tests/unit/dropdown.spec.ts
@@ -6,8 +6,8 @@ vi.mock('@popperjs/core', () => ({
   createPopper: vi.fn(() => ({
     destroy: vi.fn(),
     update: vi.fn(),
-    setOptions: vi.fn()
-  }))
+    setOptions: vi.fn(),
+  })),
 }))
 
 describe('Dropdown', () => {
@@ -48,14 +48,7 @@ describe('Dropdown', () => {
 
   describe('constructor', () => {
     it('should accept element as CSS selector or DOM element', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu">',
-        '    <a class="dropdown-item" href="#">Link</a>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
       const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdownBySelector = new Dropdown('[data-bs-toggle="dropdown"]')
@@ -66,14 +59,7 @@ describe('Dropdown', () => {
     })
 
     it('should create offset from string data attribute', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" data-bs-offset="10,20">Dropdown</button>',
-        '  <div class="dropdown-menu">',
-        '    <a class="dropdown-item" href="#">Link</a>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" data-bs-offset="10,20">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
       const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btnDropdown)
@@ -82,18 +68,11 @@ describe('Dropdown', () => {
     })
 
     it('should allow popperConfig override', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu">',
-        '    <a class="dropdown-item" href="#">Link</a>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
       const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btnDropdown, {
-        popperConfig: { placement: 'left' }
+        popperConfig: { placement: 'left' },
       })
 
       const popperConfig = dropdown._getPopperConfig()
@@ -103,15 +82,8 @@ describe('Dropdown', () => {
 
   describe('toggle', () => {
     it('should toggle a dropdown', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btnDropdown)
@@ -127,15 +99,8 @@ describe('Dropdown', () => {
     })
 
     it('should toggle dropup', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropup">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropup">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btnDropdown)
@@ -150,15 +115,8 @@ describe('Dropdown', () => {
     })
 
     it('should toggle dropend', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropend">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropend">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btnDropdown)
@@ -173,15 +131,8 @@ describe('Dropdown', () => {
     })
 
     it('should toggle dropstart', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropstart">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropstart">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btnDropdown)
@@ -198,15 +149,8 @@ describe('Dropdown', () => {
 
   describe('show', () => {
     it('should show a dropdown', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btnDropdown)
@@ -221,14 +165,7 @@ describe('Dropdown', () => {
     })
 
     it('should not show if disabled', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" disabled>Dropdown</button>',
-        '  <div class="dropdown-menu">',
-        '    <a class="dropdown-item" href="#">Link</a>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" disabled>Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
       const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btnDropdown)
@@ -238,14 +175,7 @@ describe('Dropdown', () => {
     })
 
     it('should not show if already shown', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle show" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu show">',
-        '    <a class="dropdown-item" href="#">Link</a>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle show" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu show">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
       const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btnDropdown)
@@ -258,20 +188,13 @@ describe('Dropdown', () => {
     })
 
     it('should not show if show event is prevented', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btnDropdown)
 
-        btnDropdown.addEventListener('show.bs.dropdown', ev => {
+        btnDropdown.addEventListener('show.bs.dropdown', (ev) => {
           ev.preventDefault()
           setTimeout(() => {
             expect(btnDropdown.classList.contains('show')).toBe(false)
@@ -286,15 +209,8 @@ describe('Dropdown', () => {
 
   describe('hide', () => {
     it('should hide a dropdown', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btnDropdown)
@@ -314,14 +230,7 @@ describe('Dropdown', () => {
     })
 
     it('should not hide if not shown', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu">',
-        '    <a class="dropdown-item" href="#">Link</a>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
       const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btnDropdown)
@@ -334,21 +243,14 @@ describe('Dropdown', () => {
     })
 
     it('should not hide if hide event is prevented', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btnDropdown)
 
         btnDropdown.addEventListener('shown.bs.dropdown', () => {
-          btnDropdown.addEventListener('hide.bs.dropdown', ev => {
+          btnDropdown.addEventListener('hide.bs.dropdown', (ev) => {
             ev.preventDefault()
             setTimeout(() => {
               expect(btnDropdown.classList.contains('show')).toBe(true)
@@ -365,14 +267,7 @@ describe('Dropdown', () => {
 
   describe('dispose', () => {
     it('should dispose a dropdown', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu">',
-        '    <a class="dropdown-item" href="#">Link</a>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
       const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btnDropdown)
@@ -387,15 +282,8 @@ describe('Dropdown', () => {
 
   describe('update', () => {
     it('should call update on popper', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btnDropdown)
@@ -417,12 +305,7 @@ describe('Dropdown', () => {
     })
 
     it('should return dropdown instance', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btnDropdown)
@@ -433,12 +316,7 @@ describe('Dropdown', () => {
 
   describe('getOrCreateInstance', () => {
     it('should return dropdown instance', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btnDropdown)
@@ -447,12 +325,7 @@ describe('Dropdown', () => {
     })
 
     it('should return new instance when there is no instance', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
 
@@ -463,15 +336,8 @@ describe('Dropdown', () => {
 
   describe('data-api', () => {
     it('should toggle via click on data-bs-toggle', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]') as HTMLElement
 
@@ -487,12 +353,7 @@ describe('Dropdown', () => {
 
   describe('_getPlacement', () => {
     it('should return right for dropend', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropend">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropend">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn)
@@ -502,12 +363,7 @@ describe('Dropdown', () => {
     })
 
     it('should return left for dropstart', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropstart">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropstart">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn)
@@ -517,12 +373,7 @@ describe('Dropdown', () => {
     })
 
     it('should return top for dropup-center', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropup-center">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropup-center">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn)
@@ -531,12 +382,7 @@ describe('Dropdown', () => {
     })
 
     it('should return bottom for dropdown-center', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown-center">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown-center">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn)
@@ -545,12 +391,7 @@ describe('Dropdown', () => {
     })
 
     it('should return top-start for dropup', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropup">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropup">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn)
@@ -560,29 +401,24 @@ describe('Dropdown', () => {
     })
 
     it('should return bottom-end when --bs-position is end', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu" style="--bs-position: end"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu" style="--bs-position: end"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const menu = fixtureEl.querySelector('.dropdown-menu') as HTMLElement
       const dropdown = new Dropdown(btn)
 
       const originalGetComputedStyle = window.getComputedStyle
-      vi.spyOn(window, 'getComputedStyle').mockImplementation(el => {
+      vi.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
         const result = originalGetComputedStyle(el)
         if (el === menu) {
           return new Proxy(result, {
             get(target, prop) {
               if (prop === 'getPropertyValue') {
-                return (name: string) => name === '--bs-position' ? 'end' : target.getPropertyValue(name)
+                return (name: string) => (name === '--bs-position' ? 'end' : target.getPropertyValue(name))
               }
 
               return (target as any)[prop]
-            }
+            },
           }) as CSSStyleDeclaration
         }
 
@@ -593,29 +429,24 @@ describe('Dropdown', () => {
     })
 
     it('should return top-end for dropup with --bs-position end', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropup">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu" style="--bs-position: end"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropup">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu" style="--bs-position: end"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const menu = fixtureEl.querySelector('.dropdown-menu') as HTMLElement
       const dropdown = new Dropdown(btn)
 
       const originalGetComputedStyle = window.getComputedStyle
-      vi.spyOn(window, 'getComputedStyle').mockImplementation(el => {
+      vi.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
         const result = originalGetComputedStyle(el)
         if (el === menu) {
           return new Proxy(result, {
             get(target, prop) {
               if (prop === 'getPropertyValue') {
-                return (name: string) => name === '--bs-position' ? 'end' : target.getPropertyValue(name)
+                return (name: string) => (name === '--bs-position' ? 'end' : target.getPropertyValue(name))
               }
 
               return (target as any)[prop]
-            }
+            },
           }) as CSSStyleDeclaration
         }
 
@@ -628,14 +459,7 @@ describe('Dropdown', () => {
 
   describe('_detectNavbar', () => {
     it('should detect when inside navbar', () => {
-      fixtureEl.innerHTML = [
-        '<nav class="navbar">',
-        '  <div class="dropdown">',
-        '    <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '    <div class="dropdown-menu"></div>',
-        '  </div>',
-        '</nav>'
-      ].join('')
+      fixtureEl.innerHTML = ['<nav class="navbar">', '  <div class="dropdown">', '    <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '    <div class="dropdown-menu"></div>', '  </div>', '</nav>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn)
@@ -644,12 +468,7 @@ describe('Dropdown', () => {
     })
 
     it('should detect when not inside navbar', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn)
@@ -660,12 +479,7 @@ describe('Dropdown', () => {
 
   describe('_getConfig', () => {
     it('should throw on invalid reference object', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
 
@@ -677,12 +491,7 @@ describe('Dropdown', () => {
 
   describe('_getOffset', () => {
     it('should handle function offset', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const offsetFn = vi.fn().mockReturnValue([10, 20])
@@ -693,12 +502,7 @@ describe('Dropdown', () => {
     })
 
     it('should handle array offset', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn, { offset: [5, 10] })
@@ -707,12 +511,7 @@ describe('Dropdown', () => {
     })
 
     it('should handle string offset', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn, { offset: '10,20' as any })
@@ -723,14 +522,7 @@ describe('Dropdown', () => {
 
   describe('_getPopperConfig', () => {
     it('should set popper static in navbar', () => {
-      fixtureEl.innerHTML = [
-        '<nav class="navbar">',
-        '  <div class="dropdown">',
-        '    <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '    <div class="dropdown-menu"></div>',
-        '  </div>',
-        '</nav>'
-      ].join('')
+      fixtureEl.innerHTML = ['<nav class="navbar">', '  <div class="dropdown">', '    <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '    <div class="dropdown-menu"></div>', '  </div>', '</nav>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn)
@@ -741,12 +533,7 @@ describe('Dropdown', () => {
     })
 
     it('should set popper static when display is static', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn, { display: 'static' })
@@ -757,12 +544,7 @@ describe('Dropdown', () => {
     })
 
     it('should apply custom popperConfig function', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const customPopperConfig = (_defaultConfig: any) => ({ ..._defaultConfig, strategy: 'fixed' as const })
@@ -775,12 +557,7 @@ describe('Dropdown', () => {
 
   describe('clearMenus', () => {
     it('should ignore right mouse button', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle show" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu show"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle show" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu show"></div>', '</div>'].join('')
 
       const event = new MouseEvent('click', { button: 2, bubbles: true })
       Dropdown.clearMenus(event)
@@ -792,21 +569,14 @@ describe('Dropdown', () => {
 
   describe('show with touch device', () => {
     it('should add mouseover listeners on touch device', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         Object.defineProperty(document.documentElement, 'ontouchstart', {
           value: null,
           writable: true,
-          configurable: true
+          configurable: true,
         })
 
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btn)
@@ -829,15 +599,8 @@ describe('Dropdown', () => {
 
   describe('_completeHide', () => {
     it('should not hide if hide event is prevented', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btn)
@@ -860,21 +623,14 @@ describe('Dropdown', () => {
     })
 
     it('should remove touch listeners on hide', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         Object.defineProperty(document.documentElement, 'ontouchstart', {
           value: null,
           writable: true,
-          configurable: true
+          configurable: true,
         })
 
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btn)
@@ -896,12 +652,7 @@ describe('Dropdown', () => {
 
   describe('_selectMenuItem', () => {
     it('should do nothing if no visible items', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn)
@@ -912,15 +663,7 @@ describe('Dropdown', () => {
     })
 
     it('should focus an item on ArrowDown when items are visible', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu">',
-        '    <a class="dropdown-item" href="#">Item 1</a>',
-        '    <a class="dropdown-item" href="#">Item 2</a>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Item 1</a>', '    <a class="dropdown-item" href="#">Item 2</a>', '  </div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn)
@@ -931,15 +674,8 @@ describe('Dropdown', () => {
 
   describe('_createPopper with reference', () => {
     it('should use parent as reference', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btn, { reference: 'parent' })
@@ -954,15 +690,8 @@ describe('Dropdown', () => {
     })
 
     it('should use element reference', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btn, { reference: fixtureEl })
@@ -977,19 +706,12 @@ describe('Dropdown', () => {
     })
 
     it('should use virtual element reference', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const virtualRef = {
-          getBoundingClientRect: () => ({ top: 0, left: 0, bottom: 0, right: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => {} })
+          getBoundingClientRect: () => ({ top: 0, left: 0, bottom: 0, right: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => {} }),
         }
 
         const dropdown = new Dropdown(btn, { reference: virtualRef as any })
@@ -1006,15 +728,8 @@ describe('Dropdown', () => {
 
   describe('dispose with popper', () => {
     it('should destroy popper on dispose', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btn)
@@ -1033,16 +748,8 @@ describe('Dropdown', () => {
 
   describe('clearMenus (full flow)', () => {
     it('should close open dropdown on outside click', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>',
-          '<div id="outside">outside</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>', '<div id="outside">outside</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btn)
@@ -1064,15 +771,8 @@ describe('Dropdown', () => {
     })
 
     it('should skip autoClose=false dropdown', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btn, { autoClose: false })
@@ -1092,12 +792,7 @@ describe('Dropdown', () => {
     })
 
     it('should ignore keyup that is not Tab', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle show" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu show"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle show" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu show"></div>', '</div>'].join('')
 
       const event = new KeyboardEvent('keyup', { key: 'Escape', bubbles: true })
       Dropdown.clearMenus(event)
@@ -1107,15 +802,8 @@ describe('Dropdown', () => {
     })
 
     it('should add clickEvent on click type event', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btn)
@@ -1133,16 +821,8 @@ describe('Dropdown', () => {
     })
 
     it('should not close autoClose=inside when clicked outside', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>',
-          '<div id="outside">outside</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>', '<div id="outside">outside</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const dropdown = new Dropdown(btn, { autoClose: 'inside' })
@@ -1162,15 +842,8 @@ describe('Dropdown', () => {
     })
 
     it('should not close autoClose=outside when clicked inside menu', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const menu = fixtureEl.querySelector('.dropdown-menu')!
@@ -1190,15 +863,8 @@ describe('Dropdown', () => {
     })
 
     it('should not close when click composedPath includes toggle element', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]') as HTMLElement
         const dropdown = new Dropdown(btn)
@@ -1207,7 +873,7 @@ describe('Dropdown', () => {
           const event = new MouseEvent('click', { bubbles: true })
           Object.defineProperty(event, 'composedPath', {
             value: () => [btn, fixtureEl, document.body, document.documentElement, document],
-            configurable: true
+            configurable: true,
           })
           Dropdown.clearMenus(event)
 
@@ -1222,15 +888,8 @@ describe('Dropdown', () => {
     })
 
     it('should not close on Tab keyup inside input within menu', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <input type="text" class="form-control">',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <input type="text" class="form-control">', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const menu = fixtureEl.querySelector('.dropdown-menu')!
@@ -1241,7 +900,7 @@ describe('Dropdown', () => {
           const tabEvent = new KeyboardEvent('keyup', { key: 'Tab', bubbles: true })
           Object.defineProperty(tabEvent, 'composedPath', {
             value: () => [input, menu, fixtureEl, document.body, document.documentElement, document],
-            configurable: true
+            configurable: true,
           })
           Object.defineProperty(tabEvent, 'target', { value: input, configurable: true })
           Dropdown.clearMenus(tabEvent)
@@ -1257,16 +916,8 @@ describe('Dropdown', () => {
     })
 
     it('should close on Tab keyup targeting element outside menu', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>',
-          '<button id="outside-btn">Outside</button>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>', '<button id="outside-btn">Outside</button>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
         const outsideBtn = fixtureEl.querySelector('#outside-btn') as HTMLElement
@@ -1280,7 +931,7 @@ describe('Dropdown', () => {
           const tabEvent = new KeyboardEvent('keyup', { key: 'Tab', bubbles: true })
           Object.defineProperty(tabEvent, 'composedPath', {
             value: () => [outsideBtn, fixtureEl, document.body, document.documentElement, document],
-            configurable: true
+            configurable: true,
           })
           Object.defineProperty(tabEvent, 'target', { value: outsideBtn, configurable: true })
           Dropdown.clearMenus(tabEvent)
@@ -1293,14 +944,7 @@ describe('Dropdown', () => {
 
   describe('dataApiKeydownHandler', () => {
     it('should ignore non-arrow/escape keys', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu">',
-        '    <a class="dropdown-item" href="#">Link</a>',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]') as HTMLElement
       const preventSpy = vi.spyOn(Event.prototype, 'preventDefault')
@@ -1312,14 +956,7 @@ describe('Dropdown', () => {
     })
 
     it('should ignore arrow keys in input', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu">',
-        '    <input type="text" class="form-control">',
-        '  </div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <input type="text" class="form-control">', '  </div>', '</div>'].join('')
 
       const input = fixtureEl.querySelector('input') as HTMLElement
       const preventSpy = vi.spyOn(Event.prototype, 'preventDefault')
@@ -1332,15 +969,8 @@ describe('Dropdown', () => {
     })
 
     it('should open dropdown on ArrowDown and call _selectMenuItem', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]') as HTMLElement
 
@@ -1355,15 +985,8 @@ describe('Dropdown', () => {
     })
 
     it('should close dropdown on Escape', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]') as HTMLElement
         const dropdown = new Dropdown(btn)
@@ -1383,15 +1006,8 @@ describe('Dropdown', () => {
     })
 
     it('should allow Escape in input/textarea', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <textarea class="form-control"></textarea>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <textarea class="form-control"></textarea>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]') as HTMLElement
         const textarea = fixtureEl.querySelector('textarea') as HTMLElement
@@ -1412,15 +1028,8 @@ describe('Dropdown', () => {
     })
 
     it('should handle ArrowUp to show and select', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]') as HTMLElement
 
@@ -1435,15 +1044,8 @@ describe('Dropdown', () => {
     })
 
     it('should find toggle from menu item via keydown', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]') as HTMLElement
         const menu = fixtureEl.querySelector('.dropdown-menu') as HTMLElement
@@ -1466,15 +1068,8 @@ describe('Dropdown', () => {
 
   describe('data-tblr-toggle', () => {
     it('should toggle via data-tblr-toggle="dropdown"', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="dropdown">',
-          '  <button class="btn dropdown-toggle" data-tblr-toggle="dropdown">Dropdown</button>',
-          '  <div class="dropdown-menu">',
-          '    <a class="dropdown-item" href="#">Link</a>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-tblr-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
         const btnDropdown = fixtureEl.querySelector('[data-tblr-toggle="dropdown"]') as HTMLElement
 
@@ -1489,12 +1084,7 @@ describe('Dropdown', () => {
     })
 
     it('should create instance via data-tblr-toggle', () => {
-      fixtureEl.innerHTML = [
-        '<div class="dropdown">',
-        '  <button class="btn dropdown-toggle" data-tblr-toggle="dropdown">Dropdown</button>',
-        '  <div class="dropdown-menu"></div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-tblr-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btnDropdown = fixtureEl.querySelector('[data-tblr-toggle="dropdown"]')!
       const dropdown = new Dropdown(btnDropdown)

--- a/core/js/tests/unit/modal.spec.ts
+++ b/core/js/tests/unit/modal.spec.ts
@@ -18,19 +18,20 @@ describe('Modal', () => {
     }
   })
 
-  const createModalHTML = () => [
-    '<div class="modal" tabindex="-1">',
-    '  <div class="modal-dialog">',
-    '    <div class="modal-content">',
-    '      <div class="modal-header">',
-    '        <h5 class="modal-title">Modal</h5>',
-    '        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>',
-    '      </div>',
-    '      <div class="modal-body"><p>Content</p></div>',
-    '    </div>',
-    '  </div>',
-    '</div>'
-  ].join('')
+  const createModalHTML = () =>
+    [
+      '<div class="modal" tabindex="-1">',
+      '  <div class="modal-dialog">',
+      '    <div class="modal-content">',
+      '      <div class="modal-header">',
+      '        <h5 class="modal-title">Modal</h5>',
+      '        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>',
+      '      </div>',
+      '      <div class="modal-body"><p>Content</p></div>',
+      '    </div>',
+      '  </div>',
+      '</div>',
+    ].join('')
 
   describe('VERSION', () => {
     it('should return plugin version', () => {
@@ -81,7 +82,7 @@ describe('Modal', () => {
 
   describe('toggle', () => {
     it('should show when hidden', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl)
@@ -96,7 +97,7 @@ describe('Modal', () => {
     })
 
     it('should hide when shown', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl)
@@ -117,7 +118,7 @@ describe('Modal', () => {
 
   describe('show', () => {
     it('should show modal', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl)
@@ -136,7 +137,7 @@ describe('Modal', () => {
     })
 
     it('should not show if already shown', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl)
@@ -154,12 +155,12 @@ describe('Modal', () => {
     })
 
     it('should not show if show event is prevented', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl)
 
-        modalEl.addEventListener('show.bs.modal', event => {
+        modalEl.addEventListener('show.bs.modal', (event) => {
           event.preventDefault()
           setTimeout(() => {
             expect(modal._isShown).toBe(false)
@@ -172,7 +173,7 @@ describe('Modal', () => {
     })
 
     it('should pass relatedTarget in show event', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML() + '<button id="trigger">Open</button>'
         const modalEl = fixtureEl.querySelector('.modal')!
         const trigger = fixtureEl.querySelector('#trigger') as HTMLElement
@@ -190,7 +191,7 @@ describe('Modal', () => {
 
   describe('hide', () => {
     it('should hide modal', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl)
@@ -220,13 +221,13 @@ describe('Modal', () => {
     })
 
     it('should not hide if hide event is prevented', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl)
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          modalEl.addEventListener('hide.bs.modal', event => {
+          modalEl.addEventListener('hide.bs.modal', (event) => {
             event.preventDefault()
             setTimeout(() => {
               expect(modal._isShown).toBe(true)
@@ -285,7 +286,7 @@ describe('Modal', () => {
 
   describe('keyboard', () => {
     it('should close on Escape when keyboard is true', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl, { keyboard: true })
@@ -304,7 +305,7 @@ describe('Modal', () => {
     })
 
     it('should not close on Escape when keyboard is false', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl, { keyboard: false })
@@ -323,7 +324,7 @@ describe('Modal', () => {
     })
 
     it('should ignore non-Escape keys', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl)
@@ -376,7 +377,7 @@ describe('Modal', () => {
 
   describe('_triggerBackdropTransition', () => {
     it('should add and remove modal-static class', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl, { keyboard: false })
@@ -396,13 +397,13 @@ describe('Modal', () => {
     })
 
     it('should not transition if hidePrevented is prevented', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl, { keyboard: false })
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          modalEl.addEventListener('hidePrevented.bs.modal', event => {
+          modalEl.addEventListener('hidePrevented.bs.modal', (event) => {
             event.preventDefault()
             setTimeout(() => {
               expect(modal._isShown).toBe(true)
@@ -418,7 +419,7 @@ describe('Modal', () => {
     })
 
     it('should early return if overflowY is hidden', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl, { keyboard: false })
@@ -441,7 +442,7 @@ describe('Modal', () => {
     })
 
     it('should early return if already has modal-static class', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl, { keyboard: false })
@@ -466,7 +467,7 @@ describe('Modal', () => {
 
   describe('backdrop click', () => {
     it('should hide when clicking outside dialog with backdrop true', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl, { backdrop: true })
@@ -486,7 +487,7 @@ describe('Modal', () => {
     })
 
     it('should not hide when click starts inside dialog', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const dialog = modalEl.querySelector('.modal-dialog')!
@@ -510,7 +511,7 @@ describe('Modal', () => {
     })
 
     it('should trigger backdrop transition with static backdrop', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl, { backdrop: 'static' })
@@ -539,7 +540,7 @@ describe('Modal', () => {
 
       const modal = new Modal(modalEl)
 
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         modalEl.addEventListener('shown.bs.modal', () => {
           expect(document.body.contains(modalEl)).toBe(true)
           modal.dispose()
@@ -552,7 +553,7 @@ describe('Modal', () => {
     })
 
     it('should scroll modal body to top', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
         const modalEl = fixtureEl.querySelector('.modal')!
         const modal = new Modal(modalEl)
@@ -569,13 +570,8 @@ describe('Modal', () => {
 
   describe('data-tblr-toggle', () => {
     it('should open modal via data-tblr-toggle="modal"', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<button data-tblr-toggle="modal" data-bs-target="#testModal">Open</button>',
-          '<div class="modal" id="testModal" tabindex="-1">',
-          '  <div class="modal-dialog"><div class="modal-content"></div></div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<button data-tblr-toggle="modal" data-bs-target="#testModal">Open</button>', '<div class="modal" id="testModal" tabindex="-1">', '  <div class="modal-dialog"><div class="modal-content"></div></div>', '</div>'].join('')
 
         const modalEl = fixtureEl.querySelector('#testModal')!
         const btn = fixtureEl.querySelector('[data-tblr-toggle="modal"]') as HTMLElement
@@ -591,13 +587,8 @@ describe('Modal', () => {
     })
 
     it('should open modal via data-tblr-toggle with data-tblr-target', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<button data-tblr-toggle="modal" data-tblr-target="#testModal">Open</button>',
-          '<div class="modal" id="testModal" tabindex="-1">',
-          '  <div class="modal-dialog"><div class="modal-content"></div></div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<button data-tblr-toggle="modal" data-tblr-target="#testModal">Open</button>', '<div class="modal" id="testModal" tabindex="-1">', '  <div class="modal-dialog"><div class="modal-content"></div></div>', '</div>'].join('')
 
         const modalEl = fixtureEl.querySelector('#testModal')!
         const btn = fixtureEl.querySelector('[data-tblr-toggle="modal"]') as HTMLElement
@@ -615,16 +606,8 @@ describe('Modal', () => {
 
   describe('data-tblr-dismiss', () => {
     it('should close modal via data-tblr-dismiss="modal"', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="modal" tabindex="-1">',
-          '  <div class="modal-dialog">',
-          '    <div class="modal-content">',
-          '      <button type="button" class="btn-close" data-tblr-dismiss="modal"></button>',
-          '    </div>',
-          '  </div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="modal" tabindex="-1">', '  <div class="modal-dialog">', '    <div class="modal-content">', '      <button type="button" class="btn-close" data-tblr-dismiss="modal"></button>', '    </div>', '  </div>', '</div>'].join('')
 
         const modalEl = fixtureEl.querySelector('.modal')!
         const dismissBtn = fixtureEl.querySelector('[data-tblr-dismiss="modal"]') as HTMLElement

--- a/core/js/tests/unit/offcanvas.spec.ts
+++ b/core/js/tests/unit/offcanvas.spec.ts
@@ -17,15 +17,8 @@ describe('Offcanvas', () => {
     }
   })
 
-  const createOffcanvasHTML = () => [
-    '<div class="offcanvas offcanvas-start" tabindex="-1">',
-    '  <div class="offcanvas-header">',
-    '    <h5 class="offcanvas-title">Offcanvas</h5>',
-    '    <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>',
-    '  </div>',
-    '  <div class="offcanvas-body">Content</div>',
-    '</div>'
-  ].join('')
+  const createOffcanvasHTML = () =>
+    ['<div class="offcanvas offcanvas-start" tabindex="-1">', '  <div class="offcanvas-header">', '    <h5 class="offcanvas-title">Offcanvas</h5>', '    <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>', '  </div>', '  <div class="offcanvas-body">Content</div>', '</div>'].join('')
 
   describe('VERSION', () => {
     it('should return plugin version', () => {
@@ -68,7 +61,7 @@ describe('Offcanvas', () => {
 
   describe('toggle', () => {
     it('should show when hidden', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML()
         const el = fixtureEl.querySelector('.offcanvas')!
         const instance = new Offcanvas(el)
@@ -83,7 +76,7 @@ describe('Offcanvas', () => {
     })
 
     it('should hide when shown', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML()
         const el = fixtureEl.querySelector('.offcanvas')!
         const instance = new Offcanvas(el)
@@ -104,7 +97,7 @@ describe('Offcanvas', () => {
 
   describe('show', () => {
     it('should show offcanvas', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML()
         const el = fixtureEl.querySelector('.offcanvas')!
         const instance = new Offcanvas(el)
@@ -122,7 +115,7 @@ describe('Offcanvas', () => {
     })
 
     it('should not show if already shown', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML()
         const el = fixtureEl.querySelector('.offcanvas')!
         const instance = new Offcanvas(el)
@@ -145,12 +138,12 @@ describe('Offcanvas', () => {
     })
 
     it('should not show if show event is prevented', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML()
         const el = fixtureEl.querySelector('.offcanvas')!
         const instance = new Offcanvas(el)
 
-        el.addEventListener('show.bs.offcanvas', event => {
+        el.addEventListener('show.bs.offcanvas', (event) => {
           event.preventDefault()
           setTimeout(() => {
             expect(instance._isShown).toBe(false)
@@ -163,7 +156,7 @@ describe('Offcanvas', () => {
     })
 
     it('should pass relatedTarget in show event', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML() + '<button id="trigger">Open</button>'
         const el = fixtureEl.querySelector('.offcanvas')!
         const trigger = fixtureEl.querySelector('#trigger') as HTMLElement
@@ -181,7 +174,7 @@ describe('Offcanvas', () => {
 
   describe('hide', () => {
     it('should hide offcanvas', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML()
         const el = fixtureEl.querySelector('.offcanvas')!
         const instance = new Offcanvas(el)
@@ -215,13 +208,13 @@ describe('Offcanvas', () => {
     })
 
     it('should not hide if hide event is prevented', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML()
         const el = fixtureEl.querySelector('.offcanvas')!
         const instance = new Offcanvas(el)
 
         el.addEventListener('shown.bs.offcanvas', () => {
-          el.addEventListener('hide.bs.offcanvas', event => {
+          el.addEventListener('hide.bs.offcanvas', (event) => {
             event.preventDefault()
             setTimeout(() => {
               expect(instance._isShown).toBe(true)
@@ -250,7 +243,7 @@ describe('Offcanvas', () => {
 
   describe('keyboard', () => {
     it('should close on Escape when keyboard is true', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML()
         const el = fixtureEl.querySelector('.offcanvas')!
         const instance = new Offcanvas(el, { keyboard: true })
@@ -269,7 +262,7 @@ describe('Offcanvas', () => {
     })
 
     it('should fire hidePrevented when keyboard is false and Escape pressed', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML()
         const el = fixtureEl.querySelector('.offcanvas')!
         new Offcanvas(el, { keyboard: false })
@@ -287,7 +280,7 @@ describe('Offcanvas', () => {
     })
 
     it('should ignore non-Escape keys', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML()
         const el = fixtureEl.querySelector('.offcanvas')!
         const instance = new Offcanvas(el)
@@ -340,7 +333,7 @@ describe('Offcanvas', () => {
 
   describe('scroll option', () => {
     it('should not hide scrollbar when scroll is true', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML()
         const el = fixtureEl.querySelector('.offcanvas')!
         const instance = new Offcanvas(el, { scroll: true })
@@ -357,7 +350,7 @@ describe('Offcanvas', () => {
 
   describe('backdrop option', () => {
     it('should work with backdrop set to false', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createOffcanvasHTML()
         const el = fixtureEl.querySelector('.offcanvas')!
         const instance = new Offcanvas(el, { backdrop: false })
@@ -382,13 +375,8 @@ describe('Offcanvas', () => {
 
   describe('data-tblr-toggle', () => {
     it('should open offcanvas via data-tblr-toggle="offcanvas"', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<button data-tblr-toggle="offcanvas" data-bs-target="#testOffcanvas">Open</button>',
-          '<div class="offcanvas offcanvas-start" id="testOffcanvas" tabindex="-1">',
-          '  <div class="offcanvas-body">Content</div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<button data-tblr-toggle="offcanvas" data-bs-target="#testOffcanvas">Open</button>', '<div class="offcanvas offcanvas-start" id="testOffcanvas" tabindex="-1">', '  <div class="offcanvas-body">Content</div>', '</div>'].join('')
 
         const offcanvasEl = fixtureEl.querySelector('#testOffcanvas')!
         const btn = fixtureEl.querySelector('[data-tblr-toggle="offcanvas"]') as HTMLElement
@@ -404,13 +392,8 @@ describe('Offcanvas', () => {
     })
 
     it('should open offcanvas via data-tblr-toggle with data-tblr-target', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<button data-tblr-toggle="offcanvas" data-tblr-target="#testOffcanvas">Open</button>',
-          '<div class="offcanvas offcanvas-start" id="testOffcanvas" tabindex="-1">',
-          '  <div class="offcanvas-body">Content</div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<button data-tblr-toggle="offcanvas" data-tblr-target="#testOffcanvas">Open</button>', '<div class="offcanvas offcanvas-start" id="testOffcanvas" tabindex="-1">', '  <div class="offcanvas-body">Content</div>', '</div>'].join('')
 
         const offcanvasEl = fixtureEl.querySelector('#testOffcanvas')!
         const btn = fixtureEl.querySelector('[data-tblr-toggle="offcanvas"]') as HTMLElement
@@ -428,15 +411,8 @@ describe('Offcanvas', () => {
 
   describe('data-tblr-dismiss', () => {
     it('should close offcanvas via data-tblr-dismiss="offcanvas"', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="offcanvas offcanvas-start" tabindex="-1">',
-          '  <div class="offcanvas-header">',
-          '    <button type="button" class="btn-close" data-tblr-dismiss="offcanvas"></button>',
-          '  </div>',
-          '  <div class="offcanvas-body">Content</div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="offcanvas offcanvas-start" tabindex="-1">', '  <div class="offcanvas-header">', '    <button type="button" class="btn-close" data-tblr-dismiss="offcanvas"></button>', '  </div>', '  <div class="offcanvas-body">Content</div>', '</div>'].join('')
 
         const el = fixtureEl.querySelector('.offcanvas')!
         const dismissBtn = fixtureEl.querySelector('[data-tblr-dismiss="offcanvas"]') as HTMLElement

--- a/core/js/tests/unit/popover.spec.ts
+++ b/core/js/tests/unit/popover.spec.ts
@@ -7,8 +7,8 @@ vi.mock('@popperjs/core', () => ({
   createPopper: vi.fn(() => ({
     destroy: vi.fn(),
     update: vi.fn(),
-    setOptions: vi.fn()
-  }))
+    setOptions: vi.fn(),
+  })),
 }))
 
 describe('Popover', () => {
@@ -77,7 +77,7 @@ describe('Popover', () => {
 
   describe('show', () => {
     it('should show popover', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Popover title" data-bs-content="Content">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const popover = new Popover(el, { animation: false })
@@ -93,7 +93,7 @@ describe('Popover', () => {
     })
 
     it('should show popover with only content', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const popover = new Popover(el, { content: 'Only content', animation: false })
@@ -108,7 +108,7 @@ describe('Popover', () => {
     })
 
     it('should show popover with only title', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Only title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const popover = new Popover(el, { animation: false })
@@ -125,7 +125,7 @@ describe('Popover', () => {
 
   describe('hide', () => {
     it('should hide popover', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Popover" data-bs-content="Content">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const popover = new Popover(el, { animation: false })

--- a/core/js/tests/unit/scrollspy.spec.ts
+++ b/core/js/tests/unit/scrollspy.spec.ts
@@ -12,7 +12,7 @@ class MockIntersectionObserver implements IntersectionObserver {
   constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
     this.callback = callback
     this.options = options
-    this.root = options?.root as Element | null ?? null
+    this.root = (options?.root as Element | null) ?? null
     this.rootMargin = options?.rootMargin ?? ''
     this.thresholds = Array.isArray(options?.threshold) ? options!.threshold : [options?.threshold ?? 0]
   }
@@ -23,16 +23,8 @@ class MockIntersectionObserver implements IntersectionObserver {
   takeRecords = vi.fn().mockReturnValue([])
 }
 
-const getDummyFixture = () => [
-  '<nav id="navBar" class="navbar">',
-  '  <ul class="nav">',
-  '    <li class="nav-item"><a id="li-jsm-1" class="nav-link" href="#div-jsm-1">div 1</a></li>',
-  '  </ul>',
-  '</nav>',
-  '<div class="content" data-bs-target="#navBar" style="overflow-y: auto">',
-  '  <div id="div-jsm-1">div 1</div>',
-  '</div>'
-].join('')
+const getDummyFixture = () =>
+  ['<nav id="navBar" class="navbar">', '  <ul class="nav">', '    <li class="nav-item"><a id="li-jsm-1" class="nav-link" href="#div-jsm-1">div 1</a></li>', '  </ul>', '</nav>', '<div class="content" data-bs-target="#navBar" style="overflow-y: auto">', '  <div id="div-jsm-1">div 1</div>', '</div>'].join('')
 
 describe('ScrollSpy', () => {
   let fixtureEl: HTMLElement
@@ -82,16 +74,7 @@ describe('ScrollSpy', () => {
     })
 
     it('should set _rootElement to null if overflowY is visible', () => {
-      fixtureEl.innerHTML = [
-        '<nav id="navigation" class="navbar">',
-        '  <ul class="navbar-nav">',
-        '    <li class="nav-item"><a class="nav-link" href="#one">One</a></li>',
-        '  </ul>',
-        '</nav>',
-        '<div id="content" style="overflow-y: visible;">',
-        '  <div id="one" style="height: 300px;">test</div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<nav id="navigation" class="navbar">', '  <ul class="navbar-nav">', '    <li class="nav-item"><a class="nav-link" href="#one">One</a></li>', '  </ul>', '</nav>', '<div id="content" style="overflow-y: visible;">', '  <div id="one" style="height: 300px;">test</div>', '</div>'].join('')
 
       const contentEl = fixtureEl.querySelector('#content')!
       const originalGetComputedStyle = window.getComputedStyle
@@ -102,7 +85,7 @@ describe('ScrollSpy', () => {
             get(target, prop) {
               if (prop === 'overflowY') return 'visible'
               return (target as any)[prop]
-            }
+            },
           }) as CSSStyleDeclaration
         }
 
@@ -110,42 +93,28 @@ describe('ScrollSpy', () => {
       })
 
       const scrollSpy = new ScrollSpy(contentEl, {
-        target: '#navigation'
+        target: '#navigation',
       })
 
       expect(scrollSpy._rootElement).toBeNull()
     })
 
     it('should respect threshold option', () => {
-      fixtureEl.innerHTML = [
-        '<ul id="navigation" class="navbar">',
-        '   <a class="nav-link" href="#one">One</a>',
-        '</ul>',
-        '<div id="content">',
-        '  <div id="one">test</div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<ul id="navigation" class="navbar">', '   <a class="nav-link" href="#one">One</a>', '</ul>', '<div id="content">', '  <div id="one">test</div>', '</div>'].join('')
 
       const scrollSpy = new ScrollSpy('#content', {
         target: '#navigation',
-        threshold: [1]
+        threshold: [1],
       })
 
       expect(scrollSpy._observer!.thresholds).toEqual([1])
     })
 
     it('should parse string threshold from data attribute', () => {
-      fixtureEl.innerHTML = [
-        '<ul id="navigation" class="navbar">',
-        '   <a class="nav-link" href="#one">One</a>',
-        '</ul>',
-        '<div id="content" data-bs-threshold="0,0.2,1">',
-        '  <div id="one">test</div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<ul id="navigation" class="navbar">', '   <a class="nav-link" href="#one">One</a>', '</ul>', '<div id="content" data-bs-threshold="0,0.2,1">', '  <div id="one">test</div>', '</div>'].join('')
 
       const scrollSpy = new ScrollSpy('#content', {
-        target: '#navigation'
+        target: '#navigation',
       })
 
       expect(scrollSpy._observer!.thresholds).toEqual([0, 0.2, 1])
@@ -161,11 +130,11 @@ describe('ScrollSpy', () => {
         '</nav>',
         '<div id="content" style="height: 200px; overflow-y: auto;">',
         '  <div id="two" style="height: 300px;">test</div>',
-        '</div>'
+        '</div>',
       ].join('')
 
       const scrollSpy = new ScrollSpy(fixtureEl.querySelector('#content')!, {
-        target: '#navigation'
+        target: '#navigation',
       })
 
       // jsdom elements are not "visible" (getClientRects returns empty), so maps are empty
@@ -267,10 +236,7 @@ describe('ScrollSpy', () => {
 
   describe('event handler', () => {
     it('should create scrollspy on window load event', () => {
-      fixtureEl.innerHTML = [
-        '<div id="nav"></div>',
-        '<div id="wrapper" data-bs-spy="scroll" data-bs-target="#nav" style="overflow-y: auto"></div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="nav"></div>', '<div id="wrapper" data-bs-spy="scroll" data-bs-target="#nav" style="overflow-y: auto"></div>'].join('')
 
       const scrollSpyEl = fixtureEl.querySelector('#wrapper')!
 
@@ -297,7 +263,7 @@ describe('ScrollSpy', () => {
       const entry = {
         isIntersecting: true,
         target: section,
-        intersectionRatio: 1
+        intersectionRatio: 1,
       } as unknown as IntersectionObserverEntry
 
       Object.defineProperty(section, 'offsetTop', { value: 100, configurable: true })
@@ -322,7 +288,7 @@ describe('ScrollSpy', () => {
 
       const entry = {
         isIntersecting: false,
-        target: section
+        target: section,
       } as unknown as IntersectionObserverEntry
 
       scrollSpy._observerCallback([entry])
@@ -350,7 +316,7 @@ describe('ScrollSpy', () => {
       const entry = {
         isIntersecting: true,
         target: section,
-        intersectionRatio: 1
+        intersectionRatio: 1,
       } as unknown as IntersectionObserverEntry
 
       scrollSpy._observerCallback([entry])
@@ -378,7 +344,7 @@ describe('ScrollSpy', () => {
       const entry = {
         isIntersecting: true,
         target: section,
-        intersectionRatio: 1
+        intersectionRatio: 1,
       } as unknown as IntersectionObserverEntry
 
       scrollSpy._observerCallback([entry])
@@ -406,7 +372,7 @@ describe('ScrollSpy', () => {
       const entry = {
         isIntersecting: true,
         target: section,
-        intersectionRatio: 1
+        intersectionRatio: 1,
       } as unknown as IntersectionObserverEntry
 
       const spy = vi.fn()
@@ -451,7 +417,7 @@ describe('ScrollSpy', () => {
         '</nav>',
         '<div class="content" style="overflow-y: auto">',
         '  <div id="one">one</div>',
-        '</div>'
+        '</div>',
       ].join('')
 
       const div = fixtureEl.querySelector('.content')!
@@ -465,16 +431,7 @@ describe('ScrollSpy', () => {
     })
 
     it('should activate nav parents for nav-link target', () => {
-      fixtureEl.innerHTML = [
-        '<nav class="navbar">',
-        '  <nav class="nav">',
-        '    <a class="nav-link" id="a1" href="#one">One</a>',
-        '  </nav>',
-        '</nav>',
-        '<div class="content" style="overflow-y: auto">',
-        '  <div id="one">one</div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<nav class="navbar">', '  <nav class="nav">', '    <a class="nav-link" id="a1" href="#one">One</a>', '  </nav>', '</nav>', '<div class="content" style="overflow-y: auto">', '  <div id="one">one</div>', '</div>'].join('')
 
       const div = fixtureEl.querySelector('.content')!
       const scrollSpy = new ScrollSpy(div)
@@ -489,15 +446,7 @@ describe('ScrollSpy', () => {
 
   describe('_clearActiveClass', () => {
     it('should remove active class from parent and children', () => {
-      fixtureEl.innerHTML = [
-        '<nav class="navbar active">',
-        '  <a class="nav-link active" href="#one">One</a>',
-        '  <a class="nav-link active" href="#two">Two</a>',
-        '</nav>',
-        '<div class="content" style="overflow-y: auto">',
-        '  <div id="one">one</div>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<nav class="navbar active">', '  <a class="nav-link active" href="#one">One</a>', '  <a class="nav-link active" href="#two">Two</a>', '</nav>', '<div class="content" style="overflow-y: auto">', '  <div id="one">one</div>', '</div>'].join('')
 
       const div = fixtureEl.querySelector('.content')!
       const scrollSpy = new ScrollSpy(div)
@@ -521,7 +470,7 @@ describe('ScrollSpy', () => {
 
       Object.defineProperty(section, 'getClientRects', {
         value: () => [{ width: 100, height: 100 }],
-        configurable: true
+        configurable: true,
       })
 
       scrollSpy._initializeTargetsAndObservables()
@@ -541,7 +490,7 @@ describe('ScrollSpy', () => {
         '<div class="content" style="overflow-y: auto">',
         '  <div id="div1">div 1</div>',
         '  <div id="div2">div 2</div>',
-        '</div>'
+        '</div>',
       ].join('')
 
       const div = fixtureEl.querySelector('.content')!
@@ -563,7 +512,7 @@ describe('ScrollSpy', () => {
         '<div class="content" style="overflow-y: auto">',
         '  <div id="one">one</div>',
         '  <div id="two">two</div>',
-        '</div>'
+        '</div>',
       ].join('')
 
       const div = fixtureEl.querySelector('.content')!
@@ -600,7 +549,7 @@ describe('ScrollSpy', () => {
       const section = fixtureEl.querySelector('#div-jsm-1') as HTMLElement
       Object.defineProperty(section, 'getClientRects', {
         value: () => [{ width: 100, height: 100 }],
-        configurable: true
+        configurable: true,
       })
 
       const scrollSpy = new ScrollSpy(div, { offset: 1, smoothScroll: true })
@@ -619,7 +568,7 @@ describe('ScrollSpy', () => {
       const section = fixtureEl.querySelector('#div-jsm-1') as HTMLElement
       Object.defineProperty(section, 'getClientRects', {
         value: () => [{ width: 100, height: 100 }],
-        configurable: true
+        configurable: true,
       })
 
       // Manually set _rootElement to a plain object without scrollTo
@@ -650,7 +599,7 @@ describe('ScrollSpy', () => {
         '</nav>',
         '<div class="content" data-bs-target="#navBar" style="overflow-y: auto">',
         '  <div id="div-jsm-1">div 1</div>',
-        '</div>'
+        '</div>',
       ].join('')
 
       const div = fixtureEl.querySelector('.content') as HTMLElement
@@ -666,10 +615,7 @@ describe('ScrollSpy', () => {
 
   describe('data-tblr-spy', () => {
     it('should create scrollspy on window load with data-tblr-spy="scroll"', () => {
-      fixtureEl.innerHTML = [
-        '<div id="nav"></div>',
-        '<div id="wrapper" data-tblr-spy="scroll" data-bs-target="#nav" style="overflow-y: auto"></div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="nav"></div>', '<div id="wrapper" data-tblr-spy="scroll" data-bs-target="#nav" style="overflow-y: auto"></div>'].join('')
 
       const scrollSpyEl = fixtureEl.querySelector('#wrapper')!
 

--- a/core/js/tests/unit/tab.spec.ts
+++ b/core/js/tests/unit/tab.spec.ts
@@ -22,14 +22,7 @@ describe('Tab', () => {
 
   describe('constructor', () => {
     it('should accept element as CSS selector or DOM element', () => {
-      fixtureEl.innerHTML = [
-        '<ul class="nav">',
-        '  <li><a href="#home" role="tab">Home</a></li>',
-        '</ul>',
-        '<ul>',
-        '  <li id="home"></li>',
-        '</ul>'
-      ].join('')
+      fixtureEl.innerHTML = ['<ul class="nav">', '  <li><a href="#home" role="tab">Home</a></li>', '</ul>', '<ul>', '  <li id="home"></li>', '</ul>'].join('')
 
       const tabEl = fixtureEl.querySelector('[href="#home"]')!
       const tabBySelector = new Tab('[href="#home"]')
@@ -51,7 +44,7 @@ describe('Tab', () => {
 
   describe('show', () => {
     it('should activate element by tab id using buttons', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<ul class="nav" role="tablist">',
           '  <li><button type="button" data-bs-target="#home" role="tab">Home</button></li>',
@@ -60,7 +53,7 @@ describe('Tab', () => {
           '<ul>',
           '  <li id="home" role="tabpanel"></li>',
           '  <li id="profile" role="tabpanel"></li>',
-          '</ul>'
+          '</ul>',
         ].join('')
 
         const profileTriggerEl = fixtureEl.querySelector('#triggerProfile')!
@@ -77,17 +70,8 @@ describe('Tab', () => {
     })
 
     it('should activate element by tab id using links', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<ul class="nav" role="tablist">',
-          '  <li><a href="#home" role="tab">Home</a></li>',
-          '  <li><a id="triggerProfile" href="#profile" role="tab">Profile</a></li>',
-          '</ul>',
-          '<ul>',
-          '  <li id="home" role="tabpanel"></li>',
-          '  <li id="profile" role="tabpanel"></li>',
-          '</ul>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<ul class="nav" role="tablist">', '  <li><a href="#home" role="tab">Home</a></li>', '  <li><a id="triggerProfile" href="#profile" role="tab">Profile</a></li>', '</ul>', '<ul>', '  <li id="home" role="tabpanel"></li>', '  <li id="profile" role="tabpanel"></li>', '</ul>'].join('')
 
         const profileTriggerEl = fixtureEl.querySelector('#triggerProfile')!
         const tab = new Tab(profileTriggerEl)
@@ -103,7 +87,7 @@ describe('Tab', () => {
     })
 
     it('should activate element in list group', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<div class="list-group" role="tablist">',
           '  <button type="button" data-bs-target="#home" role="tab">Home</button>',
@@ -112,7 +96,7 @@ describe('Tab', () => {
           '<div>',
           '  <div id="home" role="tabpanel"></div>',
           '  <div id="profile" role="tabpanel"></div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const profileTriggerEl = fixtureEl.querySelector('#triggerProfile')!
@@ -134,7 +118,7 @@ describe('Tab', () => {
         const navEl = fixtureEl.querySelector('.nav > div')!
         const tab = new Tab(navEl)
 
-        navEl.addEventListener('show.bs.tab', ev => {
+        navEl.addEventListener('show.bs.tab', (ev) => {
           ev.preventDefault()
           setTimeout(resolve, 30)
         })
@@ -157,7 +141,7 @@ describe('Tab', () => {
           '<div class="tab-content">',
           '  <div class="tab-pane active" id="home" role="tabpanel"></div>',
           '  <div class="tab-pane" id="profile" role="tabpanel"></div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const triggerActive = fixtureEl.querySelector('button.active')!
@@ -173,7 +157,7 @@ describe('Tab', () => {
     })
 
     it('show and shown events should reference correct relatedTarget', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<ul class="nav nav-tabs" role="tablist">',
           '  <li class="nav-item" role="presentation"><button type="button" data-bs-target="#home" class="nav-link active" role="tab" aria-selected="true">Home</button></li>',
@@ -182,7 +166,7 @@ describe('Tab', () => {
           '<div class="tab-content">',
           '  <div class="tab-pane active" id="home" role="tabpanel"></div>',
           '  <div class="tab-pane" id="profile" role="tabpanel"></div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const secondTabTrigger = fixtureEl.querySelector('#triggerProfile')!
@@ -203,13 +187,8 @@ describe('Tab', () => {
     })
 
     it('should fire hide and hidden events', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<ul class="nav" role="tablist">',
-          '  <li><button type="button" data-bs-target="#home" role="tab">Home</button></li>',
-          '  <li><button type="button" data-bs-target="#profile" role="tab">Profile</button></li>',
-          '</ul>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<ul class="nav" role="tablist">', '  <li><button type="button" data-bs-target="#home" role="tab">Home</button></li>', '  <li><button type="button" data-bs-target="#profile" role="tab">Profile</button></li>', '</ul>'].join('')
 
         const triggerList = fixtureEl.querySelectorAll('button')
         const firstTab = new Tab(triggerList[0])
@@ -237,12 +216,7 @@ describe('Tab', () => {
 
     it('should not fire hidden when hide is prevented', () => {
       return new Promise<void>((resolve, reject) => {
-        fixtureEl.innerHTML = [
-          '<ul class="nav" role="tablist">',
-          '  <li><button type="button" data-bs-target="#home" role="tab">Home</button></li>',
-          '  <li><button type="button" data-bs-target="#profile" role="tab">Profile</button></li>',
-          '</ul>'
-        ].join('')
+        fixtureEl.innerHTML = ['<ul class="nav" role="tablist">', '  <li><button type="button" data-bs-target="#home" role="tab">Home</button></li>', '  <li><button type="button" data-bs-target="#profile" role="tab">Profile</button></li>', '</ul>'].join('')
 
         const triggerList = fixtureEl.querySelectorAll('button')
         const firstTab = new Tab(triggerList[0])
@@ -252,7 +226,7 @@ describe('Tab', () => {
           secondTab.show()
         })
 
-        triggerList[0].addEventListener('hide.bs.tab', ev => {
+        triggerList[0].addEventListener('hide.bs.tab', (ev) => {
           ev.preventDefault()
           setTimeout(resolve, 30)
         })
@@ -283,11 +257,7 @@ describe('Tab', () => {
 
   describe('_activate', () => {
     it('should not be called if element is null', () => {
-      fixtureEl.innerHTML = [
-        '<ul class="nav" role="tablist">',
-        '  <li class="nav-link"></li>',
-        '</ul>'
-      ].join('')
+      fixtureEl.innerHTML = ['<ul class="nav" role="tablist">', '  <li class="nav-link"></li>', '</ul>'].join('')
 
       const tabEl = fixtureEl.querySelector('.nav-link')!
       const tab = new Tab(tabEl)
@@ -300,14 +270,7 @@ describe('Tab', () => {
 
   describe('_setInitialAttributes', () => {
     it('should set aria attributes', () => {
-      fixtureEl.innerHTML = [
-        '<ul class="nav">',
-        '  <li class="nav-link" id="foo" data-bs-target="#panel"></li>',
-        '  <li class="nav-link" data-bs-target="#panel2"></li>',
-        '</ul>',
-        '<div id="panel"></div>',
-        '<div id="panel2"></div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<ul class="nav">', '  <li class="nav-link" id="foo" data-bs-target="#panel"></li>', '  <li class="nav-link" data-bs-target="#panel2"></li>', '</ul>', '<div id="panel"></div>', '<div id="panel2"></div>'].join('')
 
       const tabEl = fixtureEl.querySelector('.nav-link')!
       const parent = fixtureEl.querySelector('.nav') as HTMLElement
@@ -331,11 +294,7 @@ describe('Tab', () => {
 
   describe('_keydown', () => {
     it('should ignore non-arrow keys', () => {
-      fixtureEl.innerHTML = [
-        '<ul class="nav">',
-        '  <li class="nav-link" data-bs-toggle="tab"></li>',
-        '</ul>'
-      ].join('')
+      fixtureEl.innerHTML = ['<ul class="nav">', '  <li class="nav-link" data-bs-toggle="tab"></li>', '</ul>'].join('')
 
       const tabEl = fixtureEl.querySelector('.nav-link')!
       const tab = new Tab(tabEl)
@@ -352,13 +311,7 @@ describe('Tab', () => {
     })
 
     it('should handle right/down arrow', () => {
-      fixtureEl.innerHTML = [
-        '<div class="nav">',
-        '  <span id="tab1" class="nav-link" data-bs-toggle="tab"></span>',
-        '  <span id="tab2" class="nav-link" data-bs-toggle="tab"></span>',
-        '  <span id="tab3" class="nav-link" data-bs-toggle="tab"></span>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="nav">', '  <span id="tab1" class="nav-link" data-bs-toggle="tab"></span>', '  <span id="tab2" class="nav-link" data-bs-toggle="tab"></span>', '  <span id="tab3" class="nav-link" data-bs-toggle="tab"></span>', '</div>'].join('')
 
       const tabEl1 = fixtureEl.querySelector('#tab1')!
       const tabEl2 = fixtureEl.querySelector('#tab2')!
@@ -377,12 +330,7 @@ describe('Tab', () => {
     })
 
     it('should handle left/up arrow', () => {
-      fixtureEl.innerHTML = [
-        '<div class="nav">',
-        '  <span id="tab1" class="nav-link" data-bs-toggle="tab"></span>',
-        '  <span id="tab2" class="nav-link" data-bs-toggle="tab"></span>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="nav">', '  <span id="tab1" class="nav-link" data-bs-toggle="tab"></span>', '  <span id="tab2" class="nav-link" data-bs-toggle="tab"></span>', '</div>'].join('')
 
       const tabEl1 = fixtureEl.querySelector('#tab1')!
       const tabEl2 = fixtureEl.querySelector('#tab2')!
@@ -398,13 +346,7 @@ describe('Tab', () => {
     })
 
     it('should handle Home key', () => {
-      fixtureEl.innerHTML = [
-        '<div class="nav">',
-        '  <span id="tab1" class="nav-link" data-bs-toggle="tab"></span>',
-        '  <span id="tab2" class="nav-link" data-bs-toggle="tab"></span>',
-        '  <span id="tab3" class="nav-link" data-bs-toggle="tab"></span>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="nav">', '  <span id="tab1" class="nav-link" data-bs-toggle="tab"></span>', '  <span id="tab2" class="nav-link" data-bs-toggle="tab"></span>', '  <span id="tab3" class="nav-link" data-bs-toggle="tab"></span>', '</div>'].join('')
 
       const tabEl1 = fixtureEl.querySelector('#tab1')!
       const tabEl3 = fixtureEl.querySelector('#tab3')!
@@ -420,13 +362,7 @@ describe('Tab', () => {
     })
 
     it('should handle End key', () => {
-      fixtureEl.innerHTML = [
-        '<div class="nav">',
-        '  <span id="tab1" class="nav-link" data-bs-toggle="tab"></span>',
-        '  <span id="tab2" class="nav-link" data-bs-toggle="tab"></span>',
-        '  <span id="tab3" class="nav-link" data-bs-toggle="tab"></span>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="nav">', '  <span id="tab1" class="nav-link" data-bs-toggle="tab"></span>', '  <span id="tab2" class="nav-link" data-bs-toggle="tab"></span>', '  <span id="tab3" class="nav-link" data-bs-toggle="tab"></span>', '</div>'].join('')
 
       const tabEl1 = fixtureEl.querySelector('#tab1')!
       const tabEl3 = fixtureEl.querySelector('#tab3')!
@@ -448,7 +384,7 @@ describe('Tab', () => {
         '  <span id="tab2" class="nav-link" data-bs-toggle="tab" disabled></span>',
         '  <span id="tab3" class="nav-link disabled" data-bs-toggle="tab"></span>',
         '  <span id="tab4" class="nav-link" data-bs-toggle="tab"></span>',
-        '</div>'
+        '</div>',
       ].join('')
 
       const tabEl1 = fixtureEl.querySelector('#tab1')!
@@ -504,7 +440,7 @@ describe('Tab', () => {
 
   describe('data-api', () => {
     it('should create dynamically a tab', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<ul class="nav nav-tabs" role="tablist">',
           '  <li class="nav-item" role="presentation"><button type="button" data-bs-target="#home" class="nav-link active" role="tab" aria-selected="true">Home</button></li>',
@@ -513,7 +449,7 @@ describe('Tab', () => {
           '<div class="tab-content">',
           '  <div class="tab-pane active" id="home" role="tabpanel"></div>',
           '  <div class="tab-pane" id="profile" role="tabpanel"></div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const secondTabTrigger = fixtureEl.querySelector('#triggerProfile')!
@@ -529,13 +465,8 @@ describe('Tab', () => {
     })
 
     it('should prevent default when trigger is <a>', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<ul class="nav" role="tablist">',
-          '  <li><a type="button" href="#test" class="active" role="tab" data-bs-toggle="tab">Home</a></li>',
-          '  <li><a type="button" href="#test2" role="tab" data-bs-toggle="tab">Profile</a></li>',
-          '</ul>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<ul class="nav" role="tablist">', '  <li><a type="button" href="#test" class="active" role="tab" data-bs-toggle="tab">Home</a></li>', '  <li><a type="button" href="#test2" role="tab" data-bs-toggle="tab">Profile</a></li>', '</ul>'].join('')
 
         const tabEl = fixtureEl.querySelector('[href="#test2"]') as HTMLElement
         const spy = vi.spyOn(Event.prototype, 'preventDefault')
@@ -556,7 +487,7 @@ describe('Tab', () => {
           '<ul class="nav nav-tabs" role="tablist">',
           '  <li class="nav-item" role="presentation"><button type="button" data-bs-target="#home" class="nav-link active" role="tab">Home</button></li>',
           '  <li class="nav-item" role="presentation"><button type="button" data-bs-target="#profile" class="nav-link" disabled role="tab" data-bs-toggle="tab">Profile</button></li>',
-          '</ul>'
+          '</ul>',
         ].join('')
 
         const triggerDisabled = fixtureEl.querySelector('button[disabled]')!
@@ -575,7 +506,7 @@ describe('Tab', () => {
           '<ul class="nav nav-tabs" role="tablist">',
           '  <li class="nav-item" role="presentation"><a href="#home" class="nav-link active" role="tab" data-bs-toggle="tab">Home</a></li>',
           '  <li class="nav-item" role="presentation"><a href="#profile" class="nav-link disabled" role="tab" data-bs-toggle="tab">Profile</a></li>',
-          '</ul>'
+          '</ul>',
         ].join('')
 
         const triggerDisabled = fixtureEl.querySelector('a.disabled')!
@@ -589,7 +520,7 @@ describe('Tab', () => {
     })
 
     it('should handle nested tabs', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<nav class="nav nav-tabs" role="tablist">',
           '  <button type="button" id="tab1" data-bs-target="#x-tab1" class="nav-link" data-bs-toggle="tab" role="tab">Tab 1</button>',
@@ -607,7 +538,7 @@ describe('Tab', () => {
           '    </div>',
           '  </div>',
           '  <div class="tab-pane active" id="x-tab2" role="tabpanel">Tab2</div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const tab1El = fixtureEl.querySelector('#tab1') as HTMLElement
@@ -640,7 +571,7 @@ describe('Tab', () => {
         '      <a class="dropdown-item" href="#dropdown2" id="dropdown2-tab" data-bs-toggle="tab">@mdo</a>',
         '    </div>',
         '  </li>',
-        '</ul>'
+        '</ul>',
       ].join('')
 
       const firstLiLinkEl = fixtureEl.querySelector('li:first-child a') as HTMLElement
@@ -670,7 +601,7 @@ describe('Tab', () => {
         '      <a class="dropdown-item" href="#dropdown2" id="dropdown2-tab" data-bs-toggle="tab">@fat</a>',
         '    </div>',
         '  </li>',
-        '</ul>'
+        '</ul>',
       ].join('')
 
       const firstDropItem = fixtureEl.querySelector('#nav1 .dropdown-item') as HTMLElement
@@ -693,7 +624,7 @@ describe('Tab', () => {
         '      <li><a class="dropdown-item" href="#dropdown2" data-bs-toggle="tab">@mdo</a></li>',
         '    </ul>',
         '  </li>',
-        '</ul>'
+        '</ul>',
       ].join('')
 
       const dropItems = fixtureEl.querySelectorAll('.dropdown-item')
@@ -705,7 +636,7 @@ describe('Tab', () => {
     })
 
     it('should add show class to pane without fade', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<ul class="nav nav-tabs" role="tablist">',
           '  <li class="nav-item" role="presentation">',
@@ -718,7 +649,7 @@ describe('Tab', () => {
           '<div class="tab-content">',
           '  <div role="tabpanel" class="tab-pane" id="home">test 1</div>',
           '  <div role="tabpanel" class="tab-pane" id="profile">test 2</div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const secondNavEl = fixtureEl.querySelector('#secondNav') as HTMLElement
@@ -735,7 +666,7 @@ describe('Tab', () => {
 
   describe('data-tblr-toggle', () => {
     it('should create tab via data-tblr-toggle="tab"', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<ul class="nav nav-tabs" role="tablist">',
           '  <li class="nav-item" role="presentation"><button type="button" data-bs-target="#home" class="nav-link active" role="tab" aria-selected="true">Home</button></li>',
@@ -744,7 +675,7 @@ describe('Tab', () => {
           '<div class="tab-content">',
           '  <div class="tab-pane active" id="home" role="tabpanel"></div>',
           '  <div class="tab-pane" id="profile" role="tabpanel"></div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const trigger = fixtureEl.querySelector('#triggerProfile') as HTMLElement
@@ -760,7 +691,7 @@ describe('Tab', () => {
     })
 
     it('should create tab via data-tblr-toggle="pill"', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<ul class="nav nav-pills" role="tablist">',
           '  <li class="nav-item" role="presentation"><button type="button" data-bs-target="#home" class="nav-link active" role="tab" aria-selected="true">Home</button></li>',
@@ -769,7 +700,7 @@ describe('Tab', () => {
           '<div class="tab-content">',
           '  <div class="tab-pane active" id="home" role="tabpanel"></div>',
           '  <div class="tab-pane" id="profile" role="tabpanel"></div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const trigger = fixtureEl.querySelector('#triggerProfile') as HTMLElement
@@ -784,12 +715,7 @@ describe('Tab', () => {
     })
 
     it('should initialize active tabs with data-tblr-toggle on load', () => {
-      fixtureEl.innerHTML = [
-        '<ul class="nav" role="tablist">',
-        '  <li><button class="nav-link active" data-tblr-toggle="tab" data-bs-target="#home" role="tab">Home</button></li>',
-        '</ul>',
-        '<div id="home" role="tabpanel"></div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<ul class="nav" role="tablist">', '  <li><button class="nav-link active" data-tblr-toggle="tab" data-bs-target="#home" role="tab">Home</button></li>', '</ul>', '<div id="home" role="tabpanel"></div>'].join('')
 
       const trigger = fixtureEl.querySelector('button') as HTMLElement
 
@@ -799,7 +725,7 @@ describe('Tab', () => {
     })
 
     it('should create tab via data-tblr-toggle="list"', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<div class="list-group" role="tablist">',
           '  <a class="list-group-item list-group-item-action active" data-tblr-toggle="list" href="#home" role="tab">Home</a>',
@@ -808,7 +734,7 @@ describe('Tab', () => {
           '<div class="tab-content">',
           '  <div class="tab-pane active" id="home" role="tabpanel">Home</div>',
           '  <div class="tab-pane" id="profile" role="tabpanel">Profile</div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const trigger = fixtureEl.querySelector('#triggerProfile') as HTMLElement
@@ -823,7 +749,7 @@ describe('Tab', () => {
     })
 
     it('should switch tabs via data-tblr-toggle with data-tblr-target', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = [
           '<ul class="nav" role="tablist">',
           '  <li><button class="nav-link active" data-tblr-toggle="tab" data-tblr-target="#home" role="tab">Home</button></li>',
@@ -832,7 +758,7 @@ describe('Tab', () => {
           '<div class="tab-content">',
           '  <div class="tab-pane active" id="home" role="tabpanel">Home</div>',
           '  <div class="tab-pane" id="profile" role="tabpanel">Profile</div>',
-          '</div>'
+          '</div>',
         ].join('')
 
         const trigger = fixtureEl.querySelector('#triggerProfile') as HTMLElement

--- a/core/js/tests/unit/toast.spec.ts
+++ b/core/js/tests/unit/toast.spec.ts
@@ -38,12 +38,8 @@ describe('Toast', () => {
     })
 
     it('should allow config in js', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="toast">',
-          '  <div class="toast-body">a simple toast</div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="toast">', '  <div class="toast-body">a simple toast</div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('div')!
         const toast = new Toast(toastEl, { delay: 1 })
@@ -58,12 +54,8 @@ describe('Toast', () => {
     })
 
     it('should close toast when dismiss button is clicked', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="toast" data-bs-delay="1" data-bs-autohide="false" data-bs-animation="false">',
-          '  <button type="button" class="btn-close" data-bs-dismiss="toast"></button>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="toast" data-bs-delay="1" data-bs-autohide="false" data-bs-animation="false">', '  <button type="button" class="btn-close" data-bs-dismiss="toast"></button>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('div')!
         const toast = new Toast(toastEl)
@@ -84,12 +76,8 @@ describe('Toast', () => {
     })
 
     it('should close toast via data-tblr-dismiss', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="toast" data-bs-delay="1" data-bs-autohide="false" data-bs-animation="false">',
-          '  <button type="button" class="btn-close" data-tblr-dismiss="toast"></button>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="toast" data-bs-delay="1" data-bs-autohide="false" data-bs-animation="false">', '  <button type="button" class="btn-close" data-tblr-dismiss="toast"></button>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('div')!
         const toast = new Toast(toastEl)
@@ -117,11 +105,7 @@ describe('Toast', () => {
 
       Toast.Default.delay = defaultDelay
 
-      fixtureEl.innerHTML = [
-        '<div class="toast" data-bs-autohide="false" data-bs-animation="false">',
-        '  <button type="button" class="btn-close" data-bs-dismiss="toast"></button>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div class="toast" data-bs-autohide="false" data-bs-animation="false">', '  <button type="button" class="btn-close" data-bs-dismiss="toast"></button>', '</div>'].join('')
 
       const toastEl = fixtureEl.querySelector('div')!
       const toast = new Toast(toastEl)
@@ -140,12 +124,8 @@ describe('Toast', () => {
 
   describe('show', () => {
     it('should auto hide', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="toast" data-bs-delay="1">',
-          '  <div class="toast-body">a simple toast</div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="toast" data-bs-delay="1">', '  <div class="toast-body">a simple toast</div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('.toast')!
         const toast = new Toast(toastEl)
@@ -160,12 +140,8 @@ describe('Toast', () => {
     })
 
     it('should not add fade class when animation is false', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="toast" data-bs-delay="1" data-bs-animation="false">',
-          '  <div class="toast-body">a simple toast</div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="toast" data-bs-delay="1" data-bs-animation="false">', '  <div class="toast-body">a simple toast</div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('.toast')!
         const toast = new Toast(toastEl)
@@ -181,16 +157,12 @@ describe('Toast', () => {
 
     it('should not trigger shown if show is prevented', () => {
       return new Promise<void>((resolve, reject) => {
-        fixtureEl.innerHTML = [
-          '<div class="toast" data-bs-delay="1" data-bs-animation="false">',
-          '  <div class="toast-body">a simple toast</div>',
-          '</div>'
-        ].join('')
+        fixtureEl.innerHTML = ['<div class="toast" data-bs-delay="1" data-bs-animation="false">', '  <div class="toast-body">a simple toast</div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('.toast')!
         const toast = new Toast(toastEl)
 
-        toastEl.addEventListener('show.bs.toast', event => {
+        toastEl.addEventListener('show.bs.toast', (event) => {
           event.preventDefault()
           setTimeout(() => {
             expect(toastEl.classList.contains('show')).toBe(false)
@@ -207,12 +179,8 @@ describe('Toast', () => {
     })
 
     it('should clear timeout on mouse interaction', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="toast">',
-          '  <div class="toast-body">a simple toast</div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="toast">', '  <div class="toast-body">a simple toast</div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('.toast')!
         const toast = new Toast(toastEl)
@@ -234,13 +202,8 @@ describe('Toast', () => {
     })
 
     it('should clear timeout on keyboard interaction', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<button id="outside">outside</button>',
-          '<div class="toast">',
-          '  <div class="toast-body">a simple toast <button>inside</button></div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<button id="outside">outside</button>', '<div class="toast">', '  <div class="toast-body">a simple toast <button>inside</button></div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('.toast')!
         const toast = new Toast(toastEl)
@@ -263,13 +226,8 @@ describe('Toast', () => {
     })
 
     it('should still auto hide after mouse and keyboard leave', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<button id="outside-focusable">outside</button>',
-          '<div class="toast">',
-          '  <div class="toast-body">a simple toast <button>inside</button></div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<button id="outside-focusable">outside</button>', '<div class="toast">', '  <div class="toast-body">a simple toast <button>inside</button></div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('.toast')!
         const toast = new Toast(toastEl)
@@ -297,13 +255,8 @@ describe('Toast', () => {
     })
 
     it('should not auto hide if focus leaves but mouse remains inside', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<button id="outside-focusable">outside</button>',
-          '<div class="toast">',
-          '  <div class="toast-body">a simple toast <button>inside</button></div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<button id="outside-focusable">outside</button>', '<div class="toast">', '  <div class="toast-body">a simple toast <button>inside</button></div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('.toast')!
         const toast = new Toast(toastEl)
@@ -328,13 +281,8 @@ describe('Toast', () => {
     })
 
     it('should not auto hide if mouse leaves but focus remains inside', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<button id="outside-focusable">outside</button>',
-          '<div class="toast">',
-          '  <div class="toast-body">a simple toast <button>inside</button></div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<button id="outside-focusable">outside</button>', '<div class="toast">', '  <div class="toast-body">a simple toast <button>inside</button></div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('.toast')!
         const toast = new Toast(toastEl)
@@ -359,12 +307,8 @@ describe('Toast', () => {
     })
 
     it('should handle _onInteraction with unknown event type', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="toast">',
-          '  <div class="toast-body">a simple toast</div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="toast">', '  <div class="toast-body">a simple toast</div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('.toast')!
         const toast = new Toast(toastEl)
@@ -385,13 +329,8 @@ describe('Toast', () => {
     })
 
     it('should not schedule hide when relatedTarget is within the toast', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<button id="outside-focusable">outside</button>',
-          '<div class="toast">',
-          '  <div class="toast-body">a simple toast <button id="inside-btn">inside</button></div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<button id="outside-focusable">outside</button>', '<div class="toast">', '  <div class="toast-body">a simple toast <button id="inside-btn">inside</button></div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('.toast')!
         const insideBtn = toastEl.querySelector('#inside-btn')!
@@ -402,7 +341,7 @@ describe('Toast', () => {
 
           const focusOutEvent = new FocusEvent('focusout', {
             bubbles: true,
-            relatedTarget: insideBtn
+            relatedTarget: insideBtn,
           })
           toast._onInteraction(focusOutEvent, false)
 
@@ -417,12 +356,8 @@ describe('Toast', () => {
 
   describe('hide', () => {
     it('should allow to hide toast manually', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="toast" data-bs-delay="1" data-bs-autohide="false">',
-          '  <div class="toast-body">a simple toast</div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="toast" data-bs-delay="1" data-bs-autohide="false">', '  <div class="toast-body">a simple toast</div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('.toast')!
         const toast = new Toast(toastEl)
@@ -454,11 +389,7 @@ describe('Toast', () => {
 
     it('should not trigger hidden if hide is prevented', () => {
       return new Promise<void>((resolve, reject) => {
-        fixtureEl.innerHTML = [
-          '<div class="toast" data-bs-delay="1" data-bs-animation="false">',
-          '  <div class="toast-body">a simple toast</div>',
-          '</div>'
-        ].join('')
+        fixtureEl.innerHTML = ['<div class="toast" data-bs-delay="1" data-bs-animation="false">', '  <div class="toast-body">a simple toast</div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('.toast')!
         const toast = new Toast(toastEl)
@@ -467,7 +398,7 @@ describe('Toast', () => {
           toast.hide()
         })
 
-        toastEl.addEventListener('hide.bs.toast', event => {
+        toastEl.addEventListener('hide.bs.toast', (event) => {
           event.preventDefault()
           setTimeout(() => {
             expect(toastEl.classList.contains('show')).toBe(true)
@@ -499,12 +430,8 @@ describe('Toast', () => {
     })
 
     it('should destroy and hide shown toast', () => {
-      return new Promise<void>(resolve => {
-        fixtureEl.innerHTML = [
-          '<div class="toast" data-bs-delay="0" data-bs-autohide="false">',
-          '  <div class="toast-body">a simple toast</div>',
-          '</div>'
-        ].join('')
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = ['<div class="toast" data-bs-delay="0" data-bs-autohide="false">', '  <div class="toast-body">a simple toast</div>', '</div>'].join('')
 
         const toastEl = fixtureEl.querySelector('div')!
         const toast = new Toast(toastEl)

--- a/core/js/tests/unit/tooltip.spec.ts
+++ b/core/js/tests/unit/tooltip.spec.ts
@@ -6,8 +6,8 @@ vi.mock('@popperjs/core', () => ({
   createPopper: vi.fn(() => ({
     destroy: vi.fn(),
     update: vi.fn(),
-    setOptions: vi.fn()
-  }))
+    setOptions: vi.fn(),
+  })),
 }))
 
 describe('Tooltip', () => {
@@ -145,7 +145,7 @@ describe('Tooltip', () => {
     })
 
     it('should toggle tooltip visibility', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })
@@ -167,7 +167,7 @@ describe('Tooltip', () => {
 
   describe('show', () => {
     it('should show tooltip', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })
@@ -192,12 +192,12 @@ describe('Tooltip', () => {
     })
 
     it('should not show if show event is prevented', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })
 
-        el.addEventListener('show.bs.tooltip', event => {
+        el.addEventListener('show.bs.tooltip', (event) => {
           event.preventDefault()
           setTimeout(() => {
             expect(tooltip._isShown()).toBe(false)
@@ -219,7 +219,7 @@ describe('Tooltip', () => {
     })
 
     it('should fire inserted event', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })
@@ -235,7 +235,7 @@ describe('Tooltip', () => {
 
   describe('hide', () => {
     it('should hide tooltip', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })
@@ -263,13 +263,13 @@ describe('Tooltip', () => {
     })
 
     it('should not hide if hide event is prevented', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })
 
         el.addEventListener('shown.bs.tooltip', () => {
-          el.addEventListener('hide.bs.tooltip', event => {
+          el.addEventListener('hide.bs.tooltip', (event) => {
             event.preventDefault()
             setTimeout(() => {
               expect(tooltip._isShown()).toBe(true)
@@ -287,7 +287,7 @@ describe('Tooltip', () => {
 
   describe('update', () => {
     it('should call popper update', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })
@@ -332,7 +332,7 @@ describe('Tooltip', () => {
     })
 
     it('should destroy popper on dispose', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })
@@ -360,7 +360,7 @@ describe('Tooltip', () => {
     })
 
     it('should update shown tooltip', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })
@@ -527,7 +527,7 @@ describe('Tooltip', () => {
 
   describe('_disposePopper', () => {
     it('should destroy popper and remove tip', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })

--- a/core/js/tests/unit/util/backdrop.spec.ts
+++ b/core/js/tests/unit/util/backdrop.spec.ts
@@ -22,7 +22,7 @@ describe('Backdrop', () => {
 
   describe('show', () => {
     it('should append the backdrop and include the "show" class', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         const instance = new Backdrop({ isVisible: true, isAnimated: false })
         const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
 
@@ -41,7 +41,7 @@ describe('Backdrop', () => {
     })
 
     it('should not append the backdrop if not visible', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         const instance = new Backdrop({ isVisible: false, isAnimated: true })
         const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
 
@@ -54,7 +54,7 @@ describe('Backdrop', () => {
     })
 
     it('should include the "fade" class if animated', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         const instance = new Backdrop({ isVisible: true, isAnimated: true })
         const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
 
@@ -73,7 +73,7 @@ describe('Backdrop', () => {
 
   describe('hide', () => {
     it('should remove the backdrop html', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         const instance = new Backdrop({ isVisible: true, isAnimated: true })
         const getElements = () => document.body.querySelectorAll(CLASS_BACKDROP)
 
@@ -89,7 +89,7 @@ describe('Backdrop', () => {
     })
 
     it('should remove the "show" class', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         const instance = new Backdrop({ isVisible: true, isAnimated: true })
         const elem = instance._getElement()
 
@@ -102,7 +102,7 @@ describe('Backdrop', () => {
     })
 
     it('should not try to remove if not visible', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         const instance = new Backdrop({ isVisible: false, isAnimated: true })
         const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
 
@@ -121,12 +121,14 @@ describe('Backdrop', () => {
 
   describe('click callback', () => {
     it('should execute callback on click', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         let called = false
         const instance = new Backdrop({
           isVisible: true,
           isAnimated: false,
-          clickCallback: () => { called = true }
+          clickCallback: () => {
+            called = true
+          },
         })
 
         instance.show(() => {
@@ -143,7 +145,7 @@ describe('Backdrop', () => {
 
   describe('Config', () => {
     it('should be appended on document.body by default', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         const instance = new Backdrop({ isVisible: true })
         instance.show(() => {
           expect(document.querySelector(CLASS_BACKDROP)!.parentElement).toBe(document.body)
@@ -153,7 +155,7 @@ describe('Backdrop', () => {
     })
 
     it('should find rootElement if passed as a string', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         const instance = new Backdrop({ isVisible: true, rootElement: 'body' })
         instance.show(() => {
           expect(document.querySelector(CLASS_BACKDROP)!.parentElement).toBe(document.body)
@@ -163,7 +165,7 @@ describe('Backdrop', () => {
     })
 
     it('should be appended on custom rootElement', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<div id="wrapper"></div>'
         const wrapper = fixtureEl.querySelector('#wrapper')!
 
@@ -176,7 +178,7 @@ describe('Backdrop', () => {
     })
 
     it('should allow configuring className', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         const instance = new Backdrop({ isVisible: true, className: 'foo' })
         instance.show(() => {
           expect(document.querySelector('.foo')).toBe(instance._getElement())
@@ -196,7 +198,7 @@ describe('Backdrop', () => {
     })
 
     it('should remove element and reset _isAppended after show', () => {
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve) => {
         const instance = new Backdrop({ isVisible: true, isAnimated: false })
         instance.show(() => {
           expect(instance._isAppended).toBe(true)

--- a/core/js/tests/unit/util/component-functions.spec.ts
+++ b/core/js/tests/unit/util/component-functions.spec.ts
@@ -30,11 +30,7 @@ describe('Component Functions', () => {
 
   describe('data-bs-dismiss', () => {
     it('should get plugin and execute given method on click', () => {
-      fixtureEl.innerHTML = [
-        '<div id="foo" class="test">',
-        '  <button type="button" data-bs-dismiss="test" data-bs-target="#foo"></button>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="foo" class="test">', '  <button type="button" data-bs-dismiss="test" data-bs-target="#foo"></button>', '</div>'].join('')
 
       const spyGet = vi.spyOn(DummyClass, 'getOrCreateInstance')
       const spyTest = vi.spyOn(DummyClass.prototype, 'testMethod')
@@ -49,11 +45,7 @@ describe('Component Functions', () => {
     })
 
     it('should use closest class when no data-bs-target', () => {
-      fixtureEl.innerHTML = [
-        '<div id="foo" class="test">',
-        '  <button type="button" data-bs-dismiss="test"></button>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="foo" class="test">', '  <button type="button" data-bs-dismiss="test"></button>', '</div>'].join('')
 
       const spyGet = vi.spyOn(DummyClass, 'getOrCreateInstance')
       const spyHide = vi.spyOn(DummyClass.prototype, 'hide')
@@ -68,11 +60,7 @@ describe('Component Functions', () => {
     })
 
     it('should not trigger if disabled', () => {
-      fixtureEl.innerHTML = [
-        '<div id="foo" class="test">',
-        '  <button type="button" disabled data-bs-dismiss="test"></button>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="foo" class="test">', '  <button type="button" disabled data-bs-dismiss="test"></button>', '</div>'].join('')
 
       const spy = vi.spyOn(DummyClass, 'getOrCreateInstance')
 
@@ -85,11 +73,7 @@ describe('Component Functions', () => {
     })
 
     it('should preventDefault for <a> elements', () => {
-      fixtureEl.innerHTML = [
-        '<div id="foo" class="test">',
-        '  <a type="button" data-bs-dismiss="test"></a>',
-        '</div>'
-      ].join('')
+      fixtureEl.innerHTML = ['<div id="foo" class="test">', '  <a type="button" data-bs-dismiss="test"></a>', '</div>'].join('')
 
       enableDismissTrigger(DummyClass)
       const preventSpy = vi.spyOn(Event.prototype, 'preventDefault')

--- a/core/js/tests/unit/util/config.spec.ts
+++ b/core/js/tests/unit/util/config.spec.ts
@@ -45,7 +45,7 @@ describe('Config', () => {
         testBool: true,
         testString: 'foo',
         testString1: 'foo',
-        testInt: 7
+        testInt: 7,
       })
 
       const instance = new DummyConfigClass()
@@ -66,14 +66,17 @@ describe('Config', () => {
         testBool: true,
         testString: 'foo',
         testString1: 'foo',
-        testInt: 7
+        testInt: 7,
       })
 
       const instance = new DummyConfigClass()
-      const result = instance._mergeConfigObj({
-        testString1: 'test',
-        testInt: 3
-      }, fixtureEl.querySelector('#test')!)
+      const result = instance._mergeConfigObj(
+        {
+          testString1: 'test',
+          testInt: 3,
+        },
+        fixtureEl.querySelector('#test')!,
+      )
 
       expect(result.testBool).toBe(false)
       expect(result.testString).toBe('foo')
@@ -88,7 +91,7 @@ describe('Config', () => {
 
       vi.spyOn(DummyConfigClass, 'Default', 'get').mockReturnValue({
         testInt: 7,
-        testInt2: 79
+        testInt2: 79,
       })
 
       const instance = new DummyConfigClass()
@@ -105,7 +108,7 @@ describe('Config', () => {
     it('should throw TypeError for wrong config types', () => {
       vi.spyOn(DummyConfigClass, 'DefaultType', 'get').mockReturnValue({
         toggle: 'boolean',
-        parent: '(string|element)'
+        parent: '(string|element)',
       })
 
       const obj = new DummyConfigClass()
@@ -119,7 +122,7 @@ describe('Config', () => {
     it('should accept null when type includes null', () => {
       vi.spyOn(DummyConfigClass, 'DefaultType', 'get').mockReturnValue({
         toggle: 'boolean',
-        parent: '(null|element)'
+        parent: '(null|element)',
       })
 
       const obj = new DummyConfigClass()
@@ -133,7 +136,7 @@ describe('Config', () => {
     it('should accept undefined when type includes undefined', () => {
       vi.spyOn(DummyConfigClass, 'DefaultType', 'get').mockReturnValue({
         toggle: 'boolean',
-        parent: '(undefined|element)'
+        parent: '(undefined|element)',
       })
 
       const obj = new DummyConfigClass()

--- a/core/js/tests/unit/util/focustrap.spec.ts
+++ b/core/js/tests/unit/util/focustrap.spec.ts
@@ -6,7 +6,7 @@ vi.mock('../../../src/bootstrap/util/index', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../src/bootstrap/util/index')>()
   return {
     ...actual,
-    isVisible: () => true
+    isVisible: () => true,
   }
 })
 
@@ -19,12 +19,7 @@ describe('FocusTrap', () => {
   })
 
   beforeEach(() => {
-    fixtureEl.innerHTML =
-      '<div id="trap" tabindex="-1">' +
-        '<button id="btn1">First</button>' +
-        '<button id="btn2">Second</button>' +
-      '</div>' +
-      '<button id="outside">Outside</button>'
+    fixtureEl.innerHTML = '<div id="trap" tabindex="-1">' + '<button id="btn1">First</button>' + '<button id="btn2">Second</button>' + '</div>' + '<button id="outside">Outside</button>'
     trapEl = fixtureEl.querySelector('#trap')!
   })
 
@@ -40,14 +35,14 @@ describe('FocusTrap', () => {
     it('Default should have correct values', () => {
       expect(FocusTrap.Default).toEqual({
         autofocus: true,
-        trapElement: null
+        trapElement: null,
       })
     })
 
     it('DefaultType should have correct values', () => {
       expect(FocusTrap.DefaultType).toEqual({
         autofocus: 'boolean',
-        trapElement: 'element'
+        trapElement: 'element',
       })
     })
   })

--- a/core/js/tests/unit/util/index.spec.ts
+++ b/core/js/tests/unit/util/index.spec.ts
@@ -1,22 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest'
-import {
-  execute,
-  executeAfterTransition,
-  findShadowRoot,
-  getElement,
-  getNextActiveElement,
-  getTransitionDurationFromElement,
-  getUID,
-  isDisabled,
-  isElement,
-  isRTL,
-  isVisible,
-  noop,
-  parseSelector,
-  reflow,
-  toType,
-  triggerTransitionEnd
-} from '../../../src/bootstrap/util/index'
+import { execute, executeAfterTransition, findShadowRoot, getElement, getNextActiveElement, getTransitionDurationFromElement, getUID, isDisabled, isElement, isRTL, isVisible, noop, parseSelector, reflow, toType, triggerTransitionEnd } from '../../../src/bootstrap/util/index'
 import { clearFixture, getFixture } from '../../helpers/fixture'
 
 describe('util/index', () => {
@@ -44,7 +27,7 @@ describe('util/index', () => {
       const original = window.CSS
       Object.defineProperty(window, 'CSS', {
         value: { escape: vi.fn((s: string) => s) },
-        configurable: true
+        configurable: true,
       })
       parseSelector('#test-id')
       expect(window.CSS.escape).toHaveBeenCalledWith('test-id')
@@ -119,7 +102,7 @@ describe('util/index', () => {
       const div = fixtureEl.querySelector('div')!
       vi.spyOn(window, 'getComputedStyle').mockReturnValue({
         transitionDuration: '0.3s',
-        transitionDelay: '0.1s'
+        transitionDelay: '0.1s',
       } as CSSStyleDeclaration)
       expect(getTransitionDurationFromElement(div)).toBe(400)
       vi.restoreAllMocks()
@@ -130,7 +113,7 @@ describe('util/index', () => {
       const div = fixtureEl.querySelector('div')!
       vi.spyOn(window, 'getComputedStyle').mockReturnValue({
         transitionDuration: '0.5s, 0.2s',
-        transitionDelay: '0.1s, 0s'
+        transitionDelay: '0.1s, 0s',
       } as CSSStyleDeclaration)
       expect(getTransitionDurationFromElement(div)).toBe(600)
       vi.restoreAllMocks()

--- a/core/js/tests/unit/util/sanitizer.spec.ts
+++ b/core/js/tests/unit/util/sanitizer.spec.ts
@@ -5,7 +5,7 @@ describe('sanitizer', () => {
   describe('DefaultAllowlist', () => {
     it('should have a wildcard entry with common attributes', () => {
       expect(DefaultAllowlist['*']).toBeDefined()
-      const wildcardStrings = DefaultAllowlist['*'].filter(a => typeof a === 'string')
+      const wildcardStrings = DefaultAllowlist['*'].filter((a) => typeof a === 'string')
       expect(wildcardStrings).toContain('class')
       expect(wildcardStrings).toContain('id')
       expect(wildcardStrings).toContain('role')

--- a/core/js/tests/unit/util/swipe.spec.ts
+++ b/core/js/tests/unit/util/swipe.spec.ts
@@ -5,7 +5,7 @@ import { clearFixture, getFixture } from '../../helpers/fixture'
 function mockTouchSupport() {
   Object.defineProperty(document.documentElement, 'ontouchstart', {
     value: () => {},
-    configurable: true
+    configurable: true,
   })
 }
 
@@ -26,7 +26,7 @@ function createTouchEvent(type: string, touches: Array<{ clientX: number }>, tar
     radiusX: 0,
     radiusY: 0,
     rotationAngle: 0,
-    force: 0
+    force: 0,
   })) as unknown as Touch[]
 
   const event = new Event(type, { bubbles: true, cancelable: true }) as TouchEvent
@@ -40,8 +40,8 @@ function createPointerEvent(type: string, opts: Partial<PointerEvent> = {}): Poi
     bubbles: true,
     cancelable: true,
     clientX: opts.clientX ?? 0,
-    pointerType: (opts as Record<string, unknown>).pointerType as string ?? 'touch',
-    ...opts
+    pointerType: ((opts as Record<string, unknown>).pointerType as string) ?? 'touch',
+    ...opts,
   })
 }
 
@@ -162,16 +162,20 @@ describe('Swipe', () => {
       const leftCallback = vi.fn()
       const swipe = new Swipe(div, { leftCallback })
 
-      div.dispatchEvent(new PointerEvent('pointerdown', {
-        bubbles: true,
-        clientX: 300,
-        pointerType: 'mouse'
-      }))
-      div.dispatchEvent(new PointerEvent('pointerup', {
-        bubbles: true,
-        clientX: 100,
-        pointerType: 'mouse'
-      }))
+      div.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          clientX: 300,
+          pointerType: 'mouse',
+        }),
+      )
+      div.dispatchEvent(
+        new PointerEvent('pointerup', {
+          bubbles: true,
+          clientX: 100,
+          pointerType: 'mouse',
+        }),
+      )
 
       expect(leftCallback).not.toHaveBeenCalled()
       swipe.dispose()
@@ -181,16 +185,20 @@ describe('Swipe', () => {
       const leftCallback = vi.fn()
       const swipe = new Swipe(div, { leftCallback })
 
-      div.dispatchEvent(new PointerEvent('pointerdown', {
-        bubbles: true,
-        clientX: 300,
-        pointerType: 'pen'
-      }))
-      div.dispatchEvent(new PointerEvent('pointerup', {
-        bubbles: true,
-        clientX: 100,
-        pointerType: 'pen'
-      }))
+      div.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          clientX: 300,
+          pointerType: 'pen',
+        }),
+      )
+      div.dispatchEvent(
+        new PointerEvent('pointerup', {
+          bubbles: true,
+          clientX: 100,
+          pointerType: 'pen',
+        }),
+      )
 
       expect(leftCallback).toHaveBeenCalledOnce()
       swipe.dispose()
@@ -296,7 +304,7 @@ describe('Swipe', () => {
       expect(Swipe.Default).toEqual({
         endCallback: null,
         leftCallback: null,
-        rightCallback: null
+        rightCallback: null,
       })
     })
 
@@ -304,7 +312,7 @@ describe('Swipe', () => {
       expect(Swipe.DefaultType).toEqual({
         endCallback: '(function|null)',
         leftCallback: '(function|null)',
-        rightCallback: '(function|null)'
+        rightCallback: '(function|null)',
       })
     })
   })

--- a/core/js/tests/unit/util/template-factory.spec.ts
+++ b/core/js/tests/unit/util/template-factory.spec.ts
@@ -30,7 +30,7 @@ describe('TemplateFactory', () => {
       it('should sanitize template by default', () => {
         const factory = new TemplateFactory({
           sanitize: true,
-          template: '<div><a href="javascript:alert(7)">Click me</a></div>'
+          template: '<div><a href="javascript:alert(7)">Click me</a></div>',
         })
         expect(factory.toHtml().innerHTML).not.toContain('href="javascript:alert(7)')
       })
@@ -38,7 +38,7 @@ describe('TemplateFactory', () => {
       it('should not sanitize template if disabled', () => {
         const factory = new TemplateFactory({
           sanitize: false,
-          template: '<div><a href="javascript:alert(7)">Click me</a></div>'
+          template: '<div><a href="javascript:alert(7)">Click me</a></div>',
         })
         expect(factory.toHtml().innerHTML).toContain('href="javascript:alert(7)')
       })
@@ -48,7 +48,7 @@ describe('TemplateFactory', () => {
           sanitize: true,
           html: true,
           template: '<div id="foo"></div>',
-          content: { '#foo': '<a href="javascript:alert(7)">Click me</a>' }
+          content: { '#foo': '<a href="javascript:alert(7)">Click me</a>' },
         })
         expect(factory.toHtml().innerHTML).not.toContain('href="javascript:alert(7)')
       })
@@ -58,7 +58,7 @@ describe('TemplateFactory', () => {
           sanitize: false,
           html: true,
           template: '<div id="foo"></div>',
-          content: { '#foo': '<a href="javascript:alert(7)">Click me</a>' }
+          content: { '#foo': '<a href="javascript:alert(7)">Click me</a>' },
         })
         expect(factory.toHtml().innerHTML).toContain('href="javascript:alert(7)')
       })
@@ -81,7 +81,7 @@ describe('TemplateFactory', () => {
         const factory = new TemplateFactory({
           extraClass() {
             return 'testClass'
-          }
+          },
         })
         expect(factory.toHtml().classList.contains('testClass')).toBe(true)
       })
@@ -93,7 +93,7 @@ describe('TemplateFactory', () => {
       const template = '<div><div class="foo"></div><div class="foo2"></div></div>'
       const factory = new TemplateFactory({
         template,
-        content: { '.foo': 'bar', '.foo2': 'bar2' }
+        content: { '.foo': 'bar', '.foo2': 'bar2' },
       })
 
       const html = factory.toHtml()
@@ -106,7 +106,7 @@ describe('TemplateFactory', () => {
         sanitize: true,
         html: true,
         template: '<div id="foo"></div>',
-        content: { '#bar': 'test' }
+        content: { '#bar': 'test' },
       })
       expect(factory.toHtml().outerHTML).toBe('<div id="foo"></div>')
     })
@@ -116,7 +116,7 @@ describe('TemplateFactory', () => {
         sanitize: true,
         html: true,
         template: '<div><div id="foo"></div></div>',
-        content: { '#foo': null }
+        content: { '#foo': null },
       })
       expect(factory.toHtml().outerHTML).toBe('<div></div>')
     })
@@ -126,7 +126,7 @@ describe('TemplateFactory', () => {
         sanitize: true,
         html: true,
         template: '<div><div id="foo"></div></div>',
-        content: { '#foo': () => null }
+        content: { '#foo': () => null },
       })
       expect(factory.toHtml().outerHTML).toBe('<div></div>')
     })
@@ -138,7 +138,7 @@ describe('TemplateFactory', () => {
       const factory = new TemplateFactory({
         html: false,
         template: '<div><div id="foo"></div></div>',
-        content: { '#foo': contentElement }
+        content: { '#foo': contentElement },
       })
 
       const fooEl = factory.toHtml().querySelector('#foo')!
@@ -154,7 +154,7 @@ describe('TemplateFactory', () => {
       const factory = new TemplateFactory({
         html: true,
         template: '<div><div id="foo"></div></div>',
-        content: { '#foo': contentElement }
+        content: { '#foo': contentElement },
       })
 
       const fooEl = factory.toHtml().querySelector('#foo')!
@@ -165,7 +165,7 @@ describe('TemplateFactory', () => {
   describe('getContent', () => {
     it('should get content as array', () => {
       const factory = new TemplateFactory({
-        content: { '.foo': 'bar', '.foo2': 'bar2' }
+        content: { '.foo': 'bar', '.foo2': 'bar2' },
       })
       expect(factory.getContent()).toEqual(['bar', 'bar2'])
     })
@@ -177,8 +177,8 @@ describe('TemplateFactory', () => {
           '.foo2': '',
           '.foo3': null,
           '.foo4': () => 2,
-          '.foo5': () => null
-        }
+          '.foo5': () => null,
+        },
       })
       expect(factory.getContent()).toEqual(['bar', 2])
     })
@@ -187,14 +187,14 @@ describe('TemplateFactory', () => {
   describe('hasContent', () => {
     it('should return true if it has content', () => {
       const factory = new TemplateFactory({
-        content: { '.foo': 'bar', '.foo2': 'bar2', '.foo3': '' }
+        content: { '.foo': 'bar', '.foo2': 'bar2', '.foo3': '' },
       })
       expect(factory.hasContent()).toBe(true)
     })
 
     it('should return false if all content is empty', () => {
       const factory = new TemplateFactory({
-        content: { '.foo2': '', '.foo3': null, '.foo4': () => null }
+        content: { '.foo2': '', '.foo3': null, '.foo4': () => null },
       })
       expect(factory.hasContent()).toBe(false)
     })
@@ -205,7 +205,7 @@ describe('TemplateFactory', () => {
       const template = '<div><div class="foo"></div><div class="foo2"></div></div>'
       const factory = new TemplateFactory({
         template,
-        content: { '.foo': 'bar', '.foo2': 'bar2' }
+        content: { '.foo': 'bar', '.foo2': 'bar2' },
       })
 
       const text = (sel: string) => factory.toHtml().querySelector(sel)!.textContent
@@ -221,7 +221,7 @@ describe('TemplateFactory', () => {
       const template = '<div><div class="foo"></div><div class="foo2"></div></div>'
       const factory = new TemplateFactory({
         template,
-        content: { '.foo': 'bar', '.foo2': 'bar2' }
+        content: { '.foo': 'bar', '.foo2': 'bar2' },
       })
 
       const text = (sel: string) => factory.toHtml().querySelector(sel)!.textContent

--- a/core/package.json
+++ b/core/package.json
@@ -35,8 +35,6 @@
     "watch-js": "nodemon --watch js/ --ext ts,js --exec \"pnpm run js-build\"",
     "bundlewatch": "bundlewatch",
     "generate-sri": "tsx .build/generate-sri.ts",
-    "format:check": "prettier --check \"scss/**/*.scss\" \"js/**/*.{js,ts}\" --cache",
-    "format:write": "prettier --write \"scss/**/*.scss\" \"js/**/*.{js,ts}\" --cache",
     "type-check": "tsc --noEmit",
     "test": "concurrently \"pnpm run test:js\" \"pnpm run test:scss\"",
     "test:js": "vitest run",

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -984,21 +984,29 @@ $aspect-ratios: (
 
 // Shadows
 $box-shadow-xs: 0 1px 2px 0 rgba(18, 18, 23, 0.05) !default;
-$box-shadow-sm: 0 1px 3px 0 rgba(18, 18, 23, 0.1), 0 1px 2px 0 rgba(18, 18, 23, 0.06) !default;
-$box-shadow-md: 0px 2px 4px -1px rgba(18, 18, 23, 0.06), 0px 4px 6px -1px rgba(18, 18, 23, 0.08) !default;
-$box-shadow-lg: 0px 4px 6px -2px rgba(18, 18, 23, 0.05), 0px 10px 15px -3px rgba(18, 18, 23, 0.08) !default;
-$box-shadow-xl: 0px 10px 10px -5px rgba(18, 18, 23, 0.04), 0px 20px 25px -5px rgba(18, 18, 23, 0.10) !default;
+$box-shadow-sm:
+  0 1px 3px 0 rgba(18, 18, 23, 0.1),
+  0 1px 2px 0 rgba(18, 18, 23, 0.06) !default;
+$box-shadow-md:
+  0px 2px 4px -1px rgba(18, 18, 23, 0.06),
+  0px 4px 6px -1px rgba(18, 18, 23, 0.08) !default;
+$box-shadow-lg:
+  0px 4px 6px -2px rgba(18, 18, 23, 0.05),
+  0px 10px 15px -3px rgba(18, 18, 23, 0.08) !default;
+$box-shadow-xl:
+  0px 10px 10px -5px rgba(18, 18, 23, 0.04),
+  0px 20px 25px -5px rgba(18, 18, 23, 0.1) !default;
 $box-shadow-2xl: 0px 25px 50px -12px rgba(18, 18, 23, 0.25) !default;
 $box-shadow-overlay:
   0px 2px 4px 0px rgba(18, 18, 23, 0.04),
   0px 5px 8px 0px rgba(18, 18, 23, 0.04),
   0px 10px 18px 0px rgba(18, 18, 23, 0.03),
   0px 24px 48px 0px rgba(18, 18, 23, 0.03),
-  0px 0px 0px 1px rgba(18, 18, 23, 0.10) !default;
+  0px 0px 0px 1px rgba(18, 18, 23, 0.1) !default;
 
 $box-shadow: $box-shadow-md !default;
 $box-shadow-transparent: 0 0 0 0 transparent !default;
-$box-shadow-border: 0px 0px 0px 1px rgba(18, 18, 23, 0.10) !default;
+$box-shadow-border: 0px 0px 0px 1px rgba(18, 18, 23, 0.1) !default;
 $box-shadow-input: $box-shadow-xs !default;
 $box-shadow-card: $box-shadow-xs !default;
 $box-shadow-card-hover: $box-shadow-lg !default;

--- a/core/scss/mixins/_mixins.scss
+++ b/core/scss/mixins/_mixins.scss
@@ -1,9 +1,9 @@
-@use "sass:meta";
-@use "../settings" as *;
-@use "../variables" as *;
-@use "functions" as *;
-@use "bootstrap/transition" as *;
-@use "bootstrap/border-radius" as *;
+@use 'sass:meta';
+@use '../settings' as *;
+@use '../variables' as *;
+@use 'functions' as *;
+@use 'bootstrap/transition' as *;
+@use 'bootstrap/border-radius' as *;
 
 @mixin subheader($include-color: true, $include-line-height: true) {
   font-size: $h5-font-size;
@@ -21,7 +21,7 @@
 }
 
 @mixin scrollbar {
-  $selector: if(sass(meta.type-of(&) != "null"): "&"; else: "*");
+  $selector: if(sass(meta.type-of(&) != 'null'): '&'; else: '*');
   #{$selector} {
     scrollbar-color: color-transparent(var(--#{$prefix}scrollbar-color, var(--#{$prefix}body-color)), 0.2) transparent;
   }

--- a/core/scss/mixins/bootstrap/_alert.scss
+++ b/core/scss/mixins/bootstrap/_alert.scss
@@ -1,7 +1,7 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // Alert variants
 //
 // Tabler overrides Bootstrap's alert-variant with an empty mixin

--- a/core/scss/mixins/bootstrap/_backdrop.scss
+++ b/core/scss/mixins/bootstrap/_backdrop.scss
@@ -1,7 +1,7 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // Shared between modals and offcanvases
 @mixin overlay-backdrop($zindex, $backdrop-bg, $backdrop-opacity) {
   position: fixed;
@@ -13,6 +13,10 @@
   background-color: $backdrop-bg;
 
   // Fade for backdrop
-  &.fade { opacity: 0; }
-  &.show { opacity: $backdrop-opacity; }
+  &.fade {
+    opacity: 0;
+  }
+  &.show {
+    opacity: $backdrop-opacity;
+  }
 }

--- a/core/scss/mixins/bootstrap/_border-radius.scss
+++ b/core/scss/mixins/bootstrap/_border-radius.scss
@@ -1,11 +1,11 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // stylelint-disable property-disallowed-list
-@use "sass:list";
-@use "sass:math";
-@use "sass:meta";
+@use 'sass:list';
+@use 'sass:math';
+@use 'sass:meta';
 
 // Single side border-radius
 

--- a/core/scss/mixins/bootstrap/_box-shadow.scss
+++ b/core/scss/mixins/bootstrap/_box-shadow.scss
@@ -1,8 +1,8 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
-@use "sass:list";
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
+@use 'sass:list';
 
 @mixin box-shadow($shadow...) {
   @if $enable-shadows {

--- a/core/scss/mixins/bootstrap/_breakpoints.scss
+++ b/core/scss/mixins/bootstrap/_breakpoints.scss
@@ -1,6 +1,6 @@
-@use "sass:list";
-@use "sass:map";
-@use "../../settings" as *;
+@use 'sass:list';
+@use 'sass:map';
+@use '../../settings' as *;
 
 // Breakpoint viewport sizes and media queries.
 //
@@ -35,7 +35,7 @@
 
 // Returns a blank string if smallest breakpoint, otherwise returns the name with a dash in front.
 @function breakpoint-infix($name, $breakpoints: $grid-breakpoints) {
-  @return if(sass(breakpoint-min($name, $breakpoints) == null): ""; else: "-#{$name}");
+  @return if(sass(breakpoint-min($name, $breakpoints) == null): ''; else: '-#{$name}');
 }
 
 // Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
@@ -84,9 +84,9 @@
 
 // Media between the breakpoint's minimum and maximum widths.
 @mixin media-breakpoint-only($name, $breakpoints: $grid-breakpoints) {
-  $min:  breakpoint-min($name, $breakpoints);
+  $min: breakpoint-min($name, $breakpoints);
   $next: breakpoint-next($name, $breakpoints);
-  $max:  breakpoint-max($next, $breakpoints);
+  $max: breakpoint-max($next, $breakpoints);
 
   @if $min != null and $max != null {
     @media (min-width: $min) and (max-width: $max) {

--- a/core/scss/mixins/bootstrap/_buttons.scss
+++ b/core/scss/mixins/bootstrap/_buttons.scss
@@ -1,8 +1,8 @@
-@use "rfs" as *;
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use 'rfs' as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // Button variants
 //
 // Tabler overrides Bootstrap's button-variant and button-outline-variant with empty mixins

--- a/core/scss/mixins/bootstrap/_caret.scss
+++ b/core/scss/mixins/bootstrap/_caret.scss
@@ -1,7 +1,7 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 @mixin caret-down($width: $caret-width) {
   border-top: $width solid;
   border-right: $width solid transparent;
@@ -29,12 +29,7 @@
   border-bottom: $width solid transparent;
 }
 
-@mixin caret(
-  $direction: down,
-  $width: $caret-width,
-  $spacing: $caret-spacing,
-  $vertical-align: $caret-vertical-align
-) {
+@mixin caret($direction: down, $width: $caret-width, $spacing: $caret-spacing, $vertical-align: $caret-vertical-align) {
   $selector: 'after';
 
   @if $direction == 'left' {

--- a/core/scss/mixins/bootstrap/_clearfix.scss
+++ b/core/scss/mixins/bootstrap/_clearfix.scss
@@ -1,11 +1,11 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 @mixin clearfix() {
   &::after {
     display: block;
     clear: both;
-    content: "";
+    content: '';
   }
 }

--- a/core/scss/mixins/bootstrap/_color-mode.scss
+++ b/core/scss/mixins/bootstrap/_color-mode.scss
@@ -1,9 +1,9 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 @mixin color-mode($mode: light, $root: false) {
-  @if $color-mode-type == "media-query" {
+  @if $color-mode-type == 'media-query' {
     @if $root == true {
       @media (prefers-color-scheme: $mode) {
         :root {
@@ -16,8 +16,8 @@
       }
     }
   } @else {
-    [data-bs-theme="#{$mode}"],
-    [data-theme="#{$mode}"] {
+    [data-bs-theme='#{$mode}'],
+    [data-theme='#{$mode}'] {
       @content;
     }
   }

--- a/core/scss/mixins/bootstrap/_color-scheme.scss
+++ b/core/scss/mixins/bootstrap/_color-scheme.scss
@@ -1,7 +1,7 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 @mixin color-scheme($name) {
   @media (prefers-color-scheme: #{$name}) {
     @content;

--- a/core/scss/mixins/bootstrap/_container.scss
+++ b/core/scss/mixins/bootstrap/_container.scss
@@ -1,15 +1,15 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // Container mixins
 
 @mixin make-container($gutter: $container-padding-x) {
   --#{$prefix}gutter-x: #{$gutter};
   --#{$prefix}gutter-y: 0;
   width: 100%;
-  padding-right: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
-  padding-left: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
+  padding-right: calc(var(--#{$prefix}gutter-x) * 0.5); // stylelint-disable-line function-disallowed-list
+  padding-left: calc(var(--#{$prefix}gutter-x) * 0.5); // stylelint-disable-line function-disallowed-list
   margin-right: auto;
   margin-left: auto;
 }

--- a/core/scss/mixins/bootstrap/_deprecate.scss
+++ b/core/scss/mixins/bootstrap/_deprecate.scss
@@ -1,7 +1,7 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // Deprecate mixin
 //
 // This mixin can be used to deprecate mixins or functions.

--- a/core/scss/mixins/bootstrap/_forms.scss
+++ b/core/scss/mixins/bootstrap/_forms.scss
@@ -1,15 +1,15 @@
-@use "border-radius" as *;
-@use "box-shadow" as *;
-@use "rfs" as *;
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use 'border-radius' as *;
+@use 'box-shadow' as *;
+@use 'rfs' as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // This mixin uses an `if()` technique to be compatible with Dart Sass
 // See https://github.com/sass/sass/issues/1873#issuecomment-152293725 for more details
 
 @mixin form-validation-state-selector($state) {
-  @if ($state == "valid" or $state == "invalid") {
+  @if ($state == 'valid' or $state == 'invalid') {
     .was-validated #{if(sass(&): "&"; else: "")}:#{$state},
     #{if(sass(&): "&"; else: "")}.is-#{$state} {
       @content;
@@ -21,15 +21,7 @@
   }
 }
 
-@mixin form-validation-state(
-  $state,
-  $color,
-  $icon,
-  $tooltip-color: color-contrast($color),
-  $tooltip-bg-color: rgba($color, $form-feedback-tooltip-opacity),
-  $focus-box-shadow: 0 0 $input-btn-focus-blur $input-focus-width rgba($color, $input-btn-focus-color-opacity),
-  $border-color: $color
-) {
+@mixin form-validation-state($state, $color, $icon, $tooltip-color: color-contrast($color), $tooltip-bg-color: rgba($color, $form-feedback-tooltip-opacity), $focus-box-shadow: 0 0 $input-btn-focus-blur $input-focus-width rgba($color, $input-btn-focus-color-opacity), $border-color: $color) {
   .#{$state}-feedback {
     display: none;
     width: 100%;
@@ -46,7 +38,7 @@
     display: none;
     max-width: 100%;
     padding: $form-feedback-tooltip-padding-y $form-feedback-tooltip-padding-x;
-    margin-top: .1rem;
+    margin-top: 0.1rem;
     @include font-size($form-feedback-tooltip-font-size);
     line-height: $form-feedback-tooltip-line-height;
     color: $tooltip-color;
@@ -100,7 +92,7 @@
 
       @if $enable-validation-icons {
         &:not([multiple]):not([size]),
-        &:not([multiple])[size="1"] {
+        &:not([multiple])[size='1'] {
           --#{$prefix}form-select-bg-icon: #{escape-svg($icon)};
           padding-right: $form-select-feedback-icon-padding-end;
           background-position: $form-select-bg-position, $form-select-feedback-icon-position;
@@ -146,7 +138,7 @@
   }
   .form-check-inline .form-check-input {
     ~ .#{$state}-feedback {
-      margin-left: .5em;
+      margin-left: 0.5em;
     }
   }
 
@@ -155,9 +147,9 @@
     > .form-select:not(:focus),
     > .form-floating:not(:focus-within) {
       @include form-validation-state-selector($state) {
-        @if $state == "valid" {
+        @if $state == 'valid' {
           z-index: 3;
-        } @else if $state == "invalid" {
+        } @else if $state == 'invalid' {
           z-index: 4;
         }
       }

--- a/core/scss/mixins/bootstrap/_gradients.scss
+++ b/core/scss/mixins/bootstrap/_gradients.scss
@@ -1,7 +1,7 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // Gradients
 
 @mixin gradient-bg($color: null) {
@@ -38,6 +38,6 @@
   background-image: radial-gradient(circle, $inner-color, $outer-color);
 }
 
-@mixin gradient-striped($color: rgba($white, .15), $angle: 45deg) {
+@mixin gradient-striped($color: rgba($white, 0.15), $angle: 45deg) {
   background-image: linear-gradient($angle, $color 25%, transparent 25%, transparent 50%, $color 50%, $color 75%, transparent 75%, transparent);
 }

--- a/core/scss/mixins/bootstrap/_grid.scss
+++ b/core/scss/mixins/bootstrap/_grid.scss
@@ -1,11 +1,11 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "../../maps" as *;
-@use "breakpoints" as *;
-@use "sass:math";
-@use "sass:map";
-@use "sass:meta";
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use '../../maps' as *;
+@use 'breakpoints' as *;
+@use 'sass:math';
+@use 'sass:map';
+@use 'sass:meta';
 
 // Grid system
 //
@@ -17,17 +17,17 @@
   display: flex;
   flex-wrap: wrap;
   margin-top: calc(-1 * var(--#{$prefix}gutter-y)); // stylelint-disable-line function-disallowed-list
-  margin-right: calc(-.5 * var(--#{$prefix}gutter-x)); // stylelint-disable-line function-disallowed-list
-  margin-left: calc(-.5 * var(--#{$prefix}gutter-x)); // stylelint-disable-line function-disallowed-list
+  margin-right: calc(-0.5 * var(--#{$prefix}gutter-x)); // stylelint-disable-line function-disallowed-list
+  margin-left: calc(-0.5 * var(--#{$prefix}gutter-x)); // stylelint-disable-line function-disallowed-list
 }
 
 @mixin make-col-ready() {
-  box-sizing: if(sass(meta.global-variable-exists("include-column-box-sizing") and $include-column-box-sizing): border-box; else: null);
+  box-sizing: if(sass(meta.global-variable-exists('include-column-box-sizing') and $include-column-box-sizing): border-box; else: null);
   flex-shrink: 0;
   width: 100%;
   max-width: 100%;
-  padding-right: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
-  padding-left: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
+  padding-right: calc(var(--#{$prefix}gutter-x) * 0.5); // stylelint-disable-line function-disallowed-list
+  padding-left: calc(var(--#{$prefix}gutter-x) * 0.5); // stylelint-disable-line function-disallowed-list
   margin-top: var(--#{$prefix}gutter-y);
 }
 
@@ -91,7 +91,7 @@
         }
 
         @for $i from 0 through ($columns - 1) {
-          @if not ($infix == "" and $i == 0) {
+          @if not($infix == '' and $i == 0) {
             .offset#{$infix}-#{$i} {
               @include make-col-offset($i, $columns);
             }

--- a/core/scss/mixins/bootstrap/_image.scss
+++ b/core/scss/mixins/bootstrap/_image.scss
@@ -1,7 +1,7 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // Image Mixins
 // - Responsive image
 // - Retina image

--- a/core/scss/mixins/bootstrap/_lists.scss
+++ b/core/scss/mixins/bootstrap/_lists.scss
@@ -1,7 +1,7 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // Lists
 
 // Unstyled keeps list items block level, just removes default browser padding and list-style

--- a/core/scss/mixins/bootstrap/_pagination.scss
+++ b/core/scss/mixins/bootstrap/_pagination.scss
@@ -1,8 +1,8 @@
-@use "rfs" as *;
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use 'rfs' as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // Pagination
 
 @mixin pagination-size($padding-y, $padding-x, $font-size, $border-radius) {

--- a/core/scss/mixins/bootstrap/_reset-text.scss
+++ b/core/scss/mixins/bootstrap/_reset-text.scss
@@ -1,7 +1,7 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 @mixin reset-text {
   font-family: $font-family-base;
   // We deliberately do NOT reset font-size or overflow-wrap / word-wrap.

--- a/core/scss/mixins/bootstrap/_resize.scss
+++ b/core/scss/mixins/bootstrap/_resize.scss
@@ -1,7 +1,7 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // Resize anything
 
 @mixin resizable($direction) {

--- a/core/scss/mixins/bootstrap/_rfs.scss
+++ b/core/scss/mixins/bootstrap/_rfs.scss
@@ -1,9 +1,9 @@
 // stylelint-disable scss/dimension-no-non-numeric-values
 
-@use "sass:map";
-@use "sass:math";
-@use "sass:meta";
-@use "sass:string";
+@use 'sass:map';
+@use 'sass:math';
+@use 'sass:meta';
+@use 'sass:string';
 
 // SCSS RFS mixin
 //
@@ -77,7 +77,7 @@ $rfs-base-value-unit: math.unit($rfs-base-value);
       $quotient: $quotient + 1;
     }
     $result: $result * 10 + $quotient;
-    $factor: $factor * .1;
+    $factor: $factor * 0.1;
     $remainder: $remainder * 10;
     $precision: $precision - 1;
     @if ($precision < 0 and $remainder >= $divisor * 5) {
@@ -88,10 +88,10 @@ $rfs-base-value-unit: math.unit($rfs-base-value);
   $dividend-unit: math.unit($dividend);
   $divisor-unit: math.unit($divisor);
   $unit-map: (
-    "px": 1px,
-    "rem": 1rem,
-    "em": 1em,
-    "%": 1%
+    'px': 1px,
+    'rem': 1rem,
+    'em': 1em,
+    '%': 1%,
   );
   @if ($dividend-unit != $divisor-unit and map.has-key($unit-map, $dividend-unit)) {
     $result: $result * map.get($unit-map, $dividend-unit);
@@ -102,8 +102,7 @@ $rfs-base-value-unit: math.unit($rfs-base-value);
 // Remove px-unit from $rfs-base-value for calculations
 @if $rfs-base-value-unit == px {
   $rfs-base-value: divide($rfs-base-value, $rfs-base-value * 0 + 1);
-}
-@else if $rfs-base-value-unit == rem {
+} @else if $rfs-base-value-unit == rem {
   $rfs-base-value: divide($rfs-base-value, divide($rfs-base-value * 0 + 1, $rfs-rem-value));
 }
 
@@ -113,8 +112,7 @@ $rfs-breakpoint-unit-cache: math.unit($rfs-breakpoint);
 // Remove unit from $rfs-breakpoint for calculations
 @if $rfs-breakpoint-unit-cache == px {
   $rfs-breakpoint: divide($rfs-breakpoint, $rfs-breakpoint * 0 + 1);
-}
-@else if $rfs-breakpoint-unit-cache == rem or $rfs-breakpoint-unit-cache == "em" {
+} @else if $rfs-breakpoint-unit-cache == rem or $rfs-breakpoint-unit-cache == 'em' {
   $rfs-breakpoint: divide($rfs-breakpoint, divide($rfs-breakpoint * 0 + 1, $rfs-rem-value));
 }
 
@@ -130,14 +128,12 @@ $rfs-mq-property-height: if(sass($rfs-mode == max-media-query): max-height; else
       @media (#{$rfs-mq-property-width}: #{$rfs-mq-value}), (#{$rfs-mq-property-height}: #{$rfs-mq-value}) {
         @content;
       }
-    }
-    @else {
+    } @else {
       @media (#{$rfs-mq-property-width}: #{$rfs-mq-value}) and (#{$rfs-mq-property-height}: #{$rfs-mq-value}) {
         @content;
       }
     }
-  }
-  @else {
+  } @else {
     @media (#{$rfs-mq-property-width}: #{$rfs-mq-value}) {
       @content;
     }
@@ -153,8 +149,7 @@ $rfs-mq-property-height: if(sass($rfs-mode == max-media-query): max-height; else
     &.disable-rfs {
       @content;
     }
-  }
-  @else if $rfs-class == enable and $rfs-mode == min-media-query {
+  } @else if $rfs-class == enable and $rfs-mode == min-media-query {
     .enable-rfs &,
     &.enable-rfs {
       @content;
@@ -166,27 +161,25 @@ $rfs-mq-property-height: if(sass($rfs-mode == max-media-query): max-height; else
 
 // Internal mixin that adds enable classes to the selector if needed.
 @mixin _rfs-media-query-rule {
-
   @if $rfs-class == enable {
     @if $rfs-mode == min-media-query {
       @content;
     }
 
-    @include _rfs-media-query () {
+    @include _rfs-media-query() {
       .enable-rfs &,
       &.enable-rfs {
         @content;
       }
     }
-  }
-  @else {
+  } @else {
     @if $rfs-class == disable and $rfs-mode == min-media-query {
       .disable-rfs &,
       &.disable-rfs {
         @content;
       }
     }
-    @include _rfs-media-query () {
+    @include _rfs-media-query() {
       @content;
     }
   }
@@ -195,29 +188,27 @@ $rfs-mq-property-height: if(sass($rfs-mode == max-media-query): max-height; else
 // Helper function to get the formatted non-responsive value
 @function rfs-value($values) {
   // Convert to list
-  $values: if(sass(meta.type-of($values) != list): ($values,); else: $values);
+  $values: if(sass(meta.type-of($values) != list): ($values); else: $values);
 
-  $val: "";
+  $val: '';
 
   // Loop over each value and calculate value
   @each $value in $values {
     @if $value == 0 {
-      $val: $val + " 0";
-    }
-    @else {
+      $val: $val + ' 0';
+    } @else {
       // Cache $value unit
-      $unit: if(sass(meta.type-of($value) == "number"): math.unit($value); else: false);
+      $unit: if(sass(meta.type-of($value) == 'number'): math.unit($value); else: false);
 
       @if $unit == px {
         // Convert to rem if needed
-        $val: $val + " " + if(sass($rfs-unit == rem): #{divide($value, $value * 0 + $rfs-rem-value)}rem; else: $value);
-      }
-      @else if $unit == rem {
+        $val: $val + ' ' + if(sass($rfs-unit == rem): #{divide($value, $value * 0 + $rfs-rem-value)}rem; else: $value);
+      } @else if $unit == rem {
         // Convert to px if needed
-        $val: $val + " " + if(sass($rfs-unit == px): #{divide($value, $value * 0 + 1) * $rfs-rem-value}px; else: $value);
+        $val: $val + ' ' + if(sass($rfs-unit == px): #{divide($value, $value * 0 + 1) * $rfs-rem-value}px; else: $value);
       } @else {
         // If $value isn't a number (like inherit) or $value has a unit (not px or rem, like 1.5em) or $ is 0, just print the value
-        $val: $val + " " + $value;
+        $val: $val + ' ' + $value;
       }
     }
   }
@@ -229,30 +220,29 @@ $rfs-mq-property-height: if(sass($rfs-mode == max-media-query): max-height; else
 // Helper function to get the responsive value calculated by RFS
 @function rfs-fluid-value($values) {
   // Convert to list
-  $values: if(sass(meta.type-of($values) != list): ($values,); else: $values);
+  $values: if(sass(meta.type-of($values) != list): ($values); else: $values);
 
-  $val: "";
+  $val: '';
 
   // Loop over each value and calculate value
   @each $value in $values {
     @if $value == 0 {
-      $val: $val + " 0";
+      $val: $val + ' 0';
     } @else {
       // Cache $value unit
-      $unit: if(sass(meta.type-of($value) == "number"): math.unit($value); else: false);
+      $unit: if(sass(meta.type-of($value) == 'number'): math.unit($value); else: false);
 
       // If $value isn't a number (like inherit) or $value has a unit (not px or rem, like 1.5em) or $ is 0, just print the value
       @if not $unit or $unit != px and $unit != rem {
-        $val: $val + " " + $value;
+        $val: $val + ' ' + $value;
       } @else {
         // Remove unit from $value for calculations
         $value: divide($value, $value * 0 + if(sass($unit == px): 1; else: divide(1, $rfs-rem-value)));
 
         // Only add the media query if the value is greater than the minimum value
         @if math.abs($value) <= $rfs-base-value or not $enable-rfs {
-          $val: $val + " " + if(sass($rfs-unit == rem): #{divide($value, $rfs-rem-value)}rem; else: #{$value}px);
-        }
-        @else {
+          $val: $val + ' ' + if(sass($rfs-unit == rem): #{divide($value, $rfs-rem-value)}rem; else: #{$value}px);
+        } @else {
           // Calculate the minimum value
           $value-min: $rfs-base-value + divide(math.abs($value) - $rfs-base-value, $rfs-factor);
 
@@ -272,7 +262,7 @@ $rfs-mq-property-height: if(sass($rfs-mode == max-media-query): max-height; else
           $variable-width: #{divide($value-diff * 100, $rfs-breakpoint)}#{$variable-unit};
 
           // Return the calculated value
-          $val: $val + " calc(" + $min-width + if(sass($value < 0): " - "; else: " + ") + $variable-width + ")";
+          $val: $val + ' calc(' + $min-width + if(sass($value < 0): ' - '; else: ' + ') + $variable-width + ')';
         }
       }
     }
@@ -291,16 +281,20 @@ $rfs-mq-property-height: if(sass($rfs-mode == max-media-query): max-height; else
     // Do not print the media query if responsive & non-responsive values are the same
     @if $val == $fluid-val {
       #{$property}: $val;
-    }
-    @else {
-      @include _rfs-rule () {
+    } @else {
+      @include _rfs-rule() {
         #{$property}: if(sass($rfs-mode == max-media-query): $val; else: $fluid-val);
 
         // Include safari iframe resize fix if needed
-        min-width: if(sass($rfs-safari-iframe-resize-bug-fix): (0 * 1vw); else: null);
+        min-width: if(
+          sass($rfs-safari-iframe-resize-bug-fix): (
+            0 * 1vw,
+          );
+          else: null
+        );
       }
 
-      @include _rfs-media-query-rule () {
+      @include _rfs-media-query-rule() {
         #{$property}: if(sass($rfs-mode == max-media-query): $fluid-val; else: $val);
       }
     }

--- a/core/scss/mixins/bootstrap/_table-variants.scss
+++ b/core/scss/mixins/bootstrap/_table-variants.scss
@@ -1,9 +1,9 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
-@use "sass:color";
-@use "sass:math";
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
+@use 'sass:color';
+@use 'sass:math';
 
 @mixin table-variant($state, $background) {
   .table-#{$state} {

--- a/core/scss/mixins/bootstrap/_text-truncate.scss
+++ b/core/scss/mixins/bootstrap/_text-truncate.scss
@@ -1,7 +1,7 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // Text truncate
 // Requires inline-block or block for proper styling
 

--- a/core/scss/mixins/bootstrap/_transition.scss
+++ b/core/scss/mixins/bootstrap/_transition.scss
@@ -1,9 +1,9 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // stylelint-disable property-disallowed-list
-@use "sass:list";
+@use 'sass:list';
 
 @mixin transition($transition...) {
   @if list.length($transition) == 0 {

--- a/core/scss/mixins/bootstrap/_utilities.scss
+++ b/core/scss/mixins/bootstrap/_utilities.scss
@@ -1,20 +1,20 @@
-@use "rfs" as *;
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
-@use "sass:list";
-@use "sass:map";
-@use "sass:meta";
-@use "sass:string";
+@use 'rfs' as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
+@use 'sass:list';
+@use 'sass:map';
+@use 'sass:meta';
+@use 'sass:string';
 
 // Utility generator
 // Used to generate utilities & print utilities
-@mixin generate-utility($utility, $infix: "", $is-rfs-media-query: false) {
+@mixin generate-utility($utility, $infix: '', $is-rfs-media-query: false) {
   $values: map.get($utility, values);
 
   // If the values are a list or string, convert it into a map
-  @if meta.type-of($values) == "string" or meta.type-of(list.nth($values, 1)) != "list" {
+  @if meta.type-of($values) == 'string' or meta.type-of(list.nth($values, 1)) != 'list' {
     $values: list.zip($values, $values);
   }
 
@@ -22,13 +22,13 @@
     $properties: map.get($utility, property);
 
     // Multiple properties are possible, for example with vertical or horizontal margins or paddings
-    @if meta.type-of($properties) == "string" {
+    @if meta.type-of($properties) == 'string' {
       $properties: list.append((), $properties);
     }
 
     // Use custom class if present
     $property-class: if(sass(map.has-key($utility, class)): map.get($utility, class); else: list.nth($properties, 1));
-    $property-class: if(sass($property-class == null): ""; else: $property-class);
+    $property-class: if(sass($property-class == null): ''; else: $property-class);
 
     // Use custom CSS variable name if present, otherwise default to `class`
     $css-variable-name: if(sass(map.has-key($utility, css-variable-name)): map.get($utility, css-variable-name); else: map.get($utility, class));
@@ -36,10 +36,10 @@
     // State params to generate pseudo-classes
     $state: if(sass(map.has-key($utility, state)): map.get($utility, state); else: ());
 
-    $infix: if(sass($property-class == "" and string.slice($infix, 1, 1) == "-"): string.slice($infix, 2); else: $infix);
+    $infix: if(sass($property-class == '' and string.slice($infix, 1, 1) == '-'): string.slice($infix, 2); else: $infix);
 
     // Don't prefix if value key is null (e.g. with shadow class)
-    $property-class-modifier: if(sass($key): if(sass($property-class == "" and $infix == ""): ""; else: "-") + $key; else: "");
+    $property-class-modifier: if(sass($key): if(sass($property-class == '' and $infix == ''): ''; else: '-') + $key; else: '');
 
     @if map.get($utility, rfs) {
       // Inside the media query
@@ -48,8 +48,7 @@
 
         // Do not render anything if fluid and non fluid values are the same
         $value: if(sass($val == rfs-fluid-value($value)): null; else: $val);
-      }
-      @else {
+      } @else {
         $value: rfs-fluid-value($value);
       }
     }

--- a/core/scss/mixins/bootstrap/_visually-hidden.scss
+++ b/core/scss/mixins/bootstrap/_visually-hidden.scss
@@ -1,7 +1,7 @@
-@use "../../settings" as *;
-@use "../../variables" as *;
-@use "../functions" as *;
-@use "breakpoints" as *;
+@use '../../settings' as *;
+@use '../../variables' as *;
+@use '../functions' as *;
+@use 'breakpoints' as *;
 // stylelint-disable declaration-no-important
 
 // Hide content visually while keeping it accessible to assistive technologies

--- a/core/scss/tests/_add-subtract.test.scss
+++ b/core/scss/tests/_add-subtract.test.scss
@@ -3,46 +3,46 @@
 // to a `calc()` expression when the operands are unit-incompatible, so the
 // branches around null-handling and the numeric-vs-calc path are what matter.
 
-@use "sass:meta";
-@use "sass:string";
-@use "../mixins/functions" as *;
+@use 'sass:meta';
+@use 'sass:string';
+@use '../mixins/functions' as *;
 
-@include describe("add") {
-  @include it("treats a null operand as the identity") {
+@include describe('add') {
+  @include it('treats a null operand as the identity') {
     @include assert-equal(add(null, 5px), 5px);
     @include assert-equal(add(5px, null), 5px);
   }
 
-  @include it("adds two compatible numbers directly") {
+  @include it('adds two compatible numbers directly') {
     @include assert-equal(add(2px, 3px), 5px);
   }
 
   // add() returns a real `calculation` here; two structurally-identical
   // calculations aren't `==` in Sass, so compare the rendered output instead.
-  @include it("falls back to calc() for incompatible units") {
-    @include assert-equal(meta.inspect(add(2px, 3%)), "calc(2px + 3%)");
+  @include it('falls back to calc() for incompatible units') {
+    @include assert-equal(meta.inspect(add(2px, 3%)), 'calc(2px + 3%)');
   }
 
-  @include it("builds a plain expression when calc is disabled") {
-    @include assert-equal(add(2px, 3%, false), string.unquote("2px + 3%"));
+  @include it('builds a plain expression when calc is disabled') {
+    @include assert-equal(add(2px, 3%, false), string.unquote('2px + 3%'));
   }
 }
 
-@include describe("subtract") {
-  @include it("returns null when both operands are null") {
+@include describe('subtract') {
+  @include it('returns null when both operands are null') {
     @include assert-equal(subtract(null, null), null);
   }
 
-  @include it("handles a single null operand") {
+  @include it('handles a single null operand') {
     @include assert-equal(subtract(5px, null), 5px);
     @include assert-equal(subtract(null, 5px), -5px);
   }
 
-  @include it("subtracts two compatible numbers directly") {
+  @include it('subtracts two compatible numbers directly') {
     @include assert-equal(subtract(5px, 2px), 3px);
   }
 
-  @include it("falls back to calc() for incompatible units") {
-    @include assert-equal(meta.inspect(subtract(5px, 2%)), "calc(5px - 2%)");
+  @include it('falls back to calc() for incompatible units') {
+    @include assert-equal(meta.inspect(subtract(5px, 2%)), 'calc(5px - 2%)');
   }
 }

--- a/core/scss/tests/_border-radius.test.scss
+++ b/core/scss/tests/_border-radius.test.scss
@@ -5,29 +5,29 @@
 // They return Sass lists, so the results are compared through `meta.inspect(...)`
 // (a single-item list is not `==` to the bare number it contains).
 
-@use "sass:meta";
-@use "../mixins/bootstrap/border-radius" as *;
+@use 'sass:meta';
+@use '../mixins/bootstrap/border-radius' as *;
 
-@include describe("valid-radius") {
-  @include it("clamps a negative value to 0") {
-    @include assert-equal(meta.inspect(valid-radius(-5px)), "0");
+@include describe('valid-radius') {
+  @include it('clamps a negative value to 0') {
+    @include assert-equal(meta.inspect(valid-radius(-5px)), '0');
   }
 
-  @include it("leaves a non-negative value untouched") {
-    @include assert-equal(meta.inspect(valid-radius(8px)), "8px");
+  @include it('leaves a non-negative value untouched') {
+    @include assert-equal(meta.inspect(valid-radius(8px)), '8px');
   }
 
-  @include it("clamps only the negative members of a list") {
-    @include assert-equal(meta.inspect(valid-radius(4px -2px 6px)), "4px 0 6px");
+  @include it('clamps only the negative members of a list') {
+    @include assert-equal(meta.inspect(valid-radius(4px -2px 6px)), '4px 0 6px');
   }
 }
 
-@include describe("squircle-radius") {
-  @include it("keeps 0 as 0") {
-    @include assert-equal(meta.inspect(squircle-radius(0)), "0");
+@include describe('squircle-radius') {
+  @include it('keeps 0 as 0') {
+    @include assert-equal(meta.inspect(squircle-radius(0)), '0');
   }
 
-  @include it("scales a non-zero radius by 2.5 via calc()") {
-    @include assert-equal(meta.inspect(squircle-radius(4px)), "calc(4px * 2.5)");
+  @include it('scales a non-zero radius by 2.5 via calc()') {
+    @include assert-equal(meta.inspect(squircle-radius(4px)), 'calc(4px * 2.5)');
   }
 }

--- a/core/scss/tests/_box-shadow.test.scss
+++ b/core/scss/tests/_box-shadow.test.scss
@@ -4,34 +4,68 @@
 // comma list. The `$enable-shadows: false` gate depends on overriding that global
 // and is not covered here.
 
-@use "../mixins/bootstrap/box-shadow" as *;
+@use '../mixins/bootstrap/box-shadow' as *;
 
-@include describe("box-shadow") {
-  @include it("emits a single shadow value") {
+@include describe('box-shadow') {
+  @include it('emits a single shadow value') {
     @include assert() {
-      @include output() { .t { @include box-shadow(0 1px 2px #000); } }
-      @include expect() { .t { box-shadow: 0 1px 2px #000; } }
+      @include output() {
+        .t {
+          @include box-shadow(0 1px 2px #000);
+        }
+      }
+      @include expect() {
+        .t {
+          box-shadow: 0 1px 2px #000;
+        }
+      }
     }
   }
 
-  @include it("passes a keyword through untouched") {
+  @include it('passes a keyword through untouched') {
     @include assert() {
-      @include output() { .t { @include box-shadow(none); } }
-      @include expect() { .t { box-shadow: none; } }
+      @include output() {
+        .t {
+          @include box-shadow(none);
+        }
+      }
+      @include expect() {
+        .t {
+          box-shadow: none;
+        }
+      }
     }
   }
 
-  @include it("joins multiple shadows into a comma list") {
+  @include it('joins multiple shadows into a comma list') {
     @include assert() {
-      @include output() { .t { @include box-shadow(0 1px 2px #000, 0 2px 4px #111); } }
-      @include expect() { .t { box-shadow: 0 1px 2px #000, 0 2px 4px #111; } }
+      @include output() {
+        .t {
+          @include box-shadow(0 1px 2px #000, 0 2px 4px #111);
+        }
+      }
+      @include expect() {
+        .t {
+          box-shadow:
+            0 1px 2px #000,
+            0 2px 4px #111;
+        }
+      }
     }
   }
 
-  @include it("filters out null values") {
+  @include it('filters out null values') {
     @include assert() {
-      @include output() { .t { @include box-shadow(null, 0 1px 2px #000); } }
-      @include expect() { .t { box-shadow: 0 1px 2px #000; } }
+      @include output() {
+        .t {
+          @include box-shadow(null, 0 1px 2px #000);
+        }
+      }
+      @include expect() {
+        .t {
+          box-shadow: 0 1px 2px #000;
+        }
+      }
     }
   }
 }

--- a/core/scss/tests/_breakpoints.test.scss
+++ b/core/scss/tests/_breakpoints.test.scss
@@ -6,39 +6,45 @@
 // `breakpoint-prev` lives in mixins/_functions.scss; the rest live in
 // mixins/bootstrap/_breakpoints.scss.
 
-@use "../mixins/functions" as fn;
-@use "../mixins/bootstrap/breakpoints" as *;
+@use '../mixins/functions' as fn;
+@use '../mixins/bootstrap/breakpoints' as *;
 
-$grid: (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px);
+$grid: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+);
 
-@include describe("breakpoint-next / breakpoint-prev") {
-  @include it("returns the neighbouring breakpoint name") {
+@include describe('breakpoint-next / breakpoint-prev') {
+  @include it('returns the neighbouring breakpoint name') {
     @include assert-equal(breakpoint-next(md, $grid), lg);
     @include assert-equal(fn.breakpoint-prev(md, $grid), sm);
   }
 
-  @include it("returns null past the last / before the first breakpoint") {
+  @include it('returns null past the last / before the first breakpoint') {
     @include assert-equal(breakpoint-next(xl, $grid), null);
     @include assert-equal(fn.breakpoint-prev(xs, $grid), null);
   }
 }
 
-@include describe("breakpoint-min") {
-  @include it("returns the min width, or null for the zero breakpoint") {
+@include describe('breakpoint-min') {
+  @include it('returns the min width, or null for the zero breakpoint') {
     @include assert-equal(breakpoint-min(md, $grid), 768px);
     @include assert-equal(breakpoint-min(xs, $grid), null);
   }
 }
 
-@include describe("breakpoint-max") {
-  @include it("subtracts 0.02px to avoid min/max overlap") {
+@include describe('breakpoint-max') {
+  @include it('subtracts 0.02px to avoid min/max overlap') {
     @include assert-equal(breakpoint-max(md, $grid), 767.98px);
   }
 }
 
-@include describe("breakpoint-infix") {
-  @include it("is blank for the smallest breakpoint and dash-prefixed otherwise") {
-    @include assert-equal(breakpoint-infix(xs, $grid), "");
-    @include assert-equal(breakpoint-infix(md, $grid), "-md");
+@include describe('breakpoint-infix') {
+  @include it('is blank for the smallest breakpoint and dash-prefixed otherwise') {
+    @include assert-equal(breakpoint-infix(xs, $grid), '');
+    @include assert-equal(breakpoint-infix(md, $grid), '-md');
   }
 }

--- a/core/scss/tests/_caret.test.scss
+++ b/core/scss/tests/_caret.test.scss
@@ -3,12 +3,16 @@
 // main `caret()` builds a pseudo-element and branches on `$direction` for the
 // rotation and (for `left`) the ::before/::after structure.
 
-@use "../mixins/bootstrap/caret" as *;
+@use '../mixins/bootstrap/caret' as *;
 
-@include describe("caret-* border helpers") {
-  @include it("caret-down points the border triangle downward") {
+@include describe('caret-* border helpers') {
+  @include it('caret-down points the border triangle downward') {
     @include assert() {
-      @include output() { .t { @include caret-down(0.3em); } }
+      @include output() {
+        .t {
+          @include caret-down(0.3em);
+        }
+      }
       @include expect() {
         .t {
           border-top: 0.3em solid;
@@ -20,9 +24,13 @@
     }
   }
 
-  @include it("caret-up points the border triangle upward") {
+  @include it('caret-up points the border triangle upward') {
     @include assert() {
-      @include output() { .t { @include caret-up(0.3em); } }
+      @include output() {
+        .t {
+          @include caret-up(0.3em);
+        }
+      }
       @include expect() {
         .t {
           border-top: 0;
@@ -34,9 +42,13 @@
     }
   }
 
-  @include it("caret-start omits the left border") {
+  @include it('caret-start omits the left border') {
     @include assert() {
-      @include output() { .t { @include caret-start(0.3em); } }
+      @include output() {
+        .t {
+          @include caret-start(0.3em);
+        }
+      }
       @include expect() {
         .t {
           border-top: 0.3em solid transparent;
@@ -48,13 +60,17 @@
   }
 }
 
-@include describe("caret mixin") {
-  @include it("renders an ::after caret rotated for the down direction") {
+@include describe('caret mixin') {
+  @include it('renders an ::after caret rotated for the down direction') {
     @include assert() {
-      @include output() { .t { @include caret(down); } }
+      @include output() {
+        .t {
+          @include caret(down);
+        }
+      }
       @include expect() {
         .t:after {
-          content: "";
+          content: '';
           display: inline-block;
           vertical-align: 0.255em;
           width: 0.3em;
@@ -69,12 +85,16 @@
     }
   }
 
-  @include it("uses ::before and clears ::after for the left direction") {
+  @include it('uses ::before and clears ::after for the left direction') {
     @include assert() {
-      @include output() { .t { @include caret(left); } }
+      @include output() {
+        .t {
+          @include caret(left);
+        }
+      }
       @include expect() {
         .t:before {
-          content: "";
+          content: '';
           display: inline-block;
           vertical-align: 0.255em;
           width: 0.3em;

--- a/core/scss/tests/_color-contrast.test.scss
+++ b/core/scss/tests/_color-contrast.test.scss
@@ -4,21 +4,21 @@
 // live in scss/_settings.scss, which functions.scss already `@use`s, so no
 // fixtures are needed — a plain `@use` of the functions module is enough.
 
-@use "../mixins/functions" as *;
+@use '../mixins/functions' as *;
 
-@include describe("color-contrast") {
-  @include it("picks black text on a light background") {
+@include describe('color-contrast') {
+  @include it('picks black text on a light background') {
     @include assert-equal(color-contrast(#ffffff), #000000);
   }
 
-  @include it("picks white text on a dark background") {
+  @include it('picks white text on a dark background') {
     @include assert-equal(color-contrast(#000000), #ffffff);
   }
 
   // When no candidate reaches the required ratio the function falls back to the
   // highest-contrast option (and emits a @warn, which sass-true ignores). An
   // impossible ratio of 21 against mid-grey forces that branch; black wins.
-  @include it("falls back to the highest-contrast colour when none qualifies") {
+  @include it('falls back to the highest-contrast colour when none qualifies') {
     @include assert-equal(color-contrast(#808080, #000, #fff, 21), #000);
   }
 }

--- a/core/scss/tests/_color-mode.test.scss
+++ b/core/scss/tests/_color-mode.test.scss
@@ -5,19 +5,21 @@
 // Tabler uses for dark mode). The `media-query` branch depends on overriding
 // that global through the variables module, so it is not covered here.
 
-@use "../mixins/bootstrap/color-mode" as *;
+@use '../mixins/bootstrap/color-mode' as *;
 
-@include describe("color-mode") {
-  @include it("scopes content under the theme attribute selectors") {
+@include describe('color-mode') {
+  @include it('scopes content under the theme attribute selectors') {
     @include assert() {
       @include output() {
         @include color-mode(dark) {
-          .x { color: red; }
+          .x {
+            color: red;
+          }
         }
       }
       @include expect() {
-        [data-bs-theme=dark] .x,
-        [data-theme=dark] .x {
+        [data-bs-theme='dark'] .x,
+        [data-theme='dark'] .x {
           color: red;
         }
       }

--- a/core/scss/tests/_color.test.scss
+++ b/core/scss/tests/_color.test.scss
@@ -4,41 +4,41 @@
 // isolation. A regression here silently degrades accessibility, which is why
 // they rank high.
 
-@use "../mixins/functions" as *;
+@use '../mixins/functions' as *;
 
-@include describe("luminance") {
-  @include it("is 0 for black and 1 for white") {
+@include describe('luminance') {
+  @include it('is 0 for black and 1 for white') {
     @include assert-equal(luminance(#000), 0);
     @include assert-equal(luminance(#fff), 1);
   }
 }
 
-@include describe("contrast-ratio") {
-  @include it("is 21 for the black/white extreme") {
+@include describe('contrast-ratio') {
+  @include it('is 21 for the black/white extreme') {
     @include assert-equal(contrast-ratio(#000, #fff), 21);
   }
 
-  @include it("is 1 for a colour against itself") {
+  @include it('is 1 for a colour against itself') {
     @include assert-equal(contrast-ratio(#fff, #fff), 1);
   }
 }
 
-@include describe("shade-color / tint-color") {
-  @include it("shade mixes the colour toward black") {
+@include describe('shade-color / tint-color') {
+  @include it('shade mixes the colour toward black') {
     @include assert-equal(shade-color(#ffffff, 10%), rgb(229.5, 229.5, 229.5));
   }
 
-  @include it("tint mixes the colour toward white") {
+  @include it('tint mixes the colour toward white') {
     @include assert-equal(tint-color(#000000, 10%), rgb(25.5, 25.5, 25.5));
   }
 }
 
-@include describe("shift-color") {
-  @include it("shades when the weight is positive") {
+@include describe('shift-color') {
+  @include it('shades when the weight is positive') {
     @include assert-equal(shift-color(#808080, 20%), shade-color(#808080, 20%));
   }
 
-  @include it("tints when the weight is negative") {
+  @include it('tints when the weight is negative') {
     @include assert-equal(shift-color(#808080, -20%), tint-color(#808080, 20%));
   }
 }

--- a/core/scss/tests/_colors-misc.test.scss
+++ b/core/scss/tests/_colors-misc.test.scss
@@ -7,73 +7,74 @@
 // a `url(...)` token; those are asserted through `meta.inspect(...)` so the
 // comparison is against the exact rendered output.
 
-@use "sass:meta";
-@use "../mixins/functions" as *;
+@use 'sass:meta';
+@use '../mixins/functions' as *;
 
-@include describe("to-rgb") {
-  @include it("returns the comma-separated rgb channels") {
+@include describe('to-rgb') {
+  @include it('returns the comma-separated rgb channels') {
     @include assert-equal(to-rgb(#ff0000), (255, 0, 0));
     @include assert-equal(to-rgb(#123456), (18, 52, 86));
   }
 }
 
-@include describe("opaque") {
-  @include it("flattens a translucent foreground over the background") {
+@include describe('opaque') {
+  @include it('flattens a translucent foreground over the background') {
     @include assert-equal(opaque(#fff, rgba(#000, 0.5)), rgb(127.5, 127.5, 127.5));
   }
 
-  @include it("returns the foreground unchanged when it is fully opaque") {
+  @include it('returns the foreground unchanged when it is fully opaque') {
     @include assert-equal(opaque(#fff, #000), black);
   }
 }
 
-@include describe("to-percentage") {
-  @include it("converts a unitless number to a percentage") {
+@include describe('to-percentage') {
+  @include it('converts a unitless number to a percentage') {
     @include assert-equal(to-percentage(0.5), 50%);
   }
 
-  @include it("passes a value that already has a unit straight through") {
+  @include it('passes a value that already has a unit straight through') {
     @include assert-equal(to-percentage(10px), 10px);
   }
 }
 
-@include describe("color-transparent") {
-  @include it("returns the colour untouched when alpha is 1") {
+@include describe('color-transparent') {
+  @include it('returns the colour untouched when alpha is 1') {
     @include assert-equal(color-transparent(#f00, 1), #f00);
   }
 
-  @include it("builds a color-mix() with the alpha as a percentage otherwise") {
-    @include assert-equal(
-      meta.inspect(color-transparent(#f00, 0.5)),
-      "color-mix(in srgb, #f00 50%, transparent)"
-    );
+  @include it('builds a color-mix() with the alpha as a percentage otherwise') {
+    @include assert-equal(meta.inspect(color-transparent(#f00, 0.5)), 'color-mix(in srgb, #f00 50%, transparent)');
   }
 }
 
-@include describe("url-svg") {
+@include describe('url-svg') {
   @include it("percent-encodes '#' so the data URI stays valid") {
-    @include assert-equal(
-      meta.inspect(url-svg("#")),
-      'url("data:image/svg+xml;charset=UTF-8,%23")'
-    );
+    @include assert-equal(meta.inspect(url-svg('#')), 'url("data:image/svg+xml;charset=UTF-8,%23")');
   }
 
-  @include it("injects the SVG xmlns attribute") {
-    @include assert-equal(
-      meta.inspect(url-svg("<svg></svg>")),
-      "url('data:image/svg+xml;charset=UTF-8,<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>')"
-    );
+  @include it('injects the SVG xmlns attribute') {
+    @include assert-equal(meta.inspect(url-svg('<svg></svg>')), 'url(\'data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg"></svg>\')');
   }
 }
 
-@include describe("map-loop") {
+@include describe('map-loop') {
   // Applies a module-level function (resolved by name via meta.get-function) to
   // every value in the map. `to-percentage` lives in the same module, so it
   // resolves correctly.
-  @include it("maps every value through the named function") {
+  @include it('maps every value through the named function') {
     @include assert-equal(
-      map-loop((a: 0.5, b: 0.25), "to-percentage", "$value"),
-      (a: 50%, b: 25%)
+      map-loop(
+        (
+          a: 0.5,
+          b: 0.25,
+        ),
+        'to-percentage',
+        '$value'
+      ),
+      (
+        a: 50%,
+        b: 25%,
+      )
     );
   }
 }

--- a/core/scss/tests/_css-var.test.scss
+++ b/core/scss/tests/_css-var.test.scss
@@ -3,18 +3,18 @@
 // in scss/_settings.scss (already `@use`d by functions.scss), so a plain `@use`
 // of the functions module is enough — no fixtures.
 
-@use "sass:meta";
-@use "../mixins/functions" as *;
+@use 'sass:meta';
+@use '../mixins/functions' as *;
 
-@include describe("varify") {
+@include describe('varify') {
   // `varify` seeds its accumulator with `null`, so the raw list inspects as
   // `null var(...) ...`; Sass drops the null when serialising to CSS, so the
   // behaviour is asserted through the rendered output rather than the value.
-  @include it("prefixes each entry as a space-separated var() list") {
+  @include it('prefixes each entry as a space-separated var() list') {
     @include assert() {
       @include output() {
         .t {
-          padding: varify(("gutter-x" "gutter-y"));
+          padding: varify(('gutter-x' 'gutter-y'));
         }
       }
       @include expect() {
@@ -26,18 +26,12 @@
   }
 }
 
-@include describe("rgba-css-var") {
-  @include it("builds a color-mix() from the identifier and target opacity") {
-    @include assert-equal(
-      meta.inspect(rgba-css-var("primary", "bg")),
-      "color-mix(in srgb, var(--tblr-primary) calc(var(--tblr-bg-opacity) * 100%), transparent)"
-    );
+@include describe('rgba-css-var') {
+  @include it('builds a color-mix() from the identifier and target opacity') {
+    @include assert-equal(meta.inspect(rgba-css-var('primary', 'bg')), 'color-mix(in srgb, var(--tblr-primary) calc(var(--tblr-bg-opacity) * 100%), transparent)');
   }
 
-  @include it("special-cases the body background") {
-    @include assert-equal(
-      meta.inspect(rgba-css-var("body", "bg")),
-      "color-mix(in srgb, var(--tblr-body-bg) calc(var(--tblr-bg-opacity) * 100%), transparent)"
-    );
+  @include it('special-cases the body background') {
+    @include assert-equal(meta.inspect(rgba-css-var('body', 'bg')), 'color-mix(in srgb, var(--tblr-body-bg) calc(var(--tblr-bg-opacity) * 100%), transparent)');
   }
 }

--- a/core/scss/tests/_divide.test.scss
+++ b/core/scss/tests/_divide.test.scss
@@ -7,38 +7,38 @@
 // and cannot be caught by sass-true (there is no assert-throws), so it is not
 // covered here.
 
-@use "../mixins/functions" as *;
+@use '../mixins/functions' as *;
 
-@include describe("divide") {
-  @include it("divides two unitless numbers") {
+@include describe('divide') {
+  @include it('divides two unitless numbers') {
     @include assert-equal(divide(4, 2), 2);
   }
 
-  @include it("returns a fractional result") {
+  @include it('returns a fractional result') {
     @include assert-equal(divide(10, 4), 2.5);
     @include assert-equal(divide(1, 2), 0.5);
   }
 
-  @include it("returns 0 when the dividend is 0") {
+  @include it('returns 0 when the dividend is 0') {
     @include assert-equal(divide(0, 5), 0);
   }
 
-  @include it("keeps the correct sign for mixed-sign operands") {
+  @include it('keeps the correct sign for mixed-sign operands') {
     @include assert-equal(divide(-6, 2), -3);
     @include assert-equal(divide(6, -2), -3);
     @include assert-equal(divide(-6, -2), 3);
   }
 
-  @include it("propagates the dividend unit when the divisor is unitless") {
+  @include it('propagates the dividend unit when the divisor is unitless') {
     @include assert-equal(divide(10px, 2), 5px);
     @include assert-equal(divide(5%, 2), 2.5%);
   }
 
-  @include it("cancels matching units to a unitless result") {
+  @include it('cancels matching units to a unitless result') {
     @include assert-equal(divide(10px, 2px), 5);
   }
 
-  @include it("rounds to the requested precision") {
+  @include it('rounds to the requested precision') {
     @include assert-equal(divide(2, 3, 0), 1);
     @include assert-equal(divide(2, 3, 2), 0.67);
   }

--- a/core/scss/tests/_escape-svg.test.scss
+++ b/core/scss/tests/_escape-svg.test.scss
@@ -5,17 +5,14 @@
 // the functions module is enough — no fixtures. Escaping only happens when the
 // string looks like an SVG data URI; anything else is returned untouched.
 
-@use "../mixins/functions" as *;
+@use '../mixins/functions' as *;
 
-@include describe("escape-svg") {
-  @include it("returns a non data-URI string unchanged") {
-    @include assert-equal(escape-svg("no data uri <here>"), "no data uri <here>");
+@include describe('escape-svg') {
+  @include it('returns a non data-URI string unchanged') {
+    @include assert-equal(escape-svg('no data uri <here>'), 'no data uri <here>');
   }
 
-  @include it("percent-encodes reserved characters inside an SVG data URI") {
-    @include assert-equal(
-      escape-svg("data:image/svg+xml,<svg><path/></svg>"),
-      "data:image/svg+xml,%3csvg%3e%3cpath/%3e%3c/svg%3e"
-    );
+  @include it('percent-encodes reserved characters inside an SVG data URI') {
+    @include assert-equal(escape-svg('data:image/svg+xml,<svg><path/></svg>'), 'data:image/svg+xml,%3csvg%3e%3cpath/%3e%3c/svg%3e');
   }
 }

--- a/core/scss/tests/_generate-utility.test.scss
+++ b/core/scss/tests/_generate-utility.test.scss
@@ -9,39 +9,73 @@
 // single vs multiple properties, custom class, css-var mode, pseudo-class
 // states and the responsive infix.
 
-@use "sass:map";
-@use "../mixins/bootstrap/utilities" as *;
-@use "../mixins/bootstrap/breakpoints" as *;
+@use 'sass:map';
+@use '../mixins/bootstrap/utilities' as *;
+@use '../mixins/bootstrap/breakpoints' as *;
 
-@include describe("generate-utility") {
-  @include it("generates a class per key from a values map") {
+@include describe('generate-utility') {
+  @include it('generates a class per key from a values map') {
     @include assert() {
       @include output() {
-        @include generate-utility((property: opacity, values: (0: 0, 50: 0.5)));
+        @include generate-utility(
+          (
+            property: opacity,
+            values: (
+              0: 0,
+              50: 0.5,
+            ),
+          )
+        );
       }
       @include expect() {
-        .opacity-0 { opacity: 0 !important; }
-        .opacity-50 { opacity: 0.5 !important; }
+        .opacity-0 {
+          opacity: 0 !important;
+        }
+        .opacity-50 {
+          opacity: 0.5 !important;
+        }
       }
     }
   }
 
-  @include it("zips a plain list of values into key/value pairs") {
+  @include it('zips a plain list of values into key/value pairs') {
     @include assert() {
       @include output() {
-        @include generate-utility((property: float, class: float, values: (left, right)));
+        @include generate-utility(
+          (
+            property: float,
+            class: float,
+            values: (
+              left,
+              right,
+            ),
+          )
+        );
       }
       @include expect() {
-        .float-left { float: left !important; }
-        .float-right { float: right !important; }
+        .float-left {
+          float: left !important;
+        }
+        .float-right {
+          float: right !important;
+        }
       }
     }
   }
 
-  @include it("emits every property when several are given") {
+  @include it('emits every property when several are given') {
     @include assert() {
       @include output() {
-        @include generate-utility((property: (margin-right margin-left), class: mx, values: (0: 0, auto: auto)));
+        @include generate-utility(
+          (
+            property: margin-right margin-left,
+            class: mx,
+            values: (
+              0: 0,
+              auto: auto,
+            ),
+          )
+        );
       }
       @include expect() {
         .mx-0 {
@@ -56,10 +90,19 @@
     }
   }
 
-  @include it("sets a custom property instead of a declaration in css-var mode") {
+  @include it('sets a custom property instead of a declaration in css-var mode') {
     @include assert() {
       @include output() {
-        @include generate-utility((property: opacity, class: opacity, css-var: true, values: (50: 0.5)));
+        @include generate-utility(
+          (
+            property: opacity,
+            class: opacity,
+            css-var: true,
+            values: (
+              50: 0.5,
+            ),
+          )
+        );
       }
       @include expect() {
         .opacity-50 {
@@ -69,25 +112,45 @@
     }
   }
 
-  @include it("adds a pseudo-class variant for each declared state") {
+  @include it('adds a pseudo-class variant for each declared state') {
     @include assert() {
       @include output() {
-        @include generate-utility((property: text-decoration, class: text-decoration, state: hover, values: (underline)));
+        @include generate-utility(
+          (
+            property: text-decoration,
+            class: text-decoration,
+            state: hover,
+            values: (underline),
+          )
+        );
       }
       @include expect() {
-        .text-decoration-underline { text-decoration: underline !important; }
-        .text-decoration-underline-hover:hover { text-decoration: underline !important; }
+        .text-decoration-underline {
+          text-decoration: underline !important;
+        }
+        .text-decoration-underline-hover:hover {
+          text-decoration: underline !important;
+        }
       }
     }
   }
 
-  @include it("injects the responsive infix into the class name") {
+  @include it('injects the responsive infix into the class name') {
     @include assert() {
       @include output() {
-        @include generate-utility((property: display, class: d, values: (none)), "-md");
+        @include generate-utility(
+          (
+            property: display,
+            class: d,
+            values: (none),
+          ),
+          '-md'
+        );
       }
       @include expect() {
-        .d-md-none { display: none !important; }
+        .d-md-none {
+          display: none !important;
+        }
       }
     }
   }
@@ -98,21 +161,40 @@
 // the mixin for a given infix when `map.get($utility, responsive)` is truthy (or
 // it's the base, infix-less breakpoint). This reproduces that gate against a local
 // breakpoint map with two utilities: one `responsive: true`, one without.
-@include describe("generate-utility (responsive property)") {
-  $g: (xs: 0, sm: 576px, md: 768px);
+@include describe('generate-utility (responsive property)') {
+  $g: (
+    xs: 0,
+    sm: 576px,
+    md: 768px,
+  );
   $utils: (
-    "display": (property: display, class: d, responsive: true, values: (none, flex)),
-    "float": (property: float, class: float, values: (left, right)),
+    'display': (
+      property: display,
+      class: d,
+      responsive: true,
+      values: (
+        none,
+        flex,
+      ),
+    ),
+    'float': (
+      property: float,
+      class: float,
+      values: (
+        left,
+        right,
+      ),
+    ),
   );
 
-  @include it("only a `responsive: true` utility gets breakpoint-infixed variants") {
+  @include it('only a `responsive: true` utility gets breakpoint-infixed variants') {
     @include assert() {
       @include output() {
         @each $bp in map.keys($g) {
           @include media-breakpoint-up($bp, $g) {
             $infix: breakpoint-infix($bp, $g);
             @each $key, $utility in $utils {
-              @if map.get($utility, responsive) or $infix == "" {
+              @if map.get($utility, responsive) or $infix == '' {
                 @include generate-utility($utility, $infix);
               }
             }
@@ -121,20 +203,36 @@
       }
       @include expect() {
         // base breakpoint: both utilities emit bare classes
-        .d-none { display: none !important; }
-        .d-flex { display: flex !important; }
-        .float-left { float: left !important; }
-        .float-right { float: right !important; }
+        .d-none {
+          display: none !important;
+        }
+        .d-flex {
+          display: flex !important;
+        }
+        .float-left {
+          float: left !important;
+        }
+        .float-right {
+          float: right !important;
+        }
 
         // responsive breakpoints: only `d` (responsive: true) is repeated; `float` is not
         @media (min-width: 576px) {
-          .d-sm-none { display: none !important; }
-          .d-sm-flex { display: flex !important; }
+          .d-sm-none {
+            display: none !important;
+          }
+          .d-sm-flex {
+            display: flex !important;
+          }
         }
 
         @media (min-width: 768px) {
-          .d-md-none { display: none !important; }
-          .d-md-flex { display: flex !important; }
+          .d-md-none {
+            display: none !important;
+          }
+          .d-md-flex {
+            display: flex !important;
+          }
         }
       }
     }

--- a/core/scss/tests/_grid.test.scss
+++ b/core/scss/tests/_grid.test.scss
@@ -3,62 +3,118 @@
 // + math.percentage); `$columns` is passed explicitly so the tests don't depend
 // on the global `$grid-columns`.
 
-@use "../mixins/bootstrap/grid" as *;
+@use '../mixins/bootstrap/grid' as *;
 
-@include describe("make-col") {
-  @include it("sets a fixed width as a percentage of the column count") {
+@include describe('make-col') {
+  @include it('sets a fixed width as a percentage of the column count') {
     @include assert() {
-      @include output() { .t { @include make-col(6, 12); } }
-      @include expect() { .t { flex: 0 0 auto; width: 50%; } }
+      @include output() {
+        .t {
+          @include make-col(6, 12);
+        }
+      }
+      @include expect() {
+        .t {
+          flex: 0 0 auto;
+          width: 50%;
+        }
+      }
     }
   }
 
-  @include it("grows to fill the row when no size is given") {
+  @include it('grows to fill the row when no size is given') {
     @include assert() {
-      @include output() { .t { @include make-col(); } }
-      @include expect() { .t { flex: 1 1 0; max-width: 100%; } }
-    }
-  }
-}
-
-@include describe("make-col-auto") {
-  @include it("sizes to the content") {
-    @include assert() {
-      @include output() { .t { @include make-col-auto(); } }
-      @include expect() { .t { flex: 0 0 auto; width: auto; } }
-    }
-  }
-}
-
-@include describe("make-col-offset") {
-  @include it("offsets by a percentage of the column count") {
-    @include assert() {
-      @include output() { .t { @include make-col-offset(3, 12); } }
-      @include expect() { .t { margin-left: 25%; } }
-    }
-  }
-
-  @include it("collapses a zero offset to 0 (not 0%)") {
-    @include assert() {
-      @include output() { .t { @include make-col-offset(0, 12); } }
-      @include expect() { .t { margin-left: 0; } }
+      @include output() {
+        .t {
+          @include make-col();
+        }
+      }
+      @include expect() {
+        .t {
+          flex: 1 1 0;
+          max-width: 100%;
+        }
+      }
     }
   }
 }
 
-@include describe("row-cols") {
-  @include it("splits children into equal fractions of the row") {
+@include describe('make-col-auto') {
+  @include it('sizes to the content') {
     @include assert() {
-      @include output() { .t { @include row-cols(3); } }
-      @include expect() { .t > * { flex: 0 0 auto; width: 33.33333333%; } }
+      @include output() {
+        .t {
+          @include make-col-auto();
+        }
+      }
+      @include expect() {
+        .t {
+          flex: 0 0 auto;
+          width: auto;
+        }
+      }
     }
   }
 }
 
-@include describe("make-row") {
-  @include it("sets the gutter custom properties and negative margins") {
+@include describe('make-col-offset') {
+  @include it('offsets by a percentage of the column count') {
     @include assert() {
-      @include output() { .t { @include make-row(1rem); } }
+      @include output() {
+        .t {
+          @include make-col-offset(3, 12);
+        }
+      }
+      @include expect() {
+        .t {
+          margin-left: 25%;
+        }
+      }
+    }
+  }
+
+  @include it('collapses a zero offset to 0 (not 0%)') {
+    @include assert() {
+      @include output() {
+        .t {
+          @include make-col-offset(0, 12);
+        }
+      }
+      @include expect() {
+        .t {
+          margin-left: 0;
+        }
+      }
+    }
+  }
+}
+
+@include describe('row-cols') {
+  @include it('splits children into equal fractions of the row') {
+    @include assert() {
+      @include output() {
+        .t {
+          @include row-cols(3);
+        }
+      }
+      @include expect() {
+        .t > * {
+          flex: 0 0 auto;
+          width: 33.33333333%;
+        }
+      }
+    }
+  }
+}
+
+@include describe('make-row') {
+  @include it('sets the gutter custom properties and negative margins') {
+    @include assert() {
+      @include output() {
+        .t {
+          @include make-row(1rem);
+        }
+      }
       @include expect() {
         .t {
           --tblr-gutter-x: 1rem;
@@ -74,10 +130,14 @@
   }
 }
 
-@include describe("make-col-ready") {
-  @include it("primes a column with full width and gutter padding") {
+@include describe('make-col-ready') {
+  @include it('primes a column with full width and gutter padding') {
     @include assert() {
-      @include output() { .t { @include make-col-ready(); } }
+      @include output() {
+        .t {
+          @include make-col-ready();
+        }
+      }
       @include expect() {
         .t {
           flex-shrink: 0;

--- a/core/scss/tests/_maps.test.scss
+++ b/core/scss/tests/_maps.test.scss
@@ -1,38 +1,76 @@
 // Priority 3 — unit tests for the map utilities in scss/mixins/_functions.scss.
 // The test maps are built inline, so no project config is required.
 
-@use "../mixins/functions" as *;
+@use '../mixins/functions' as *;
 
-@include describe("negativify-map") {
-  @include it("prefixes keys with `n` and negates the values") {
+@include describe('negativify-map') {
+  @include it('prefixes keys with `n` and negates the values') {
     @include assert-equal(
-      negativify-map((1: 10px, 2: 20px)),
-      ("n1": -10px, "n2": -20px)
+      negativify-map(
+        (
+          1: 10px,
+          2: 20px,
+        )
+      ),
+      (
+        'n1': -10px,
+        'n2': -20px,
+      )
     );
   }
 
-  @include it("leaves a 0 key untouched") {
+  @include it('leaves a 0 key untouched') {
     @include assert-equal(
-      negativify-map((0: 0, 1: 5px)),
-      ("n1": -5px)
+      negativify-map(
+        (
+          0: 0,
+          1: 5px,
+        )
+      ),
+      (
+        'n1': -5px,
+      )
     );
   }
 }
 
-@include describe("map-get-multiple") {
-  @include it("keeps only the requested keys, preserving map order") {
+@include describe('map-get-multiple') {
+  @include it('keeps only the requested keys, preserving map order') {
     @include assert-equal(
-      map-get-multiple((a: 1, b: 2, c: 3), (a c)),
-      (a: 1, c: 3)
+      map-get-multiple(
+        (
+          a: 1,
+          b: 2,
+          c: 3,
+        ),
+        (a c)
+      ),
+      (
+        a: 1,
+        c: 3,
+      )
     );
   }
 }
 
-@include describe("map-merge-multiple") {
-  @include it("merges maps left-to-right, later keys winning") {
+@include describe('map-merge-multiple') {
+  @include it('merges maps left-to-right, later keys winning') {
     @include assert-equal(
-      map-merge-multiple((a: 1), (b: 2), (a: 3)),
-      (a: 3, b: 2)
+      map-merge-multiple(
+        (
+          a: 1,
+        ),
+        (
+          b: 2,
+        ),
+        (
+          a: 3,
+        )
+      ),
+      (
+        a: 3,
+        b: 2,
+      )
     );
   }
 }

--- a/core/scss/tests/_media-breakpoint.test.scss
+++ b/core/scss/tests/_media-breakpoint.test.scss
@@ -9,130 +9,168 @@
 // Max-widths are the breakpoint value minus 0.02px (the min-/max- overlap fix);
 // the smallest/edge cases emit the content with no media query at all.
 
-@use "../mixins/bootstrap/breakpoints" as *;
-@use "../mixins/functions" as *;
+@use '../mixins/bootstrap/breakpoints' as *;
+@use '../mixins/functions' as *;
 
-$g: (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px);
+$g: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+);
 
-@include describe("media-breakpoint-up") {
-  @include it("wraps content in a min-width query") {
+@include describe('media-breakpoint-up') {
+  @include it('wraps content in a min-width query') {
     @include assert() {
       @include output() {
         @include media-breakpoint-up(md, $g) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
       @include expect() {
         @media (min-width: 768px) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
     }
   }
 
-  @include it("emits content directly for the zero breakpoint") {
+  @include it('emits content directly for the zero breakpoint') {
     @include assert() {
       @include output() {
         @include media-breakpoint-up(xs, $g) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
       @include expect() {
-        .t { color: red; }
+        .t {
+          color: red;
+        }
       }
     }
   }
 }
 
-@include describe("media-breakpoint-down") {
-  @include it("wraps content in a max-width query (value - 0.02px)") {
+@include describe('media-breakpoint-down') {
+  @include it('wraps content in a max-width query (value - 0.02px)') {
     @include assert() {
       @include output() {
         @include media-breakpoint-down(md, $g) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
       @include expect() {
         @media (max-width: 767.98px) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
     }
   }
 
-  @include it("emits content directly for the zero breakpoint") {
+  @include it('emits content directly for the zero breakpoint') {
     @include assert() {
       @include output() {
         @include media-breakpoint-down(xs, $g) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
       @include expect() {
-        .t { color: red; }
+        .t {
+          color: red;
+        }
       }
     }
   }
 }
 
-@include describe("media-breakpoint-between") {
-  @include it("combines a min-width and a max-width query") {
+@include describe('media-breakpoint-between') {
+  @include it('combines a min-width and a max-width query') {
     @include assert() {
       @include output() {
         @include media-breakpoint-between(sm, md, $g) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
       @include expect() {
         @media (min-width: 576px) and (max-width: 767.98px) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
     }
   }
 }
 
-@include describe("media-breakpoint-only") {
-  @include it("spans from the breakpoint min to the next breakpoint max") {
+@include describe('media-breakpoint-only') {
+  @include it('spans from the breakpoint min to the next breakpoint max') {
     @include assert() {
       @include output() {
         @include media-breakpoint-only(md, $g) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
       @include expect() {
         @media (min-width: 768px) and (max-width: 991.98px) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
     }
   }
 }
 
-@include describe("media-breakpoint-down-than") {
-  @include it("targets everything below the previous breakpoint") {
+@include describe('media-breakpoint-down-than') {
+  @include it('targets everything below the previous breakpoint') {
     @include assert() {
       @include output() {
         @include media-breakpoint-down-than(md, $g) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
       @include expect() {
         @media (max-width: 575.98px) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
     }
   }
 
-  @include it("emits content directly when there is no previous breakpoint") {
+  @include it('emits content directly when there is no previous breakpoint') {
     @include assert() {
       @include output() {
         @include media-breakpoint-down-than(xs, $g) {
-          .t { color: red; }
+          .t {
+            color: red;
+          }
         }
       }
       @include expect() {
-        .t { color: red; }
+        .t {
+          color: red;
+        }
       }
     }
   }

--- a/core/scss/tests/_mixins-bootstrap.test.scss
+++ b/core/scss/tests/_mixins-bootstrap.test.scss
@@ -2,11 +2,11 @@
 // dependency on project variables, so they are pulled in directly by path.
 // `output()` / `expect()` come from the `true` module (injected by the runner).
 
-@use "../mixins/bootstrap/clearfix" as *;
-@use "../mixins/bootstrap/visually-hidden" as *;
+@use '../mixins/bootstrap/clearfix' as *;
+@use '../mixins/bootstrap/visually-hidden' as *;
 
-@include describe("clearfix mixin") {
-  @include it("emits a clearing ::after pseudo-element") {
+@include describe('clearfix mixin') {
+  @include it('emits a clearing ::after pseudo-element') {
     @include assert() {
       @include output() {
         .t {
@@ -17,15 +17,15 @@
         .t::after {
           display: block;
           clear: both;
-          content: "";
+          content: '';
         }
       }
     }
   }
 }
 
-@include describe("visually-hidden mixin") {
-  @include it("hides the element while keeping it accessible") {
+@include describe('visually-hidden mixin') {
+  @include it('hides the element while keeping it accessible') {
     @include assert() {
       @include output() {
         .t {

--- a/core/scss/tests/_mixins.test.scss
+++ b/core/scss/tests/_mixins.test.scss
@@ -5,10 +5,10 @@
 // means the assertions run against real values — `$prefix` = "tblr-", the real
 // `$h5-font-size`, etc. — instead of fixtures.
 
-@use "../mixins/mixins" as *;
+@use '../mixins/mixins' as *;
 
-@include describe("subheader mixin") {
-  @include it("outputs the full subheader with colour and line-height") {
+@include describe('subheader mixin') {
+  @include it('outputs the full subheader with colour and line-height') {
     @include assert() {
       @include output() {
         .t {
@@ -28,7 +28,7 @@
     }
   }
 
-  @include it("drops colour and line-height when the flags are false") {
+  @include it('drops colour and line-height when the flags are false') {
     @include assert() {
       @include output() {
         .t {
@@ -47,8 +47,8 @@
   }
 }
 
-@include describe("autodark-image mixin") {
-  @include it("inverts the image via filter") {
+@include describe('autodark-image mixin') {
+  @include it('inverts the image via filter') {
     @include assert() {
       @include output() {
         .t {
@@ -64,8 +64,8 @@
   }
 }
 
-@include describe("elements-list mixin") {
-  @include it("sets up a wrapping flex list with the default gap") {
+@include describe('elements-list mixin') {
+  @include it('sets up a wrapping flex list with the default gap') {
     @include assert() {
       @include output() {
         .t {
@@ -83,7 +83,7 @@
     }
   }
 
-  @include it("honours a custom gap argument") {
+  @include it('honours a custom gap argument') {
     @include assert() {
       @include output() {
         .t {
@@ -102,8 +102,8 @@
   }
 }
 
-@include describe("focus-ring mixin") {
-  @include it("outputs the ring without a border by default") {
+@include describe('focus-ring mixin') {
+  @include it('outputs the ring without a border by default') {
     @include assert() {
       @include output() {
         .t {
@@ -119,7 +119,7 @@
     }
   }
 
-  @include it("adds a border colour when requested") {
+  @include it('adds a border colour when requested') {
     @include assert() {
       @include output() {
         .t {
@@ -137,8 +137,8 @@
   }
 }
 
-@include describe("media-print mixin") {
-  @include it("wraps content in a print media query") {
+@include describe('media-print mixin') {
+  @include it('wraps content in a print media query') {
     @include assert() {
       @include output() {
         @include media-print {
@@ -158,11 +158,11 @@
   }
 }
 
-@include describe("scrollbar mixin") {
+@include describe('scrollbar mixin') {
   // The mixin resolves `&` to the current selector (or `*` at root); nested here,
   // every rule is prefixed with `.scroll`. Also covers the reduced-motion query
   // injected by the transition mixin.
-  @include it("emits the webkit scrollbar rule set") {
+  @include it('emits the webkit scrollbar rule set') {
     @include assert() {
       @include output() {
         .scroll {

--- a/core/scss/tests/_rfs.test.scss
+++ b/core/scss/tests/_rfs.test.scss
@@ -6,25 +6,25 @@
 // gives the fluid value — unchanged below the base size, a responsive `calc()`
 // above it.
 
-@use "../mixins/bootstrap/rfs" as *;
+@use '../mixins/bootstrap/rfs' as *;
 
-@include describe("rfs-value") {
-  @include it("passes rem values through and keeps 0") {
-    @include assert-equal(rfs-value(2rem), "2rem");
-    @include assert-equal(rfs-value(0), "0");
+@include describe('rfs-value') {
+  @include it('passes rem values through and keeps 0') {
+    @include assert-equal(rfs-value(2rem), '2rem');
+    @include assert-equal(rfs-value(0), '0');
   }
 
-  @include it("normalises px to rem") {
-    @include assert-equal(rfs-value(20px), "1.25rem");
+  @include it('normalises px to rem') {
+    @include assert-equal(rfs-value(20px), '1.25rem');
   }
 }
 
-@include describe("rfs-fluid-value") {
-  @include it("leaves values at or below the base size unchanged") {
-    @include assert-equal(rfs-fluid-value(1rem), "1rem");
+@include describe('rfs-fluid-value') {
+  @include it('leaves values at or below the base size unchanged') {
+    @include assert-equal(rfs-fluid-value(1rem), '1rem');
   }
 
-  @include it("produces a responsive calc() above the base size") {
-    @include assert-equal(rfs-fluid-value(3rem), "calc(1.425rem + 2.1vw)");
+  @include it('produces a responsive calc() above the base size') {
+    @include assert-equal(rfs-fluid-value(3rem), 'calc(1.425rem + 2.1vw)');
   }
 }

--- a/core/scss/tests/_str-replace.test.scss
+++ b/core/scss/tests/_str-replace.test.scss
@@ -5,30 +5,30 @@
 // `describe`, `it` and `assert-equal` come from the `true` module, which the
 // runner injects for us.
 
-@use "../mixins/functions" as *;
+@use '../mixins/functions' as *;
 
-@include describe("str-replace") {
-  @include it("replaces a single occurrence") {
-    @include assert-equal(str-replace("a-b-c", "-", "_"), "a_b_c");
+@include describe('str-replace') {
+  @include it('replaces a single occurrence') {
+    @include assert-equal(str-replace('a-b-c', '-', '_'), 'a_b_c');
   }
 
-  @include it("replaces every occurrence, not just the first") {
-    @include assert-equal(str-replace("a.b.c.d", ".", "/"), "a/b/c/d");
+  @include it('replaces every occurrence, not just the first') {
+    @include assert-equal(str-replace('a.b.c.d', '.', '/'), 'a/b/c/d');
   }
 
-  @include it("returns the string unchanged when the search is not found") {
-    @include assert-equal(str-replace("hello world", "x", "y"), "hello world");
+  @include it('returns the string unchanged when the search is not found') {
+    @include assert-equal(str-replace('hello world', 'x', 'y'), 'hello world');
   }
 
-  @include it("removes the search string when no replacement is given") {
-    @include assert-equal(str-replace("1,000,000", ","), "1000000");
+  @include it('removes the search string when no replacement is given') {
+    @include assert-equal(str-replace('1,000,000', ','), '1000000');
   }
 
-  @include it("handles a replacement longer than the search string") {
-    @include assert-equal(str-replace("aaa", "a", "bb"), "bbbbbb");
+  @include it('handles a replacement longer than the search string') {
+    @include assert-equal(str-replace('aaa', 'a', 'bb'), 'bbbbbb');
   }
 
-  @include it("returns an empty string unchanged") {
-    @include assert-equal(str-replace("", "-", "_"), "");
+  @include it('returns an empty string unchanged') {
+    @include assert-equal(str-replace('', '-', '_'), '');
   }
 }

--- a/core/scss/tests/_transition.test.scss
+++ b/core/scss/tests/_transition.test.scss
@@ -3,12 +3,16 @@
 // defaults), a real transition also emits a `prefers-reduced-motion` reset —
 // except when the value itself is `none`.
 
-@use "../mixins/bootstrap/transition" as *;
+@use '../mixins/bootstrap/transition' as *;
 
-@include describe("transition") {
-  @include it("emits the transition plus a reduced-motion reset") {
+@include describe('transition') {
+  @include it('emits the transition plus a reduced-motion reset') {
     @include assert() {
-      @include output() { .t { @include transition(color 0.3s); } }
+      @include output() {
+        .t {
+          @include transition(color 0.3s);
+        }
+      }
       @include expect() {
         .t {
           transition: color 0.3s;
@@ -22,10 +26,18 @@
     }
   }
 
-  @include it("skips the reduced-motion reset when the value is none") {
+  @include it('skips the reduced-motion reset when the value is none') {
     @include assert() {
-      @include output() { .t { @include transition(none); } }
-      @include expect() { .t { transition: none; } }
+      @include output() {
+        .t {
+          @include transition(none);
+        }
+      }
+      @include expect() {
+        .t {
+          transition: none;
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,12 @@
     "version": "changeset version",
     "publish": "changeset publish",
     "reformat-md": "tsx .build/reformat-mdx.ts",
-    "lint": "pnpm run lint-md",
+    "lint": "pnpm run lint-md && pnpm run lint-prettier",
     "lint-md": "markdownlint --config .markdownlint-docs.json \"docs/pages/**/*.mdx\"",
+    "lint-prettier": "prettier --check \"core/scss/**/*.scss\" \"core/js/**/*.{js,ts}\" \"preview/scss/**/*.scss\" \"preview/js/**/*.{js,ts}\" \"shared/**/*.{js,mjs,ts}\" --cache",
+    "format": "pnpm run format-prettier && pnpm run reformat-md",
+    "format-prettier": "prettier --write \"core/scss/**/*.scss\" \"core/js/**/*.{js,ts}\" \"preview/scss/**/*.scss\" \"preview/js/**/*.{js,ts}\" \"shared/**/*.{js,mjs,ts}\" --cache",
+    "check": "pnpm run lint && pnpm run type-check",
     "zip-package": "tsx .build/zip-package.ts",
     "start": "pnpm dev"
   },

--- a/preview/js/demo.ts
+++ b/preview/js/demo.ts
@@ -1,82 +1,80 @@
 interface SettingItem {
-	localStorage: string
-	default: string
+  localStorage: string
+  default: string
 }
 
 interface SettingsItems {
-	[key: string]: SettingItem
+  [key: string]: SettingItem
 }
 
 const items: SettingsItems = {
-	"menu-position": { localStorage: "tablerMenuPosition", default: "top" },
-	"menu-behavior": { localStorage: "tablerMenuBehavior", default: "sticky" },
-	"container-layout": {
-		localStorage: "tablerContainerLayout",
-		default: "boxed",
-	},
+  'menu-position': { localStorage: 'tablerMenuPosition', default: 'top' },
+  'menu-behavior': { localStorage: 'tablerMenuBehavior', default: 'sticky' },
+  'container-layout': {
+    localStorage: 'tablerContainerLayout',
+    default: 'boxed',
+  },
 }
 
 const config: Record<string, string> = {}
 for (const [key, params] of Object.entries(items)) {
-	const lsParams = localStorage.getItem(params.localStorage)
-	config[key] = lsParams ? lsParams : params.default
+  const lsParams = localStorage.getItem(params.localStorage)
+  config[key] = lsParams ? lsParams : params.default
 }
 
 const parseUrl = (): void => {
-	const search = window.location.search.substring(1)
-	const params = search.split("&")
+  const search = window.location.search.substring(1)
+  const params = search.split('&')
 
-	for (let i = 0; i < params.length; i++) {
-		const arr = params[i].split("=")
-		const key = arr[0]
-		const value = arr[1]
+  for (let i = 0; i < params.length; i++) {
+    const arr = params[i].split('=')
+    const key = arr[0]
+    const value = arr[1]
 
-		if (!!items[key]) {
-			localStorage.setItem(items[key].localStorage, value)
-			config[key] = value
-		}
-	}
+    if (!!items[key]) {
+      localStorage.setItem(items[key].localStorage, value)
+      config[key] = value
+    }
+  }
 }
 
 const toggleFormControls = (form: HTMLFormElement): void => {
-	for (const [key] of Object.entries(items)) {
-		const elem = form.querySelector(
-			`[name="settings-${key}"][value="${config[key]}"]`,
-		) as HTMLInputElement | null
+  for (const [key] of Object.entries(items)) {
+    const elem = form.querySelector(`[name="settings-${key}"][value="${config[key]}"]`) as HTMLInputElement | null
 
-		if (elem) {
-			elem.checked = true
-		}
-	}
+    if (elem) {
+      elem.checked = true
+    }
+  }
 }
 
 const submitForm = (form: HTMLFormElement): void => {
-	for (const [key, params] of Object.entries(items)) {
-		const checkedInput = form.querySelector(`[name="settings-${key}"]:checked`) as HTMLInputElement
-		if (checkedInput) {
-			const value = checkedInput.value
-			localStorage.setItem(params.localStorage, value)
-			config[key] = value
-		}
-	}
+  for (const [key, params] of Object.entries(items)) {
+    const checkedInput = form.querySelector(`[name="settings-${key}"]:checked`) as HTMLInputElement
+    if (checkedInput) {
+      const value = checkedInput.value
+      localStorage.setItem(params.localStorage, value)
+      config[key] = value
+    }
+  }
 
-	window.dispatchEvent(new Event("resize"))
+  window.dispatchEvent(new Event('resize'))
 
-	const bootstrap = (window as Window & { bootstrap?: { Offcanvas: new (form: HTMLFormElement) => { hide(): void } } }).bootstrap
-	if (bootstrap) {
-		new bootstrap.Offcanvas(form).hide()
-	}
+  const bootstrap = (window as Window & { bootstrap?: { Offcanvas: new (form: HTMLFormElement) => { hide(): void } } }).bootstrap
+  if (bootstrap) {
+    new bootstrap.Offcanvas(form).hide()
+  }
 }
 
 parseUrl()
 
-const form = document.querySelector("#offcanvas-settings") as HTMLFormElement | null
+const form = document.querySelector('#offcanvas-settings') as HTMLFormElement | null
 
 if (form) {
-	form.addEventListener("submit", function (event) {
-		event.preventDefault()
-		submitForm(form)
-	})
+  form.addEventListener('submit', function (event) {
+    event.preventDefault()
+    submitForm(form)
+  })
 
-	toggleFormControls(form)
+  toggleFormControls(form)
 }

--- a/preview/scss/_highlight.scss
+++ b/preview/scss/_highlight.scss
@@ -20,10 +20,29 @@ pre.highlight,
     padding: 0 !important;
   }
 
-  .c, .c1 { color: $color-highlight-gray; }
-  .nt, .nc, .nx { color: $color-highlight-red; }
-  .na, .p { color: $color-highlight-yellow; }
-  .s, .dl, .s2 { color: $color-highlight-green; }
-  .k { color: $color-highlight-blue; }
-  .s1, .mi { color: $color-highlight-purple; }
+  .c,
+  .c1 {
+    color: $color-highlight-gray;
+  }
+  .nt,
+  .nc,
+  .nx {
+    color: $color-highlight-red;
+  }
+  .na,
+  .p {
+    color: $color-highlight-yellow;
+  }
+  .s,
+  .dl,
+  .s2 {
+    color: $color-highlight-green;
+  }
+  .k {
+    color: $color-highlight-blue;
+  }
+  .s1,
+  .mi {
+    color: $color-highlight-purple;
+  }
 }

--- a/preview/scss/demo.scss
+++ b/preview/scss/demo.scss
@@ -1,6 +1,6 @@
-$prefix: "tblr-";
+$prefix: 'tblr-';
 
-@use "highlight";
+@use 'highlight';
 
 .dropdown-menu-demo {
   display: inline-block;
@@ -64,10 +64,8 @@ $demo-icon-size: 4rem;
   aspect-ratio: 1;
   text-align: center;
   padding: 0.5rem;
-  border-right: var(--#{$prefix}border-width) var(--#{$prefix}border-style)
-    var(--#{$prefix}border-color);
-  border-bottom: var(--#{$prefix}border-width) var(--#{$prefix}border-style)
-    var(--#{$prefix}border-color);
+  border-right: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
+  border-bottom: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color);
   color: inherit;
   cursor: pointer;
 

--- a/shared/astro/lib/chart-script.ts
+++ b/shared/astro/lib/chart-script.ts
@@ -4,335 +4,323 @@
 // normalizes script content at the token level (quotes, trailing commas, spacing).
 
 type Serie = {
-	name?: string;
-	data?: number[] | number;
-	color?: string;
-	'color-opacity'?: string;
-	'candlestick-data'?: { x: number; y: number[] }[];
-};
+  'name'?: string
+  'data'?: number[] | number
+  'color'?: string
+  'color-opacity'?: string
+  'candlestick-data'?: { x: number; y: number[] }[]
+}
 
 export type ChartData = {
-	type?: string;
-	height?: number;
-	extend?: string;
-	series?: Serie[];
-	categories?: Array<string | number>;
-	datetime?: boolean;
-	sparkline?: boolean;
-	stacked?: boolean;
-	animations?: boolean;
-	toolbar?: boolean;
-	horizontal?: boolean;
-	legend?: boolean;
-	title?: string;
-	color?: string;
-	colors?: string[];
-	datalabels?: boolean;
-	'fill-type'?: string;
-	'fill-gradient-shade'?: string;
-	'fill-gradient-type'?: string;
-	'fill-gradient-shade-intensity'?: number;
-	'fill-gradient-to-color'?: string;
-	'fill-gradient-inverse-colors'?: boolean;
-	'fill-gradient-opacity-from'?: number;
-	'fill-gradient-opacity-to'?: number;
-	'fill-gradient-stops'?: number[];
-	'radial-start-angle'?: number;
-	'radial-end-angle'?: number;
-	'radial-hollow-margin'?: number;
-	'radial-hollow-size'?: string;
-	'radial-labels-show'?: boolean;
-	'radial-name-show'?: boolean;
-	'radial-name-offset-y'?: number;
-	'radial-name-font-size'?: string;
-	'radial-name-color'?: string;
-	'radial-value-offset-y'?: number;
-	'radial-value-font-size'?: string;
-	'radial-value-font-weight'?: number;
-	'stroke-linecap'?: string;
-	'stroke-width'?: number[];
-	'stroke-dash'?: number[];
-	'stroke-curve'?: string;
-	'hide-grid'?: boolean;
-	'show-x'?: boolean;
-	'x-formatter'?: string;
-	'y-max'?: number;
-	'y-title'?: string;
-	'y-tooltip'?: boolean;
-	'show-data-labels'?: boolean;
-	'hide-tooltip'?: boolean;
-	'hide-points'?: boolean;
-	'show-markers'?: boolean;
-	'start-date'?: string;
-	[key: string]: unknown;
-};
+  'type'?: string
+  'height'?: number
+  'extend'?: string
+  'series'?: Serie[]
+  'categories'?: Array<string | number>
+  'datetime'?: boolean
+  'sparkline'?: boolean
+  'stacked'?: boolean
+  'animations'?: boolean
+  'toolbar'?: boolean
+  'horizontal'?: boolean
+  'legend'?: boolean
+  'title'?: string
+  'color'?: string
+  'colors'?: string[]
+  'datalabels'?: boolean
+  'fill-type'?: string
+  'fill-gradient-shade'?: string
+  'fill-gradient-type'?: string
+  'fill-gradient-shade-intensity'?: number
+  'fill-gradient-to-color'?: string
+  'fill-gradient-inverse-colors'?: boolean
+  'fill-gradient-opacity-from'?: number
+  'fill-gradient-opacity-to'?: number
+  'fill-gradient-stops'?: number[]
+  'radial-start-angle'?: number
+  'radial-end-angle'?: number
+  'radial-hollow-margin'?: number
+  'radial-hollow-size'?: string
+  'radial-labels-show'?: boolean
+  'radial-name-show'?: boolean
+  'radial-name-offset-y'?: number
+  'radial-name-font-size'?: string
+  'radial-name-color'?: string
+  'radial-value-offset-y'?: number
+  'radial-value-font-size'?: string
+  'radial-value-font-weight'?: number
+  'stroke-linecap'?: string
+  'stroke-width'?: number[]
+  'stroke-dash'?: number[]
+  'stroke-curve'?: string
+  'hide-grid'?: boolean
+  'show-x'?: boolean
+  'x-formatter'?: string
+  'y-max'?: number
+  'y-title'?: string
+  'y-tooltip'?: boolean
+  'show-data-labels'?: boolean
+  'hide-tooltip'?: boolean
+  'hide-points'?: boolean
+  'show-markers'?: boolean
+  'start-date'?: string
+  [key: string]: unknown
+}
 
-const escapeHtml = (value: string) =>
-	value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+const escapeHtml = (value: string) => value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 
 /** Verbatim JS code embedded in the config (e.g. formatter functions). */
 class RawJs {
-	readonly code: string;
-	constructor(code: string) {
-		this.code = code;
-	}
+  readonly code: string
+  constructor(code: string) {
+    this.code = code
+  }
 }
 
-const raw = (code: string) => new RawJs(code);
+const raw = (code: string) => new RawJs(code)
 
 /**
  * Serialize a config object to formatted JS: unquoted keys, tab indentation,
  * `undefined` entries omitted, small objects and primitive arrays kept inline.
  */
 function formatJs(value: unknown, indent: number): string {
-	if (value instanceof RawJs) return value.code;
-	if (typeof value === 'string') return JSON.stringify(value);
-	if (typeof value === 'number' || typeof value === 'boolean') return String(value);
-	const tab = '\t'.repeat(indent);
-	const isLeaf = (v: unknown) => typeof v !== 'object' || v === null || v instanceof RawJs;
-	if (Array.isArray(value)) {
-		if (value.length === 0) return '[]';
-		const items = value.map((item) => formatJs(item, indent + 1));
-		if (value.every(isLeaf)) {
-			return `[${items.join(', ')}]`;
-		}
-		return `[\n${items.map((item) => `${tab}\t${item}`).join(',\n')}\n${tab}]`;
-	}
-	const entries = Object.entries(value as Record<string, unknown>).filter(([, v]) => v !== undefined);
-	if (entries.length === 0) return '{}';
-	// a `//N` key suffix emits a duplicate key (mirrors Liquid emitting e.g. two
-	// `tooltip:` entries where the later one shadows the earlier — last wins in JS)
-	const parts = entries.map(([key, v]) => `${key.replace(/\/\/\d+$/, '')}: ${formatJs(v, indent + 1)}`);
-	const inline = `{ ${parts.join(', ')} }`;
-	// inline only "flat" objects (primitives, raw code, primitive arrays) that fit on one line
-	const flat = entries.every(([, v]) => isLeaf(v) || (Array.isArray(v) && v.every(isLeaf)));
-	if (flat && !inline.includes('\n') && inline.length <= 100) return inline;
-	return `{\n${parts.map((part) => `${tab}\t${part}`).join(',\n')}\n${tab}}`;
+  if (value instanceof RawJs) return value.code
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  const tab = '\t'.repeat(indent)
+  const isLeaf = (v: unknown) => typeof v !== 'object' || v === null || v instanceof RawJs
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]'
+    const items = value.map((item) => formatJs(item, indent + 1))
+    if (value.every(isLeaf)) {
+      return `[${items.join(', ')}]`
+    }
+    return `[\n${items.map((item) => `${tab}\t${item}`).join(',\n')}\n${tab}]`
+  }
+  const entries = Object.entries(value as Record<string, unknown>).filter(([, v]) => v !== undefined)
+  if (entries.length === 0) return '{}'
+  // a `//N` key suffix emits a duplicate key (mirrors Liquid emitting e.g. two
+  // `tooltip:` entries where the later one shadows the earlier — last wins in JS)
+  const parts = entries.map(([key, v]) => `${key.replace(/\/\/\d+$/, '')}: ${formatJs(v, indent + 1)}`)
+  const inline = `{ ${parts.join(', ')} }`
+  // inline only "flat" objects (primitives, raw code, primitive arrays) that fit on one line
+  const flat = entries.every(([, v]) => isLeaf(v) || (Array.isArray(v) && v.every(isLeaf)))
+  if (flat && !inline.includes('\n') && inline.length <= 100) return inline
+  return `{\n${parts.map((part) => `${tab}\t${part}`).join(',\n')}\n${tab}}`
 }
 
 /** Equivalent of the datetime loop: consecutive days from start-date (YYYY-MM-DD). */
 function datetimeLabels(startDate: string, count: number): string[] {
-	const start = new Date(`${startDate}T00:00:00Z`);
-	return Array.from({ length: count }, (_, i) => {
-		const d = new Date(start.getTime() + i * 86400_000);
-		return d.toISOString().slice(0, 10);
-	});
+  const start = new Date(`${startDate}T00:00:00Z`)
+  return Array.from({ length: count }, (_, i) => {
+    const d = new Date(start.getTime() + i * 86400_000)
+    return d.toISOString().slice(0, 10)
+  })
 }
 
-export function chartSnippet(opts: {
-	id: string;
-	chartId: string;
-	data: ChartData;
-	height: number;
-}): string {
-	const { id, chartId, data, height } = opts;
-	const type = data.type ?? 'bar';
-	const series = data.series ?? [];
-	const isRound = type === 'pie' || type === 'donut' || type === 'radialBar';
+export function chartSnippet(opts: { id: string; chartId: string; data: ChartData; height: number }): string {
+  const { id, chartId, data, height } = opts
+  const type = data.type ?? 'bar'
+  const series = data.series ?? []
+  const isRound = type === 'pie' || type === 'donut' || type === 'radialBar'
 
-	// --- <style> ---
-	let css = '';
-	for (const [i, serie] of series.entries()) {
-		const color = serie.color ?? data.color ?? 'primary';
-		const opacity = serie['color-opacity'] ?? '100%';
-		css += `    --chart-${id}-color-${i}: color-mix(in srgb, transparent, var(--tblr-${color}) ${opacity});\n`;
-	}
-	if (type === 'area') {
-		css += `    --chart-${id}-fill-0: color-mix(in srgb, transparent, var(--tblr-primary) 16%);\n`;
-		css += `    --chart-${id}-fill-1: color-mix(in srgb, transparent, var(--tblr-primary) 16%);\n`;
-	}
-	const style = `<style>\n  :root {\n${css}  }\n</style>`;
+  // --- <style> ---
+  let css = ''
+  for (const [i, serie] of series.entries()) {
+    const color = serie.color ?? data.color ?? 'primary'
+    const opacity = serie['color-opacity'] ?? '100%'
+    css += `    --chart-${id}-color-${i}: color-mix(in srgb, transparent, var(--tblr-${color}) ${opacity});\n`
+  }
+  if (type === 'area') {
+    css += `    --chart-${id}-fill-0: color-mix(in srgb, transparent, var(--tblr-primary) 16%);\n`
+    css += `    --chart-${id}-fill-1: color-mix(in srgb, transparent, var(--tblr-primary) 16%);\n`
+  }
+  const style = `<style>\n  :root {\n${css}  }\n</style>`
 
-	// --- config ---
-	const config: Record<string, unknown> = {};
+  // --- config ---
+  const config: Record<string, unknown> = {}
 
-	config.chart = {
-		type,
-		fontFamily: 'inherit',
-		height: height * 16,
-		...(data.sparkline
-			? { sparkline: { enabled: true } }
-			: { parentHeightOffset: 0, toolbar: { show: Boolean(data.toolbar) } }),
-		animations: data.animations ? undefined : { enabled: false },
-		stacked: data.stacked ? true : undefined,
-	};
+  config.chart = {
+    type,
+    fontFamily: 'inherit',
+    height: height * 16,
+    ...(data.sparkline ? { sparkline: { enabled: true } } : { parentHeightOffset: 0, toolbar: { show: Boolean(data.toolbar) } }),
+    animations: data.animations ? undefined : { enabled: false },
+    stacked: data.stacked ? true : undefined,
+  }
 
-	if (type === 'bar') {
-		config.plotOptions = {
-			bar: data.horizontal ? { barHeight: '50%', horizontal: true } : { columnWidth: '50%' },
-		};
-	}
+  if (type === 'bar') {
+    config.plotOptions = {
+      bar: data.horizontal ? { barHeight: '50%', horizontal: true } : { columnWidth: '50%' },
+    }
+  }
 
-	if (type === 'radialBar') {
-		config.plotOptions = {
-			radialBar: {
-				startAngle: data['radial-start-angle'] ?? -120,
-				endAngle: data['radial-end-angle'] ?? 120,
-				hollow: {
-					margin: data['radial-hollow-margin'] ?? 16,
-					size: data['radial-hollow-size'] ?? '50%',
-				},
-				dataLabels: {
-					show: data['radial-labels-show'] !== false,
-					name: {
-						show: Boolean(data['radial-name-show']),
-						offsetY: data['radial-name-offset-y'] ?? 0,
-						fontSize: data['radial-name-font-size'] ?? '16px',
-						color: data['radial-name-color'] ?? 'inherit',
-					},
-					value: {
-						offsetY: data['radial-value-offset-y'] ?? -8,
-						fontSize: data['radial-value-font-size'] ?? '24px',
-						fontWeight: data['radial-value-font-weight'] ?? 600,
-					},
-				},
-			},
-		};
-	}
+  if (type === 'radialBar') {
+    config.plotOptions = {
+      radialBar: {
+        startAngle: data['radial-start-angle'] ?? -120,
+        endAngle: data['radial-end-angle'] ?? 120,
+        hollow: {
+          margin: data['radial-hollow-margin'] ?? 16,
+          size: data['radial-hollow-size'] ?? '50%',
+        },
+        dataLabels: {
+          show: data['radial-labels-show'] !== false,
+          name: {
+            show: Boolean(data['radial-name-show']),
+            offsetY: data['radial-name-offset-y'] ?? 0,
+            fontSize: data['radial-name-font-size'] ?? '16px',
+            color: data['radial-name-color'] ?? 'inherit',
+          },
+          value: {
+            offsetY: data['radial-value-offset-y'] ?? -8,
+            fontSize: data['radial-value-font-size'] ?? '24px',
+            fontWeight: data['radial-value-font-weight'] ?? 600,
+          },
+        },
+      },
+    }
+  }
 
-	if (type === 'bar' || type === 'area') {
-		config.dataLabels = { enabled: Boolean(data.datalabels) };
-	}
+  if (type === 'bar' || type === 'area') {
+    config.dataLabels = { enabled: Boolean(data.datalabels) }
+  }
 
-	if (data['fill-type']) {
-		config.fill = {
-			type: data['fill-type'],
-			gradient:
-				data['fill-type'] === 'gradient'
-					? {
-							shade: data['fill-gradient-shade'] ?? 'light',
-							type: data['fill-gradient-type'] ?? 'horizontal',
-							shadeIntensity: data['fill-gradient-shade-intensity'] ?? 0.5,
-							gradientToColors: [data['fill-gradient-to-color'] ?? '#9ec2fb'],
-							inverseColors: Boolean(data['fill-gradient-inverse-colors']),
-							opacityFrom: data['fill-gradient-opacity-from'] ?? 1,
-							opacityTo: data['fill-gradient-opacity-to'] ?? 1,
-							stops: data['fill-gradient-stops'] ?? [0, 100],
-						}
-					: undefined,
-		};
-	} else if (type === 'area') {
-		config.fill = {
-			colors: [`var(--chart-${id}-fill-0)`, `var(--chart-${id}-fill-1)`],
-			type: 'solid',
-		};
-	}
+  if (data['fill-type']) {
+    config.fill = {
+      type: data['fill-type'],
+      gradient:
+        data['fill-type'] === 'gradient'
+          ? {
+              shade: data['fill-gradient-shade'] ?? 'light',
+              type: data['fill-gradient-type'] ?? 'horizontal',
+              shadeIntensity: data['fill-gradient-shade-intensity'] ?? 0.5,
+              gradientToColors: [data['fill-gradient-to-color'] ?? '#9ec2fb'],
+              inverseColors: Boolean(data['fill-gradient-inverse-colors']),
+              opacityFrom: data['fill-gradient-opacity-from'] ?? 1,
+              opacityTo: data['fill-gradient-opacity-to'] ?? 1,
+              stops: data['fill-gradient-stops'] ?? [0, 100],
+            }
+          : undefined,
+    }
+  } else if (type === 'area') {
+    config.fill = {
+      colors: [`var(--chart-${id}-fill-0)`, `var(--chart-${id}-fill-1)`],
+      type: 'solid',
+    }
+  }
 
-	if (data.title) {
-		config.title = {
-			text: escapeHtml(data.title),
-			margin: 0,
-			floating: true,
-			offsetX: 10,
-			style: { fontSize: '18px' },
-		};
-	}
+  if (data.title) {
+    config.title = {
+      text: escapeHtml(data.title),
+      margin: 0,
+      floating: true,
+      offsetX: 10,
+      style: { fontSize: '18px' },
+    }
+  }
 
-	if (type === 'radialBar' && data['stroke-linecap']) {
-		config.stroke = { lineCap: data['stroke-linecap'] };
-	} else if (type === 'area' || type === 'line') {
-		config.stroke = {
-			width: data['stroke-width'] ?? 2,
-			dashArray: data['stroke-dash'],
-			lineCap: 'round',
-			curve: data['stroke-curve'] ?? 'smooth',
-		};
-	}
+  if (type === 'radialBar' && data['stroke-linecap']) {
+    config.stroke = { lineCap: data['stroke-linecap'] }
+  } else if (type === 'area' || type === 'line') {
+    config.stroke = {
+      width: data['stroke-width'] ?? 2,
+      dashArray: data['stroke-dash'],
+      lineCap: 'round',
+      curve: data['stroke-curve'] ?? 'smooth',
+    }
+  }
 
-	if (series.length > 0) {
-		if (isRound) {
-			config.series = series.map((s) => s.data);
-			config.labels = series.map((s) => s.name ?? '');
-		} else {
-			config.series = series.map((s) => ({
-				name: s.name ?? '',
-				data: s['candlestick-data']
-					? s['candlestick-data'].map((c) => ({ x: c.x, y: c.y }))
-					: (s.data as number[]),
-			}));
-		}
-	}
+  if (series.length > 0) {
+    if (isRound) {
+      config.series = series.map((s) => s.data)
+      config.labels = series.map((s) => s.name ?? '')
+    } else {
+      config.series = series.map((s) => ({
+        name: s.name ?? '',
+        data: s['candlestick-data'] ? s['candlestick-data'].map((c) => ({ x: c.x, y: c.y })) : (s.data as number[]),
+      }))
+    }
+  }
 
-	config.tooltip = { theme: 'dark' };
+  config.tooltip = { theme: 'dark' }
 
-	config.grid = {
-		padding: data.sparkline ? undefined : { top: -20, right: 0, left: -4, bottom: -4 },
-		show: data['hide-grid'] ? false : undefined,
-		strokeDashArray: data['hide-grid'] ? undefined : 4,
-		xaxis: !data['hide-grid'] && data['show-x'] ? { lines: { show: true } } : undefined,
-	};
+  config.grid = {
+    padding: data.sparkline ? undefined : { top: -20, right: 0, left: -4, bottom: -4 },
+    show: data['hide-grid'] ? false : undefined,
+    strokeDashArray: data['hide-grid'] ? undefined : 4,
+    xaxis: !data['hide-grid'] && data['show-x'] ? { lines: { show: true } } : undefined,
+  }
 
-	if (data['show-data-labels']) {
-		config['dataLabels//2'] = { enabled: true };
-	}
+  if (data['show-data-labels']) {
+    config['dataLabels//2'] = { enabled: true }
+  }
 
-	if (data.categories || data.datetime) {
-		config.xaxis = {
-			labels: {
-				padding: 0,
-				formatter: data['x-formatter']
-					? raw(`function (val) { return ${data['x-formatter']} }`)
-					: undefined,
-			},
-			tooltip: { enabled: false },
-			axisBorder: type === 'area' || type === 'bar' ? { show: false } : undefined,
-			categories: data.categories?.map(String),
-			type: data.datetime ? 'datetime' : undefined,
-		};
-	}
+  if (data.categories || data.datetime) {
+    config.xaxis = {
+      labels: {
+        padding: 0,
+        formatter: data['x-formatter'] ? raw(`function (val) { return ${data['x-formatter']} }`) : undefined,
+      },
+      tooltip: { enabled: false },
+      axisBorder: type === 'area' || type === 'bar' ? { show: false } : undefined,
+      categories: data.categories?.map(String),
+      type: data.datetime ? 'datetime' : undefined,
+    }
+  }
 
-	if (!isRound) {
-		config.yaxis = {
-			labels: { padding: 4 },
-			max: data['y-max'],
-			title: data['y-title'] ? { text: escapeHtml(data['y-title']) } : undefined,
-			tooltip: data['y-tooltip'] ? { enabled: true } : undefined,
-		};
-	}
+  if (!isRound) {
+    config.yaxis = {
+      labels: { padding: 4 },
+      max: data['y-max'],
+      title: data['y-title'] ? { text: escapeHtml(data['y-title']) } : undefined,
+      tooltip: data['y-tooltip'] ? { enabled: true } : undefined,
+    }
+  }
 
-	if (data.datetime) {
-		const count = Array.isArray(series[0]?.data) ? (series[0].data as number[]).length : 0;
-		config.labels = datetimeLabels(data['start-date'] ?? '2020-06-20', count);
-	}
+  if (data.datetime) {
+    const count = Array.isArray(series[0]?.data) ? (series[0].data as number[]).length : 0
+    config.labels = datetimeLabels(data['start-date'] ?? '2020-06-20', count)
+  }
 
-	if (data.colors) {
-		config.colors = data.colors;
-	} else if (series.length > 0) {
-		config.colors = series.map((_, i) => `var(--chart-${id}-color-${i})`);
-	}
+  if (data.colors) {
+    config.colors = data.colors
+  } else if (series.length > 0) {
+    config.colors = series.map((_, i) => `var(--chart-${id}-color-${i})`)
+  }
 
-	config.legend = data.legend
-		? {
-				show: true,
-				position: 'bottom',
-				offsetY: 12,
-				markers: { width: 10, height: 10, radius: 100 },
-				itemMargin: { horizontal: 8, vertical: 8 },
-			}
-		: { show: false };
+  config.legend = data.legend
+    ? {
+        show: true,
+        position: 'bottom',
+        offsetY: 12,
+        markers: { width: 10, height: 10, radius: 100 },
+        itemMargin: { horizontal: 8, vertical: 8 },
+      }
+    : { show: false }
 
-	if (data['hide-tooltip'] || type === 'pie' || type === 'donut') {
-		config['tooltip//2'] = {
-			enabled: data['hide-tooltip'] ? false : undefined,
-			fillSeriesColor: type === 'pie' || type === 'donut' ? false : undefined,
-		};
-	}
+  if (data['hide-tooltip'] || type === 'pie' || type === 'donut') {
+    config['tooltip//2'] = {
+      enabled: data['hide-tooltip'] ? false : undefined,
+      fillSeriesColor: type === 'pie' || type === 'donut' ? false : undefined,
+    }
+  }
 
-	if (data['hide-points']) {
-		config.point = { show: false };
-	}
+  if (data['hide-points']) {
+    config.point = { show: false }
+  }
 
-	if (data['show-markers']) {
-		config.markers = { size: 2 };
-	}
+  if (data['show-markers']) {
+    config.markers = { size: 2 }
+  }
 
-	// environment === 'development' → window.tabler_chart registry
-	const script = `<script>
+  // environment === 'development' → window.tabler_chart registry
+  const script = `<script>
 \tdocument.addEventListener("DOMContentLoaded", function () {
 \t\twindow.tabler_chart = window.tabler_chart || {};
 \t\twindow.ApexCharts && (window.tabler_chart["chart-${chartId}"] = new ApexCharts(document.getElementById('chart-${id}'), ${formatJs(config, 2)})).render();
 \t});
-</script>`;
+</script>`
 
-	return `${style}\n${script}`;
+  return `${style}\n${script}`
 }

--- a/shared/astro/lib/code-example.ts
+++ b/shared/astro/lib/code-example.ts
@@ -1,43 +1,43 @@
 // Docs code-block pipeline: js-beautify + shiki (github-dark) — exactly the
 // same options as in docs/eleventy.config.mjs (markdown-it highlight hook).
-import beautify from 'js-beautify';
-import { createHighlighter, type Highlighter } from 'shiki';
+import beautify from 'js-beautify'
+import { createHighlighter, type Highlighter } from 'shiki'
 
-let highlighterPromise: Promise<Highlighter> | undefined;
+let highlighterPromise: Promise<Highlighter> | undefined
 
 function getHighlighter(): Promise<Highlighter> {
-	highlighterPromise ??= createHighlighter({
-		themes: ['github-dark'],
-		langs: ['html', 'yaml', 'js', 'ts', 'shell', 'diff', 'scss', 'css'],
-	});
-	return highlighterPromise;
+  highlighterPromise ??= createHighlighter({
+    themes: ['github-dark'],
+    langs: ['html', 'yaml', 'js', 'ts', 'shell', 'diff', 'scss', 'css'],
+  })
+  return highlighterPromise
 }
 
 export function beautifyHtml(code: string): string {
-	return beautify.html(code, {
-		indent_size: 2,
-		wrap_line_length: 80,
-	});
+  return beautify.html(code, {
+    indent_size: 2,
+    wrap_line_length: 80,
+  })
 }
 
 export async function highlightCode(code: string, lang = 'html'): Promise<string> {
-	const highlighter = await getHighlighter();
-	return highlighter.codeToHtml(code, { lang, theme: 'github-dark' });
+  const highlighter = await getHighlighter()
+  return highlighter.codeToHtml(code, { lang, theme: 'github-dark' })
 }
 
 /** Equivalent of the escape_attribute filter (data-clipboard-text). */
 export function escapeAttribute(text: string): string {
-	return text
-		.replace(/&/g, '&amp;')
-		.replace(/'/g, '&apos;')
-		.replace(/"/g, '&quot;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/\r\n/g, '&#13;')
-		.replace(/[\r\n]/g, '&#13;');
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/'/g, '&apos;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\r\n/g, '&#13;')
+    .replace(/[\r\n]/g, '&#13;')
 }
 
 /** Equivalent of the remove-href filter. */
 export function removeHref(content: string): string {
-	return content.replace(/href="#"/g, 'href="javascript:void(0)"');
+  return content.replace(/href="#"/g, 'href="javascript:void(0)"')
 }

--- a/shared/astro/lib/docs-children.ts
+++ b/shared/astro/lib/docs-children.ts
@@ -1,77 +1,75 @@
 type DocsPageFrontmatter = {
-	title?: string;
-	description?: string;
-	icon?: string;
-	order?: number;
-};
+  title?: string
+  description?: string
+  icon?: string
+  order?: number
+}
 
 export type DocsChildPage = {
-	url: string;
-	title: string;
-	description: string;
-	icon?: string;
-	order: number;
-};
+  url: string
+  title: string
+  description: string
+  icon?: string
+  order: number
+}
 
 // Both page conventions are supported: `foo/index.mdx` and flat `foo.mdx`
 // produce the same route (/foo/) with the default 'directory' build format.
 // `@pages` is a per-package vite alias (preview: ./src/pages, docs: ./pages) —
 // that's what lets this file live in shared/ despite import.meta.glob being
 // resolved relative to the importer.
-const pageModules = import.meta.glob('@pages/**/*.mdx', { eager: true });
+const pageModules = import.meta.glob('@pages/**/*.mdx', { eager: true })
 
 function getFrontmatter(mod: unknown): DocsPageFrontmatter | null {
-	if (!mod || typeof mod !== 'object') return null;
+  if (!mod || typeof mod !== 'object') return null
 
-	if ('frontmatter' in mod && mod.frontmatter && typeof mod.frontmatter === 'object') {
-		return mod.frontmatter as DocsPageFrontmatter;
-	}
+  if ('frontmatter' in mod && mod.frontmatter && typeof mod.frontmatter === 'object') {
+    return mod.frontmatter as DocsPageFrontmatter
+  }
 
-	return null;
+  return null
 }
 
 function urlFromGlobPath(path: string): string {
-	// glob keys for alias patterns are resolved paths — derive the route from
-	// the segment after the pages dir
-	const marker = path.indexOf('/pages/');
-	const rel = (marker === -1 ? path : path.slice(marker + '/pages/'.length))
-		.replace(/(?:^|\/)index\.mdx$/, '')
-		.replace(/\.mdx$/, '');
-	return rel ? `/${rel}/` : '/';
+  // glob keys for alias patterns are resolved paths — derive the route from
+  // the segment after the pages dir
+  const marker = path.indexOf('/pages/')
+  const rel = (marker === -1 ? path : path.slice(marker + '/pages/'.length)).replace(/(?:^|\/)index\.mdx$/, '').replace(/\.mdx$/, '')
+  return rel ? `/${rel}/` : '/'
 }
 
 function normalizeUrl(url: string): string {
-	const parts = url.split('/').filter(Boolean);
-	return parts.length ? `/${parts.join('/')}/` : '/';
+  const parts = url.split('/').filter(Boolean)
+  return parts.length ? `/${parts.join('/')}/` : '/'
 }
 
 /** Direct child pages of a docs index URL (equivalent of Eleventy's collection-children). */
 export function getDocsChildren(parentUrl: string): DocsChildPage[] {
-	const parentParts = normalizeUrl(parentUrl).split('/').filter(Boolean);
+  const parentParts = normalizeUrl(parentUrl).split('/').filter(Boolean)
 
-	return Object.entries(pageModules)
-		.map(([path, mod]) => {
-			const pageUrl = urlFromGlobPath(path);
-			const parts = pageUrl.split('/').filter(Boolean);
-			const isDirectChild =
-				parts.length === parentParts.length + 1 &&
-				parts.slice(0, -1).join('/') === parentParts.join('/');
+  return (
+    Object.entries(pageModules)
+      .map(([path, mod]) => {
+        const pageUrl = urlFromGlobPath(path)
+        const parts = pageUrl.split('/').filter(Boolean)
+        const isDirectChild = parts.length === parentParts.length + 1 && parts.slice(0, -1).join('/') === parentParts.join('/')
 
-			if (!isDirectChild) return null;
+        if (!isDirectChild) return null
 
-			const fm = getFrontmatter(mod);
-			if (!fm?.title) return null;
+        const fm = getFrontmatter(mod)
+        if (!fm?.title) return null
 
-			return {
-				url: pageUrl,
-				title: String(fm.title),
-				description: String(fm.description ?? ''),
-				icon: fm.icon ? String(fm.icon) : undefined,
-				order: Number(fm.order ?? 999),
-			};
-		})
-		.filter((page): page is DocsChildPage => page !== null)
-		// if a route exists in both conventions (foo.mdx AND foo/index.mdx), count it once
-		.filter((page, i, all) => all.findIndex((p) => p.url === page.url) === i)
-		.sort((a, b) => a.order - b.order || a.title.localeCompare(b.title));
+        return {
+          url: pageUrl,
+          title: String(fm.title),
+          description: String(fm.description ?? ''),
+          icon: fm.icon ? String(fm.icon) : undefined,
+          order: Number(fm.order ?? 999),
+        }
+      })
+      .filter((page): page is DocsChildPage => page !== null)
+      // if a route exists in both conventions (foo.mdx AND foo/index.mdx), count it once
+      .filter((page, i, all) => all.findIndex((p) => p.url === page.url) === i)
+      .sort((a, b) => a.order - b.order || a.title.localeCompare(b.title))
+  )
 }

--- a/shared/astro/lib/liquid-date.ts
+++ b/shared/astro/lib/liquid-date.ts
@@ -4,17 +4,14 @@
 //    the true epoch (LiquidJS renders the wall clock, then reads its seconds).
 //  - `%B %d, %Y` uses the UTC wall-clock components of the original timestamp.
 // Both are reproduced against the reference build on the same machine/timezone.
-const MONTHS = [
-	'January', 'February', 'March', 'April', 'May', 'June',
-	'July', 'August', 'September', 'October', 'November', 'December',
-];
+const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
 
 /** Equivalent of `{{ date | date: '%s' }}` with timezoneOffset: 0. */
 export function liquidUnixSeconds(date: Date): number {
-	return Math.floor(date.getTime() / 1000) + date.getTimezoneOffset() * 60;
+  return Math.floor(date.getTime() / 1000) + date.getTimezoneOffset() * 60
 }
 
 /** Equivalent of `{{ date | date: '%B %d, %Y' }}` with timezoneOffset: 0. */
 export function liquidLongDate(date: Date): string {
-	return `${MONTHS[date.getUTCMonth()]} ${String(date.getUTCDate()).padStart(2, '0')}, ${date.getUTCFullYear()}`;
+  return `${MONTHS[date.getUTCMonth()]} ${String(date.getUTCDate()).padStart(2, '0')}, ${date.getUTCFullYear()}`
 }

--- a/shared/astro/lib/page-modals.ts
+++ b/shared/astro/lib/page-modals.ts
@@ -6,16 +6,16 @@
 // control via await), because Astro renders siblings concurrently and
 // PageModals may drain the registry before the asynchronous render of the
 // modal's slot completes.
-const modals: Array<string | Promise<string>> = [];
+const modals: Array<string | Promise<string>> = []
 
 export function addPageModal(html: string | Promise<string>): void {
-	if (!modals.includes(html)) {
-		modals.push(html);
-	}
+  if (!modals.includes(html)) {
+    modals.push(html)
+  }
 }
 
 export function drainPageModals(): Array<string | Promise<string>> {
-	const out = [...modals];
-	modals.length = 0;
-	return out;
+  const out = [...modals]
+  modals.length = 0
+  return out
 }

--- a/shared/astro/lib/page-scripts.ts
+++ b/shared/astro/lib/page-scripts.ts
@@ -2,17 +2,17 @@
 // page content register snippets (<style>/<script>) during rendering, and BaseLayout
 // emits them at the end of <body>. This works because Astro streams the render
 // sequentially: the <slot /> content renders before the tail of the layout.
-const scripts: string[] = [];
+const scripts: string[] = []
 
 export function addPageScript(html: string): void {
-	// No dedup: Liquid's {% capture_script %} emits every snippet, even byte-identical
-	// ones (e.g. two identical star-rating inits on stars-rating.html).
-	scripts.push(html);
+  // No dedup: Liquid's {% capture_script %} emits every snippet, even byte-identical
+  // ones (e.g. two identical star-rating inits on stars-rating.html).
+  scripts.push(html)
 }
 
 /** Returns the collected snippets and clears the buffer (called once per page, in BaseLayout). */
 export function drainPageScripts(): string[] {
-	const out = [...scripts];
-	scripts.length = 0;
-	return out;
+  const out = [...scripts]
+  scripts.length = 0
+  return out
 }

--- a/shared/astro/lib/render-markdown.ts
+++ b/shared/astro/lib/render-markdown.ts
@@ -7,14 +7,14 @@
 
 // @ts-ignore -- markdown-it ships no type declarations and @types/markdown-it
 // is intentionally not added (build-time helper only).
-import MarkdownIt from 'markdown-it';
+import MarkdownIt from 'markdown-it'
 
-const md = new MarkdownIt({ html: true });
+const md = new MarkdownIt({ html: true })
 
 // Eleventy disables indented code blocks by default (11ty/eleventy#2438).
-md.disable('code');
+md.disable('code')
 
 /** Render a markdown string to HTML exactly like Eleventy's `renderContent: "md"`. */
 export function renderMarkdown(src: string): string {
-	return md.render(src);
+  return md.render(src)
 }

--- a/shared/astro/lib/site.ts
+++ b/shared/astro/lib/site.ts
@@ -1,47 +1,33 @@
-import corePackage from '@tabler/core/package.json';
+import corePackage from '@tabler/core/package.json'
 
-const version = corePackage.version;
+const version = corePackage.version
 
 export const site = {
-	title: 'Tabler',
-	version,
-	docsUrl: 'https://docs.tabler.io',
-	cdnUrl: `https://cdn.jsdelivr.net/npm/@tabler/core@${version}`,
-	// site.email — used by parts/modals/success.html ({{ site.email }}). Verified
-	// against the reference build (support@tabler.io).
-	email: 'support@tabler.io',
-	previewUrl: 'https://preview.tabler.io',
-	githubUrl: 'https://github.com/tabler/tabler',
-	githubSponsorsUrl: 'https://github.com/sponsors/codecalm',
-	icons: { link: 'https://tabler.io/icons' },
-	// site.emails — used by preview/pages/emails.html. From shared/data/site.json.
-	// `count` is intentionally absent in the source data (site.emails.count is
-	// undefined → renders empty, producing "Buy  emails" with a double space).
-	emails: { price: '$29', buy_link: 'https://r.tabler.io/buy-emails', count: '' },
-	// dev key used in the development build (Liquid: site.googleMapsDevKey)
-	googleMapsDevKey: 'AIzaSyCL-BY8-sq12m0S9H-S_yMqDmcun3A9znw',
-	// From shared/data/icons-info.json.
-	iconsCount: 5986,
-	descriptionShort: 'Premium and Open Source dashboard template with responsive and high quality UI.',
-	description:
-		'Tabler is packed with beautifully crafted components and powerful features. Jump in and start building a stunning dashboard — all for free!',
-	themeColor: '#066fd1',
-	cssPlugins: ['flags', 'socials', 'payments', 'vendors', 'marketing', 'themes'],
-	themeColors: [
-		'blue',
-		'azure',
-		'indigo',
-		'purple',
-		'pink',
-		'red',
-		'orange',
-		'yellow',
-		'lime',
-		'green',
-		'teal',
-		'cyan',
-	],
-	themeFonts: ['sans-serif', 'serif', 'monospace', 'comic'],
-	themeBases: ['slate', 'gray', 'zinc', 'neutral', 'stone'],
-	themeRadiuses: ['0', '0.5', '1', '1.5', '2'],
-};
+  title: 'Tabler',
+  version,
+  docsUrl: 'https://docs.tabler.io',
+  cdnUrl: `https://cdn.jsdelivr.net/npm/@tabler/core@${version}`,
+  // site.email — used by parts/modals/success.html ({{ site.email }}). Verified
+  // against the reference build (support@tabler.io).
+  email: 'support@tabler.io',
+  previewUrl: 'https://preview.tabler.io',
+  githubUrl: 'https://github.com/tabler/tabler',
+  githubSponsorsUrl: 'https://github.com/sponsors/codecalm',
+  icons: { link: 'https://tabler.io/icons' },
+  // site.emails — used by preview/pages/emails.html. From shared/data/site.json.
+  // `count` is intentionally absent in the source data (site.emails.count is
+  // undefined → renders empty, producing "Buy  emails" with a double space).
+  emails: { price: '$29', buy_link: 'https://r.tabler.io/buy-emails', count: '' },
+  // dev key used in the development build (Liquid: site.googleMapsDevKey)
+  googleMapsDevKey: 'AIzaSyCL-BY8-sq12m0S9H-S_yMqDmcun3A9znw',
+  // From shared/data/icons-info.json.
+  iconsCount: 5986,
+  descriptionShort: 'Premium and Open Source dashboard template with responsive and high quality UI.',
+  description: 'Tabler is packed with beautifully crafted components and powerful features. Jump in and start building a stunning dashboard — all for free!',
+  themeColor: '#066fd1',
+  cssPlugins: ['flags', 'socials', 'payments', 'vendors', 'marketing', 'themes'],
+  themeColors: ['blue', 'azure', 'indigo', 'purple', 'pink', 'red', 'orange', 'yellow', 'lime', 'green', 'teal', 'cyan'],
+  themeFonts: ['sans-serif', 'serif', 'monospace', 'comic'],
+  themeBases: ['slate', 'gray', 'zinc', 'neutral', 'stone'],
+  themeRadiuses: ['0', '0.5', '1', '1.5', '2'],
+}

--- a/shared/banner/index.mjs
+++ b/shared/banner/index.mjs
@@ -10,7 +10,7 @@ const pkg = JSON.parse(readFileSync(pkgJson, 'utf8'))
 const year = new Date().getFullYear()
 
 function getBanner(pluginFilename) {
-	return `/*!
+  return `/*!
  * Tabler${pluginFilename ? ` ${pluginFilename}` : ''} v${pkg.version} (${pkg.homepage})
  * Copyright 2018-${year} The Tabler Authors
  * Copyright 2018-${year} codecalm.net Paweł Kuna


### PR DESCRIPTION
## Summary

- Moved Prettier lint and format scripts to the workspace root so `core`, `preview`, and `shared` use the same commands.
- Added a root `check` script that runs lint and type-check together, matching what CI now runs.
- Updated the GitHub lint workflow to run `pnpm run lint` (Markdown + Prettier) and `pnpm run type-check`.
- Removed duplicate `format:check` / `format:write` scripts from `core/package.json`.
- Ran Prettier on 114 files across Bootstrap JS, SCSS, preview, and shared code. No behavior changes.

## Preview

- **URL:** [preview](https://tabler-git-chore-unify-quality-gates-tabler-io.vercel.app/)
- **How to test:** This change is tooling only. There is no UI to review on the preview site. Run `pnpm run lint`, `pnpm run type-check`, and `pnpm run check` locally and confirm they pass. Check that the updated lint workflow passes on this branch.

## Notes / rollout

- Patch release for `@tabler/core`, `@tabler/docs`, and `@tabler/preview` (changeset only; no package API changes).
- Contributors should use `pnpm run format` at the repo root instead of `core` format scripts.