### PR TITLE
Fix dead Plugins link on docs homepage

### DIFF
--- a/.changeset/fix-docs-homepage-plugins-link.md
+++ b/.changeset/fix-docs-homepage-plugins-link.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Fixed the `Plugins` card on the docs homepage linking to a 404 `/plugins` route instead of `/ui/plugins`.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -16,7 +16,7 @@ any device.
 <div class="mt-6 pt-6">
   <div class="row row-deck row-cards">
     <Card title="UI Components" href="/ui" icon="paint" description="Free and open source web application UI kit based on Bootstrap" />
-    <Card title="Plugins" href="/plugins" icon="plug" description="Free and open source plugins for Tabler UI components" />
+    <Card title="Plugins" href="/ui/plugins" icon="plug" description="Free and open source plugins for Tabler UI components" />
     <Card title="Icons" href="/icons" icon="ghost" description="Pixel-perfect icons for web design and development" />
     <Card title="Illustrations" href="/illustrations" icon="brand-figma" description="Customizable SVG illustrations for your web project" />
     <Card title="Email Templates" href="/emails" icon="mail" description="Responsive email templates ready to use in your marketing campaigns" />


### PR DESCRIPTION
## Summary

- Fixed the `Plugins` card on the docs homepage linking to a non-existent `/plugins` route (404) instead of the real `/ui/plugins` docs page.

## Preview

- **URL:** [preview link](https://tabler-git-fix-docs-homepage-plugins-link-tabler-io.vercel.app/)
- **How to test:** Open the preview homepage, click the `Plugins` card, and confirm it lands on the Plugins docs page instead of a 404.

## Notes / rollout

- Closes #2427