### PR TITLE
Enable Astro TypeScript checks across preview, docs, and shared

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["astro-build.astro-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,14 @@
 {
-   "files.exclude": {
-      "**/.git": true,
-      "**/.svn": true,
-      "**/.hg": true,
-      "**/CVS": true,
-      "**/.DS_Store": true,
-      "**/Thumbs.db": true,
-      "**/.idea/": true
-   },
-   "explorerExclude.backup": {}
+	"files.exclude": {
+		"**/.git": true,
+		"**/.svn": true,
+		"**/.hg": true,
+		"**/CVS": true,
+		"**/.DS_Store": true,
+		"**/Thumbs.db": true,
+		"**/.idea/": true
+	},
+	"explorerExclude.backup": {},
+	"typescript.tsdk": "preview/node_modules/typescript/lib",
+	"typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/docs/components/Colors.astro
+++ b/docs/components/Colors.astro
@@ -7,7 +7,7 @@ const { colors }: Props = Astro.props;
 ---
 
 <div class="row row-cols-4 row-cols-md-6 g-3 g-md-4">
-	{Object.values(colors).map((color, i) => {
+	{Object.values(colors).map((color) => {
 		return (
 			<div class="col-2 text-center">
 				<div class="p-6 rounded border" style={{ backgroundColor: `var(${color.prop})` }}></div>

--- a/docs/components/OpenSourceResources.astro
+++ b/docs/components/OpenSourceResources.astro
@@ -14,7 +14,7 @@ import openSources from '@data/open-source.json';
 			License
 		</th>
 	</tr>
-	{ openSources.map((el, i) => {
+	{ openSources.map((el) => {
 		return (
 			<tr>
 				<td>

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "build": "pnpm run assets && astro build",
     "preview": "astro preview",
     "clean": "shx rm -rf dist public .astro",
-    "astro": "astro"
+    "type-check": "astro check"
   },
   "dependencies": {
     "@tabler/core": "workspace:*",
@@ -20,11 +20,13 @@
     "shiki": "^4.3.1"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.4",
     "@astrojs/markdown-satteri": "^0.3.4",
     "@astrojs/mdx": "^7.0.3",
     "@tabler/preview": "workspace:*",
     "@types/node": "^26.1.1",
     "js-beautify": "^2.0.3",
-    "shx": "^0.4.0"
+    "shx": "^0.4.0",
+    "typescript": "^5.7.3"
   }
 }

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -5,7 +5,9 @@
     "**/*"
   ],
   "exclude": [
-    "dist"
+    "dist",
+    "public",
+    "assets"
   ],
   "compilerOptions": {
     "baseUrl": ".",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
       '@tabler/icons':
         specifier: ^3.45.0
         version: 3.45.0
+      '@types/js-beautify':
+        specifier: ^1.14.3
+        version: 1.14.3
       js-beautify:
         specifier: ^2.0.3
         version: 2.0.3
@@ -283,6 +286,15 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1
     devDependencies:
+      '@types/js-beautify':
+        specifier: ^1.14.3
+        version: 1.14.3
+      astro:
+        specifier: ^7.1.3
+        version: 7.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.1)(sass@1.102.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(sass@1.102.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -1525,6 +1537,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/js-beautify@1.14.3':
+    resolution: {integrity: sha512-FMbQHz+qd9DoGvgLHxeqqVPaNRffpIu5ZjozwV8hf9JAGpIOzuAf4wGbRSo8LNITHqGjmmVjaMggTT5P4v4IHg==}
 
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
@@ -4780,6 +4795,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/core@7.29.7(supports-color@5.5.0)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))(supports-color@5.5.0)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@5.5.0)
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@5.5.0)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@babel/generator@7.29.7':
     dependencies:
       '@babel/parser': 7.29.7
@@ -4805,6 +4841,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.29.7(supports-color@5.5.0)':
+    dependencies:
+      '@babel/traverse': 7.29.7(supports-color@5.5.0)
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
@@ -4813,6 +4857,16 @@ snapshots:
       '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))(supports-color@5.5.0)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@5.5.0)
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -4852,6 +4906,19 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/traverse@7.29.7(supports-color@5.5.0)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@babel/types@7.29.7':
     dependencies:
@@ -5727,6 +5794,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/js-beautify@1.14.3': {}
+
   '@types/katex@0.16.8': {}
 
   '@types/mdast@4.0.4':
@@ -5860,6 +5929,23 @@ snapshots:
       vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(sass@1.102.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/coverage-istanbul@4.1.10(supports-color@5.5.0)(vitest@4.1.10)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@5.5.0)
+      '@istanbuljs/schema': 0.1.6
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(sass@1.102.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -8953,7 +9039,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
       '@vitest/browser-playwright': 4.1.10(playwright@1.62.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(sass@1.102.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/coverage-istanbul': 4.1.10(supports-color@10.2.2)(vitest@4.1.10)
+      '@vitest/coverage-istanbul': 4.1.10(supports-color@5.5.0)(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1
     devDependencies:
+      '@astrojs/check':
+        specifier: ^0.9.4
+        version: 0.9.10(prettier@3.9.6)(typescript@5.9.3)
       '@astrojs/markdown-satteri':
         specifier: ^0.3.4
         version: 0.3.4
@@ -224,6 +227,9 @@ importers:
       shx:
         specifier: ^0.4.0
         version: 0.4.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
 
   preview:
     dependencies:
@@ -234,6 +240,9 @@ importers:
         specifier: ^7.1.3
         version: 7.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.1)(sass@1.102.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
     devDependencies:
+      '@astrojs/check':
+        specifier: ^0.9.4
+        version: 0.9.10(prettier@3.9.6)(typescript@5.9.3)
       '@astrojs/markdown-satteri':
         specifier: ^0.3.4
         version: 0.3.4
@@ -255,6 +264,9 @@ importers:
       shx:
         specifier: ^0.4.0
         version: 0.4.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
 
   shared:
     dependencies:
@@ -276,6 +288,12 @@ importers:
         version: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(sass@1.102.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
+
+  '@astrojs/check@0.9.10':
+    resolution: {integrity: sha512-zgx/UQMozdjOa3bOxjgeCFdtpE3c9rRX6xHwa+2QXvy8z8Akifu2AtubHyv/zzC2znO8dl8fFWL4K+Ba9kS8HQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0 || ^6.0.0
 
   '@astrojs/compiler-binding-darwin-arm64@0.3.1':
     resolution: {integrity: sha512-IEmEF2fUIlTHtpeE/isyEGVOB14cEyh/LZOFYt6wn3jNyVpdC8aR5OZ+RzFUR/f+8ZDM1LaMwZKvoA7eMyJeFw==}
@@ -342,11 +360,26 @@ packages:
     resolution: {integrity: sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg==}
     engines: {node: '>=22.12.0'}
 
+  '@astrojs/compiler@2.13.1':
+    resolution: {integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==}
+
   '@astrojs/internal-helpers@0.10.1':
     resolution: {integrity: sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==}
 
   '@astrojs/internal-helpers@0.10.2':
     resolution: {integrity: sha512-yt7fMgPYqSM4Tmr+taTW6Per+hjJ8Pk6lA1PAcDyqzOt8HzJ6Kje5WzCxA2Sd+9wsUW7uhkLeoTMK0cXPwH9rQ==}
+
+  '@astrojs/language-server@2.16.13':
+    resolution: {integrity: sha512-ekOa+CYprEq5n4EJC1qTIAhLk49HZIUQuFwrEuF+3JK/pdMaYnWoREFUI2A0KEPOJiFA2kamBzKzbYljDvUxLg==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^3.0.0
+      prettier-plugin-astro: '>=0.11.0'
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+      prettier-plugin-astro:
+        optional: true
 
   '@astrojs/markdown-remark@7.2.1':
     resolution: {integrity: sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==}
@@ -374,6 +407,9 @@ packages:
   '@astrojs/telemetry@3.3.3':
     resolution: {integrity: sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/yaml2ts@0.2.4':
+    resolution: {integrity: sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -574,6 +610,27 @@ packages:
   '@clack/prompts@1.7.0':
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
+
+  '@emmetio/abbreviation@2.3.3':
+    resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
+
+  '@emmetio/css-abbreviation@2.1.8':
+    resolution: {integrity: sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==}
+
+  '@emmetio/css-parser@0.4.1':
+    resolution: {integrity: sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==}
+
+  '@emmetio/html-matcher@1.3.0':
+    resolution: {integrity: sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==}
+
+  '@emmetio/scanner@1.0.4':
+    resolution: {integrity: sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==}
+
+  '@emmetio/stream-reader-utils@0.1.0':
+    resolution: {integrity: sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==}
+
+  '@emmetio/stream-reader@2.2.0':
+    resolution: {integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -1667,6 +1724,32 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  '@volar/kit@2.4.28':
+    resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
+    peerDependencies:
+      typescript: '*'
+
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/language-server@2.4.28':
+    resolution: {integrity: sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==}
+
+  '@volar/language-service@2.4.28':
+    resolution: {integrity: sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
+  '@vscode/emmet-helper@2.11.0':
+    resolution: {integrity: sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==}
+
+  '@vscode/l10n@0.0.18':
+    resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
+
   abbrev@5.0.0:
     resolution: {integrity: sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
@@ -1684,6 +1767,22 @@ packages:
   adm-zip@0.6.0:
     resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
     engines: {node: '>=14.0'}
+
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-i18n@4.2.0:
+    resolution: {integrity: sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==}
+    peerDependencies:
+      ajv: ^8.0.0-beta.0
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   am-i-vibing@0.4.0:
     resolution: {integrity: sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==}
@@ -1872,6 +1971,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -2138,6 +2241,9 @@ packages:
   electron-to-chromium@1.5.397:
     resolution: {integrity: sha512-khGTy9U9x02KEtsKM8vx5A62BsRmcOsIgDpWr1ImE32Ax8GxHGPHZf+Eu9H8zOOyHJnB0jTbseyTHbq2XCT8yw==}
 
+  emmet@2.4.11:
+    resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -2250,6 +2356,9 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -2259,6 +2368,9 @@ packages:
 
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -2671,10 +2783,16 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@2.3.1:
+    resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
@@ -2701,6 +2819,10 @@ packages:
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -3075,6 +3197,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3244,6 +3369,9 @@ packages:
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3463,6 +3591,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -3522,8 +3654,18 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  request-light@0.5.8:
+    resolution: {integrity: sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==}
+
+  request-light@0.7.0:
+    resolution: {integrity: sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
@@ -3925,6 +4067,17 @@ packages:
   typed.js@3.0.0:
     resolution: {integrity: sha512-X4pjf0E7riZBo6j3NS21/7cJJ20osSOtD1OxlRoKfFU3GsdPuSpWlFcIKWf0k8uoKwBBrPuHGx+fKeU6GzRcKg==}
 
+  typesafe-path@0.2.2:
+    resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
+
+  typescript-auto-import-cache@0.3.6:
+    resolution: {integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
@@ -4210,6 +4363,108 @@ packages:
       jsdom:
         optional: true
 
+  volar-service-css@0.0.71:
+    resolution: {integrity: sha512-wRRFt9BpjMKCazcgOh67MSjUjiWUCAh99DyYSDIOTuxaRjEtDC7PpB0k1Y1wbJIW/pVtMUSVbpPo3UGSm0Byxw==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-emmet@0.0.71:
+    resolution: {integrity: sha512-zqjzt6bN95e3CUstBm0PBFAJnrfz0ZAARka87fart46/gNCLLuP3Vujy8V/J8HEziTFLnfkgIASLFYPUhonJcA==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-html@0.0.71:
+    resolution: {integrity: sha512-e8tHPhgQ7ooLfudAEIku+kgd9pWkq3SSz8RbnQDI1+Eb8wbenkLGHqoirLqz5ORLV6wIMr2Iv08RWBG5eOcgpw==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-prettier@0.0.71:
+    resolution: {integrity: sha512-Rz7JVH3qD108UCdmIEiZvOBNljMt2nLFdbN8AXcDfn7xD9F5I2aCIsDVqBbXw21PsnxG0b7MfwtNF+zPS/NKUg==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+      prettier: ^2.2 || ^3.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+      prettier:
+        optional: true
+
+  volar-service-typescript-twoslash-queries@0.0.71:
+    resolution: {integrity: sha512-9K2k72s4n7rV9s4bX0MyjbX9iBribvKZbBJKuEmTCZfeWJXs6Yh7bGpY4eoc7UufAjvpheBqwyZCOIPBvxCv0A==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-typescript@0.0.71:
+    resolution: {integrity: sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-yaml@0.0.71:
+    resolution: {integrity: sha512-qYGWGuVpUTnZGu5P/CR4KLK4aIR8RrcVnmfZ2eRcj9q/I8VZCoC5yy9FtEvfNvnDp4MU17yhdJcvpQPIqhJS2Q==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  vscode-css-languageservice@6.3.10:
+    resolution: {integrity: sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==}
+
+  vscode-html-languageservice@5.6.2:
+    resolution: {integrity: sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==}
+
+  vscode-json-languageservice@4.1.8:
+    resolution: {integrity: sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==}
+    engines: {npm: '>=7.0.0'}
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-jsonrpc@9.0.1:
+    resolution: {integrity: sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-protocol@3.18.2:
+    resolution: {integrity: sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver-types@3.18.0:
+    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-nls@5.2.0:
+    resolution: {integrity: sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==}
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -4266,6 +4521,15 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml-language-server@1.23.0:
+    resolution: {integrity: sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A==}
+    hasBin: true
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -4298,6 +4562,17 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@astrojs/check@0.9.10(prettier@3.9.6)(typescript@5.9.3)':
+    dependencies:
+      '@astrojs/language-server': 2.16.13(prettier@3.9.6)(typescript@5.9.3)
+      chokidar: 4.0.3
+      kleur: 4.1.5
+      typescript: 5.9.3
+      yargs: 18.0.0
+    transitivePeerDependencies:
+      - prettier
+      - prettier-plugin-astro
 
   '@astrojs/compiler-binding-darwin-arm64@0.3.1':
     optional: true
@@ -4353,6 +4628,8 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  '@astrojs/compiler@2.13.1': {}
+
   '@astrojs/internal-helpers@0.10.1':
     dependencies:
       '@types/hast': 3.0.4
@@ -4374,6 +4651,31 @@ snapshots:
       shiki: 4.3.1
       smol-toml: 1.6.1
       unified: 11.0.5
+
+  '@astrojs/language-server@2.16.13(prettier@3.9.6)(typescript@5.9.3)':
+    dependencies:
+      '@astrojs/compiler': 2.13.1
+      '@astrojs/yaml2ts': 0.2.4
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@volar/kit': 2.4.28(typescript@5.9.3)
+      '@volar/language-core': 2.4.28
+      '@volar/language-server': 2.4.28
+      '@volar/language-service': 2.4.28
+      muggle-string: 0.4.1
+      tinyglobby: 0.2.17
+      volar-service-css: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-emmet: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-html: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-prettier: 0.0.71(@volar/language-service@2.4.28)(prettier@3.9.6)
+      volar-service-typescript: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-typescript-twoslash-queries: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-yaml: 0.0.71(@volar/language-service@2.4.28)
+      vscode-html-languageservice: 5.6.2
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      prettier: 3.9.6
+    transitivePeerDependencies:
+      - typescript
 
   '@astrojs/markdown-remark@7.2.1(supports-color@5.5.0)':
     dependencies:
@@ -4445,6 +4747,10 @@ snapshots:
       dset: 3.1.4
       is-docker: 4.0.0
       package-manager-detector: 1.7.0
+
+  '@astrojs/yaml2ts@0.2.4':
+    dependencies:
+      yaml: 2.9.0
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -4758,6 +5064,29 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@emmetio/abbreviation@2.3.3':
+    dependencies:
+      '@emmetio/scanner': 1.0.4
+
+  '@emmetio/css-abbreviation@2.1.8':
+    dependencies:
+      '@emmetio/scanner': 1.0.4
+
+  '@emmetio/css-parser@0.4.1':
+    dependencies:
+      '@emmetio/stream-reader': 2.2.0
+      '@emmetio/stream-reader-utils': 0.1.0
+
+  '@emmetio/html-matcher@1.3.0':
+    dependencies:
+      '@emmetio/scanner': 1.0.4
+
+  '@emmetio/scanner@1.0.4': {}
+
+  '@emmetio/stream-reader-utils@0.1.0': {}
+
+  '@emmetio/stream-reader@2.2.0': {}
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -5573,6 +5902,56 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@volar/kit@2.4.28(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      typesafe-path: 0.2.2
+      typescript: 5.9.3
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/language-server@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      path-browserify: 1.0.1
+      request-light: 0.7.0
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-protocol: 3.18.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/language-service@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      vscode-languageserver-protocol: 3.18.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vscode/emmet-helper@2.11.0':
+    dependencies:
+      emmet: 2.4.11
+      jsonc-parser: 2.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-uri: 3.1.0
+
+  '@vscode/l10n@0.0.18': {}
+
   abbrev@5.0.0: {}
 
   acorn-jsx@5.3.2(acorn@8.17.0):
@@ -5582,6 +5961,21 @@ snapshots:
   acorn@8.17.0: {}
 
   adm-zip@0.6.0: {}
+
+  ajv-draft-04@1.0.0(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv-i18n@4.2.0(ajv@8.20.0):
+    dependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.4
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   am-i-vibing@0.4.0:
     dependencies:
@@ -5839,6 +6233,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -6085,6 +6483,11 @@ snapshots:
 
   electron-to-chromium@1.5.397: {}
 
+  emmet@2.4.11:
+    dependencies:
+      '@emmetio/abbreviation': 2.3.3
+      '@emmetio/css-abbreviation': 2.1.8
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -6237,6 +6640,8 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
+  fast-deep-equal@3.1.3: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -6250,6 +6655,8 @@ snapshots:
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
+
+  fast-uri@3.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -6727,7 +7134,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json5@2.2.3: {}
+
+  jsonc-parser@2.3.1: {}
 
   jsonc-parser@3.3.1: {}
 
@@ -6752,6 +7163,8 @@ snapshots:
   katex@0.16.47:
     dependencies:
       commander: 8.3.0
+
+  kleur@4.1.5: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -7394,6 +7807,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  muggle-string@0.4.1: {}
+
   nanoid@3.3.16: {}
 
   neotraverse@1.0.1: {}
@@ -7574,6 +7989,8 @@ snapshots:
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
+
+  path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
 
@@ -7759,6 +8176,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
+  readdirp@4.1.2: {}
+
   readdirp@5.0.0: {}
 
   rechoir@0.6.2:
@@ -7872,7 +8291,13 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  request-light@0.5.8: {}
+
+  request-light@0.7.0: {}
+
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-from@5.0.0: {}
 
@@ -8319,6 +8744,14 @@ snapshots:
 
   typed.js@3.0.0: {}
 
+  typesafe-path@0.2.2: {}
+
+  typescript-auto-import-cache@0.3.6:
+    dependencies:
+      semver: 7.8.5
+
+  typescript@5.9.3: {}
+
   typescript@7.0.2:
     optionalDependencies:
       '@typescript/typescript-aix-ppc64': 7.0.2
@@ -8524,6 +8957,112 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  volar-service-css@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-css-languageservice: 6.3.10
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-emmet@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      '@emmetio/css-parser': 0.4.1
+      '@emmetio/html-matcher': 1.3.0
+      '@vscode/emmet-helper': 2.11.0
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-html@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-html-languageservice: 5.6.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-prettier@0.0.71(@volar/language-service@2.4.28)(prettier@3.9.6):
+    dependencies:
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+      prettier: 3.9.6
+
+  volar-service-typescript-twoslash-queries@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-typescript@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      path-browserify: 1.0.1
+      semver: 7.8.5
+      typescript-auto-import-cache: 0.3.6
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-nls: 5.2.0
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-yaml@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-uri: 3.1.0
+      yaml-language-server: 1.23.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  vscode-css-languageservice@6.3.10:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.1.0
+
+  vscode-html-languageservice@5.6.2:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-uri: 3.1.0
+
+  vscode-json-languageservice@4.1.8:
+    dependencies:
+      jsonc-parser: 3.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-nls: 5.2.0
+      vscode-uri: 3.1.0
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-jsonrpc@9.0.1: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-protocol@3.18.2:
+    dependencies:
+      vscode-jsonrpc: 9.0.1
+      vscode-languageserver-types: 3.18.0
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver-types@3.18.0: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-nls@5.2.0: {}
+
+  vscode-uri@3.1.0: {}
+
   web-namespaces@2.0.1: {}
 
   webidl-conversions@3.0.1: {}
@@ -8567,6 +9106,23 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml-language-server@1.23.0:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      ajv: 8.20.0
+      ajv-draft-04: 1.0.0(ajv@8.20.0)
+      ajv-i18n: 4.2.0(ajv@8.20.0)
+      prettier: 3.9.6
+      request-light: 0.5.8
+      vscode-json-languageservice: 4.1.8
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-uri: 3.1.0
+      yaml: 2.8.3
+
+  yaml@2.8.3: {}
 
   yaml@2.9.0: {}
 

--- a/preview/astro.config.mjs
+++ b/preview/astro.config.mjs
@@ -22,6 +22,7 @@ function prettifyHtml() {
 				// dist/preview/ and dist/dist/ are copy-assets.mjs's copies of public/{preview,dist}
 				// (demo css/js and @tabler/core's dist, including vendored libs) — not pages, and
 				// some vendored libs ship their own malformed docs/*.html that trips the parser below.
+				/** @param {string} file */
 				const isVendorCopy = (file) => file.includes(`${outDir}preview/`) || file.includes(`${outDir}dist/`);
 				// Astro appends "overflow-x: auto" to the shiki <pre> style — the
 				// Eleventy pipeline doesn't have it and HTML is the product: restore 1:1.

--- a/preview/env.d.ts
+++ b/preview/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/preview/package.json
+++ b/preview/package.json
@@ -18,19 +18,22 @@
     "preview": "astro preview",
     "clean": "shx rm -rf dist public/dist public/preview public/css .astro tmp-assets",
     "import-icons": "pnpm up @tabler/icons@latest && node .build/import-icons.mjs",
-    "import-illustrations": "node .build/import-illustrations.mjs"
+    "import-illustrations": "node .build/import-illustrations.mjs",
+    "type-check": "astro check"
   },
   "dependencies": {
     "@tabler/core": "workspace:*",
     "astro": "^7.1.3"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.4",
     "@astrojs/markdown-satteri": "^0.3.4",
     "@astrojs/mdx": "^7.0.3",
     "@tabler/icons": "^3.45.0",
     "js-beautify": "^2.0.3",
     "prettier": "^3.9.6",
     "shiki": "^4.3.1",
-    "shx": "^0.4.0"
+    "shx": "^0.4.0",
+    "typescript": "^5.7.3"
   }
 }

--- a/preview/package.json
+++ b/preview/package.json
@@ -30,6 +30,7 @@
     "@astrojs/markdown-satteri": "^0.3.4",
     "@astrojs/mdx": "^7.0.3",
     "@tabler/icons": "^3.45.0",
+    "@types/js-beautify": "^1.14.3",
     "js-beautify": "^2.0.3",
     "prettier": "^3.9.6",
     "shiki": "^4.3.1",

--- a/preview/pages/2-step-verification-code.astro
+++ b/preview/pages/2-step-verification-code.astro
@@ -59,20 +59,22 @@ import ButtonList from '@ui/ButtonList.astro';
 
 	<!-- BEGIN CODE INPUT SCRIPT -->
 	<script>
-		const inputs = document.querySelectorAll('[data-code-input]');
+		const inputs = document.querySelectorAll<HTMLInputElement>('[data-code-input]');
 
 		// Attach an event listener to each input element
 		inputs.forEach((input, i) => {
 			input.addEventListener('input', (e) => {
+				const target = e.target as HTMLInputElement;
 				// If the input field has a character, and there is a next input field, focus it
-				if (e.target.value.length === e.target.maxLength && i + 1 < inputs.length) {
+				if (target.value.length === target.maxLength && i + 1 < inputs.length) {
 					inputs[i + 1].focus();
 				}
 			});
 
-			input.addEventListener('keydown', (e) => {
-				// If the input field is empty and the keyCode for Backspace (8) is detected, and there is a previous input field, focus it
-				if (e.target.value.length === 0 && e.keyCode === 8 && i > 0) {
+			input.addEventListener('keydown', (e: KeyboardEvent) => {
+				const target = e.target as HTMLInputElement;
+				// If the input field is empty and Backspace is pressed, and there is a previous input field, focus it
+				if (target.value.length === 0 && e.key === 'Backspace' && i > 0) {
 					inputs[i - 1].focus();
 				}
 			});

--- a/preview/pages/all-elements.astro
+++ b/preview/pages/all-elements.astro
@@ -448,7 +448,7 @@ function greetUser(name) {
 
 							<h4>Rating</h4>
 							<div class="mb-3">
-								<Rating id="demo-rating" value="4" />
+								<Rating id="demo-rating" value={4} />
 							</div>
 
 							<h4>Steps</h4>

--- a/preview/pages/colors.astro
+++ b/preview/pages/colors.astro
@@ -1,6 +1,5 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro';
-import Icon from '@ui/Icon.astro';
 import FormGroup from '@ui/FormGroup.astro';
 import Card from '@ui/Card.astro';
 import CardBody from '@ui/CardBody.astro';

--- a/preview/pages/emails.astro
+++ b/preview/pages/emails.astro
@@ -87,18 +87,15 @@ const emailEntries = Object.entries(emails);
 		const emailModal = document.getElementById('email-modal');
 		if (emailModal) {
 			emailModal.addEventListener('show.bs.modal', function (e) {
-				const button = e.relatedTarget;
+				const button = (e as Event & { relatedTarget: HTMLElement }).relatedTarget;
 
 				const image = button.getAttribute('data-bs-image'),
 					title = button.getAttribute('data-bs-title'),
 					description = button.getAttribute('data-bs-description');
 
-				emailModal.querySelector('[data-email-title]').textContent = title;
-				emailModal.querySelector('[data-email-description]').textContent = description;
-				emailModal.querySelector('[data-email-image]').src = image;
-
-				modalTitle.textContent = `New message to ${recipient}`;
-				modalBodyInput.value = recipient;
+				emailModal.querySelector('[data-email-title]')!.textContent = title;
+				emailModal.querySelector('[data-email-description]')!.textContent = description;
+				(emailModal.querySelector('[data-email-image]') as HTMLImageElement).src = image ?? '';
 			});
 		}
 	</script>

--- a/preview/pages/emails.astro
+++ b/preview/pages/emails.astro
@@ -87,7 +87,8 @@ const emailEntries = Object.entries(emails);
 		const emailModal = document.getElementById('email-modal');
 		if (emailModal) {
 			emailModal.addEventListener('show.bs.modal', function (e) {
-				const button = (e as Event & { relatedTarget: HTMLElement }).relatedTarget;
+				const button = (e as Event & { relatedTarget?: EventTarget | null }).relatedTarget;
+				if (!(button instanceof HTMLElement)) return;
 
 				const image = button.getAttribute('data-bs-image'),
 					title = button.getAttribute('data-bs-title'),

--- a/preview/pages/form-elements.astro
+++ b/preview/pages/form-elements.astro
@@ -179,7 +179,7 @@ const rows = [
 								<div class="col-sm-6 col-md-6"><FormGroup label="Last Name"><input type="text" class="form-control" placeholder="Last Name" value="Faker" /></FormGroup></div>
 								<div class="col-md-12"><FormGroup label="Address"><input type="text" class="form-control" placeholder="Home Address" value="Melbourne, Australia" /></FormGroup></div>
 								<div class="col-sm-6 col-md-4"><FormGroup label="City"><input type="text" class="form-control" placeholder="City" value="Melbourne" /></FormGroup></div>
-								<div class="col-sm-6 col-md-3"><FormGroup label="Postal Code"><input type="test" class="form-control" placeholder="ZIP Code" /></FormGroup></div>
+								<div class="col-sm-6 col-md-3"><FormGroup label="Postal Code"><input type="text" class="form-control" placeholder="ZIP Code" /></FormGroup></div>
 								<div class="col-md-5"><FormGroup label="Country"><select class="form-control form-select"><option value="">Germany</option></select></FormGroup></div>
 								<div class="col-md-12">
 									<FormGroup label="About Me" class="mb-3 mb-0">

--- a/preview/pages/illustrations.astro
+++ b/preview/pages/illustrations.astro
@@ -175,7 +175,9 @@ const illustrationsData = Object.fromEntries(
 		</div>
 	</div>
 	<!-- BEGIN ILLUSTRATIONS SCRIPT -->
-	<script define:vars={{ illustrationsData }}>
+	<script is:inline define:vars={{ illustrationsData }}>
+		// @ts-nocheck — illustrationsData is injected at runtime by define:vars, which
+		// the type checker can't see since is:inline skips TS processing of this script.
 		let skinColor = 'var()',
 			primaryColor = 'var()';
 

--- a/preview/pages/pay.astro
+++ b/preview/pages/pay.astro
@@ -34,7 +34,7 @@ import Icon from '@ui/Icon.astro';
 
 				<nav class="nav nav-segmented w-100 mb-4" role="tablist">
 					<button
-						href="#tab-card"
+						data-bs-target="#tab-card"
 						class="nav-link active"
 						data-bs-toggle="tab"
 						role="tab"
@@ -45,7 +45,7 @@ import Icon from '@ui/Icon.astro';
 						<span>Pay With Card</span>
 					</button>
 					<button
-						href="#tab-paypal"
+						data-bs-target="#tab-paypal"
 						class="nav-link"
 						data-bs-toggle="tab"
 						role="tab"

--- a/preview/pages/progress.astro
+++ b/preview/pages/progress.astro
@@ -141,16 +141,17 @@ import ProgressDescription from '@ui/ProgressDescription.astro';
 
 						This is just a demo script to show how to animate the progress bar. You can modify it as needed.
 						*/
-						const progress = document.getElementById('progress-animated');
+						const progress = document.getElementById('progress-animated')!;
 						let width = 0;
 
-						const setWidth = (w) => {
+						const setWidth = (w: number) => {
 							width = Math.min(Math.max(w, 0), 100);
 
-							progress.querySelector('.progress-bar').style.width = `${width}%`;
-							progress.querySelector('.progress-bar').setAttribute('aria-valuenow', width);
-							document.getElementById('progress-animated-value').innerText = `${width}%`;
-							progress.querySelector('.progress-bar').classList.toggle('bg-green', width >= 100);
+							const bar = progress.querySelector<HTMLElement>('.progress-bar')!;
+							bar.style.width = `${width}%`;
+							bar.setAttribute('aria-valuenow', `${width}`);
+							document.getElementById('progress-animated-value')!.innerText = `${width}%`;
+							bar.classList.toggle('bg-green', width >= 100);
 						};
 
 						const interval = setInterval(() => {
@@ -158,10 +159,10 @@ import ProgressDescription from '@ui/ProgressDescription.astro';
 							if (width >= 100) clearInterval(interval);
 						}, 2000);
 
-						document.getElementById('progress-animated-0').addEventListener('click', () => setWidth(0));
-						document.getElementById('progress-animated-add-10').addEventListener('click', () => setWidth(width + 10));
-						document.getElementById('progress-animated-minus-10').addEventListener('click', () => setWidth(width - 10));
-						document.getElementById('progress-animated-100').addEventListener('click', () => setWidth(100));
+						document.getElementById('progress-animated-0')!.addEventListener('click', () => setWidth(0));
+						document.getElementById('progress-animated-add-10')!.addEventListener('click', () => setWidth(width + 10));
+						document.getElementById('progress-animated-minus-10')!.addEventListener('click', () => setWidth(width - 10));
+						document.getElementById('progress-animated-100')!.addEventListener('click', () => setWidth(100));
 					</script>
 					<!-- END SCRIPT OF ANIMATION -->
 				</CardBody>

--- a/preview/pages/signatures.astro
+++ b/preview/pages/signatures.astro
@@ -109,13 +109,13 @@ document.querySelector("#signature-advanced-png").addEventListener("click", func
 							<div class="mt-4">
 								<div class="row">
 									<FormGroup label="Pen color" for="signature-advanced-color" labelClass="visually-hidden" class="col">
-										<input href="" type="color" id="signature-advanced-color" class="w-100 form-control form-control-color" />
+										<input type="color" id="signature-advanced-color" class="w-100 form-control form-control-color" />
 									</FormGroup>
 									<div class="col">
-										<button href="" class="btn w-100" id="signature-advanced-svg">Download SVG</button>
+										<button class="btn w-100" id="signature-advanced-svg">Download SVG</button>
 									</div>
 									<div class="col">
-										<button href="" class="btn w-100" id="signature-advanced-png">Download PNG</button>
+										<button class="btn w-100" id="signature-advanced-png">Download PNG</button>
 									</div>
 								</div>
 							</div>

--- a/preview/tsconfig.json
+++ b/preview/tsconfig.json
@@ -5,7 +5,9 @@
 		"**/*"
 	],
 	"exclude": [
-		"dist"
+		"dist",
+		"public",
+		"tmp-assets"
 	],
 	"compilerOptions": {
 		"paths": {

--- a/shared/env.d.ts
+++ b/shared/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/shared/lib/docs-children.ts
+++ b/shared/lib/docs-children.ts
@@ -47,29 +47,28 @@ function normalizeUrl(url: string): string {
 export function getDocsChildren(parentUrl: string): DocsChildPage[] {
   const parentParts = normalizeUrl(parentUrl).split('/').filter(Boolean)
 
-  return (
-    Object.entries(pageModules)
-      .map(([path, mod]) => {
-        const pageUrl = urlFromGlobPath(path)
-        const parts = pageUrl.split('/').filter(Boolean)
-        const isDirectChild = parts.length === parentParts.length + 1 && parts.slice(0, -1).join('/') === parentParts.join('/')
+  return Object.entries(pageModules)
+    .flatMap(([path, mod]): DocsChildPage[] => {
+      const pageUrl = urlFromGlobPath(path)
+      const parts = pageUrl.split('/').filter(Boolean)
+      const isDirectChild = parts.length === parentParts.length + 1 && parts.slice(0, -1).join('/') === parentParts.join('/')
 
-        if (!isDirectChild) return null
+      if (!isDirectChild) return []
 
-        const fm = getFrontmatter(mod)
-        if (!fm?.title) return null
+      const fm = getFrontmatter(mod)
+      if (!fm?.title) return []
 
-        return {
+      return [
+        {
           url: pageUrl,
           title: String(fm.title),
           description: String(fm.description ?? ''),
-          icon: fm.icon ? String(fm.icon) : undefined,
+          ...(fm.icon ? { icon: String(fm.icon) } : {}),
           order: Number(fm.order ?? 999),
-        }
-      })
-      .filter((page): page is DocsChildPage => page !== null)
-      // if a route exists in both conventions (foo.mdx AND foo/index.mdx), count it once
-      .filter((page, i, all) => all.findIndex((p) => p.url === page.url) === i)
-      .sort((a, b) => a.order - b.order || a.title.localeCompare(b.title))
-  )
+        },
+      ]
+    })
+    // if a route exists in both conventions (foo.mdx AND foo/index.mdx), count it once
+    .filter((page, i, all) => all.findIndex((p) => p.url === page.url) === i)
+    .sort((a, b) => a.order - b.order || a.title.localeCompare(b.title))
 }

--- a/shared/lib/docs-children.ts
+++ b/shared/lib/docs-children.ts
@@ -47,28 +47,30 @@ function normalizeUrl(url: string): string {
 export function getDocsChildren(parentUrl: string): DocsChildPage[] {
   const parentParts = normalizeUrl(parentUrl).split('/').filter(Boolean)
 
-  return Object.entries(pageModules)
-    .flatMap(([path, mod]): DocsChildPage[] => {
-      const pageUrl = urlFromGlobPath(path)
-      const parts = pageUrl.split('/').filter(Boolean)
-      const isDirectChild = parts.length === parentParts.length + 1 && parts.slice(0, -1).join('/') === parentParts.join('/')
+  return (
+    Object.entries(pageModules)
+      .flatMap(([path, mod]): DocsChildPage[] => {
+        const pageUrl = urlFromGlobPath(path)
+        const parts = pageUrl.split('/').filter(Boolean)
+        const isDirectChild = parts.length === parentParts.length + 1 && parts.slice(0, -1).join('/') === parentParts.join('/')
 
-      if (!isDirectChild) return []
+        if (!isDirectChild) return []
 
-      const fm = getFrontmatter(mod)
-      if (!fm?.title) return []
+        const fm = getFrontmatter(mod)
+        if (!fm?.title) return []
 
-      return [
-        {
-          url: pageUrl,
-          title: String(fm.title),
-          description: String(fm.description ?? ''),
-          ...(fm.icon ? { icon: String(fm.icon) } : {}),
-          order: Number(fm.order ?? 999),
-        },
-      ]
-    })
-    // if a route exists in both conventions (foo.mdx AND foo/index.mdx), count it once
-    .filter((page, i, all) => all.findIndex((p) => p.url === page.url) === i)
-    .sort((a, b) => a.order - b.order || a.title.localeCompare(b.title))
+        return [
+          {
+            url: pageUrl,
+            title: String(fm.title),
+            description: String(fm.description ?? ''),
+            ...(fm.icon ? { icon: String(fm.icon) } : {}),
+            order: Number(fm.order ?? 999),
+          },
+        ]
+      })
+      // if a route exists in both conventions (foo.mdx AND foo/index.mdx), count it once
+      .filter((page, i, all) => all.findIndex((p) => p.url === page.url) === i)
+      .sort((a, b) => a.order - b.order || a.title.localeCompare(b.title))
+  )
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -6,7 +6,8 @@
 	"description": "Astro components and lib shared between preview and docs (imported via the @shared vite alias; this package.json exists so npm imports resolve from shared sources)",
 	"scripts": {
 		"test": "vitest run",
-		"test:watch": "vitest"
+		"test:watch": "vitest",
+		"type-check": "tsc --noEmit"
 	},
 	"dependencies": {
 		"js-beautify": "^2.0.3",
@@ -15,6 +16,12 @@
 		"markdown-it": "^14.3.0"
 	},
 	"devDependencies": {
+		"@types/js-beautify": "^1.14.3",
+		"astro": "^7.1.3",
+		"typescript": "^5.7.3",
 		"vitest": "4.1.10"
+	},
+	"peerDependencies": {
+		"astro": "^7.1.3"
 	}
 }

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,0 +1,27 @@
+{
+	"extends": "astro/tsconfigs/strict",
+	"include": [
+		"**/*"
+	],
+	"exclude": [
+		"dist",
+		"node_modules"
+	],
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"@data/*": [
+				"./data/*"
+			],
+			"@shared/*": [
+				"./*"
+			],
+			"@ui/*": [
+				"./ui/*"
+			],
+			"@components/*": [
+				"./components/*"
+			]
+		}
+	}
+}

--- a/shared/ui/Pagination.astro
+++ b/shared/ui/Pagination.astro
@@ -5,7 +5,7 @@ import Icon from './Icon.astro';
 interface Props {
 	count?: number;
 	offset?: number;
-	activeItem?: number;
+	activeItem?: number | string;
 	class?: string;
 	firstLast?: boolean;
 	text?: boolean;

--- a/shared/ui/Pagination.astro
+++ b/shared/ui/Pagination.astro
@@ -16,13 +16,16 @@ interface Props {
 const {
 	count = 5,
 	offset = count,
-	activeItem = 3,
+	activeItem: activeItemProp = 3,
 	class: className,
 	firstLast,
 	text,
 	prevDescription,
 	nextDescription,
 } = Astro.props;
+
+const activeItem = Number(activeItemProp);
+const normalizedActiveItem = Number.isFinite(activeItem) ? activeItem : 3;
 
 // equivalent of the (1..offset) loop
 const firstPages: number[] = [];
@@ -60,7 +63,7 @@ if (offset < count) {
 		</a>
 	</li>
 	{firstPages.map((i) => (
-		<li class={`page-item${i === activeItem ? ' active' : ''}`}>
+		<li class={`page-item${i === normalizedActiveItem ? ' active' : ''}`}>
 			<a class="page-link" href="#">{i}</a>
 		</li>
 	))}
@@ -70,7 +73,7 @@ if (offset < count) {
 				<span class="page-link disabled">&hellip;</span>
 			</li>
 			{lastPages.map((i) => (
-				<li class={`page-item${i === activeItem ? ' active' : ''}`}>
+				<li class={`page-item${i === normalizedActiveItem ? ' active' : ''}`}>
 					<a class="page-link" href="#">{i}</a>
 				</li>
 			))}


### PR DESCRIPTION
## Summary

- Add `type-check` scripts (`astro check` / `tsc --noEmit`) and TypeScript tooling (`@astrojs/check`, `typescript`, `env.d.ts`, `shared/tsconfig.json`) for preview, docs, and shared.
- Fix type errors and invalid markup so checks pass (typed DOM scripts, prop types, `href` on buttons, `input type="test"`, unused imports).
- Point the workspace TypeScript SDK at preview’s TypeScript and recommend the Astro VS Code extension.

## Preview

- **URL:** [pay](https://tabler-git-type-check-tabler-io.vercel.app/pay.html), [form-elements](https://tabler-git-type-check-tabler-io.vercel.app/form-elements.html), [signatures](https://tabler-git-type-check-tabler-io.vercel.app/signatures.html)
- **How to test:** Run `pnpm type-check` (or the package scripts) in `preview`, `docs`, and `shared` and confirm they pass. Spot-check pay tabs, postal code input type, and signature download buttons if you want to verify the small HTML fixes.