### PR TITLE
Disable trailing slash on docs URLs

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,3 @@
+{
+  "trailingSlash": false
+}


### PR DESCRIPTION
## Summary

- Add `docs/vercel.json` with `trailingSlash: false` so Vercel stops appending a trailing slash to docs routes (e.g. `/ui/layout/navbars` instead of `/ui/layout/navbars/`), matching the URL format the old Eleventy-based site used.

## Notes / rollout

- After this deploys, Vercel will 301-redirect any request that includes a trailing slash to the version without it.