### PR TITLE
Serve `error-404.html` as the Vercel 404 page

### DIFF
--- a/.changeset/preview-vercel-404.md
+++ b/.changeset/preview-vercel-404.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": patch
+---
+
+Fixed Vercel deployment to serve `error-404.html` as the custom 404 page.

--- a/preview/vercel.json
+++ b/preview/vercel.json
@@ -1,5 +1,15 @@
 {
-  "redirects": [
-    { "source": "/marketing", "destination": "/marketing.html", "permanent": true }
+  "routes": [
+    {
+      "src": "/marketing",
+      "status": 308,
+      "headers": { "Location": "/marketing.html" }
+    },
+    { "handle": "filesystem" },
+    {
+      "src": "/(.*)",
+      "status": 404,
+      "dest": "/error-404.html"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Configure Vercel so unknown routes serve `error-404.html` with HTTP 404.
- Keep the existing `/marketing` → `/marketing.html` redirect in the same `routes` list.

## Preview

- **URL:** [non-existent path](https://tabler-git-fix-preview-vercel-404-tabler-io.vercel.app/this-page-does-not-exist)
- **How to test:** Open a missing URL on the preview deploy. You should see the Tabler 404 page and a 404 status. Also check that `/error-404.html` still loads with 200, and `/marketing` still redirects to `/marketing.html`.