### PR TITLE
Fix class rendering artifacts left over from Astro migration

### DIFF
--- a/shared/astro/components/navbar/NavbarMenuItem.astro
+++ b/shared/astro/components/navbar/NavbarMenuItem.astro
@@ -43,7 +43,7 @@ const itemClasses = [
 	hasChildren ? (
 		<div class="dropend">
 			<a
-				class={itemClasses}
+				class:list={itemClasses}
 				href={`#sidebar-${itemKey}`}
 				data-bs-toggle="dropdown"
 				data-bs-auto-close={keepOpen ? 'false' : 'outside'}

--- a/shared/astro/components/ui/Trending.astro
+++ b/shared/astro/components/ui/Trending.astro
@@ -13,7 +13,7 @@ const { value = 25, unit = '%', class: className } = Astro.props;
 const trendingColor = value > 0 ? 'green' : value === 0 ? 'muted' : 'red';
 const trendingIcon = value > 0 ? 'arrow-up' : value === 0 ? 'minus' : 'arrow-down';
 
-const classes = ['text-${trendingColor} d-inline-flex align-items-center lh-1', className];
+const classes = [`text-${trendingColor} d-inline-flex align-items-center lh-1`, className];
 ---
 
 <span class:list={classes}>


### PR DESCRIPTION
## Summary

- `Trending.astro` built its class with a plain string, not a template literal, so `${trendingColor}` was never filled in. The value shipped as literal text: `text-${trendingColor} d-inline-flex...`.
- `NavbarMenuItem.astro` passed its class array straight to `class` instead of `class:list` on the dropdown-toggle link. Astro turned the array into a comma-joined string, so the link got `class="dropdown-item,dropdown-toggle,false,"` instead of `class="dropdown-item dropdown-toggle"`.
- Both bugs came from the Eleventy → Astro migration. The sibling link in the same file already used `class:list` correctly, so this brings the two code paths in line.

## Preview

- **URL:** [dashboard-crypto](https://tabler-git-astro-migration-class-fixes-tabler-io.vercel.app/dashboard-crypto.html) (Trending colors) and [layout-fluid-vertical](https://tabler-git-astro-migration-class-fixes-tabler-io.vercel.app/layout-fluid-vertical.html) (sidebar dropdown)
- **How to test:**
  1. On `dashboard-crypto.html`, check the small trend numbers next to stats — they should be green/red/muted, not plain text with `text-${trendingColor}` in the class.
  2. On `layout-fluid-vertical.html`, open the sidebar and expand a menu item that has children (e.g. "Layout"). Inspect the link's class attribute — it should read `dropdown-item dropdown-toggle`, no commas or `false`.