### PR TITLE
Restore `$caret-width` value shrunk by SCSS refactor

### DIFF
--- a/.changeset/restore-caret-width.md
+++ b/.changeset/restore-caret-width.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed the `caret()` mixin by restoring `$caret-width` to `0.36em`, which had shrunk to `0.3em` in a previous SCSS refactor.

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -911,7 +911,7 @@ $hr-opacity: $border-opacity !default;
 $vr-border-width: var(--#{$prefix}border-width) !default;
 
 // Caret
-$caret-width: 0.3em !default;
+$caret-width: 0.36em !default;
 $caret-vertical-align: $caret-width * 0.85 !default;
 $caret-spacing: $caret-width * 0.85 !default;
 

--- a/core/scss/tests/_caret.test.scss
+++ b/core/scss/tests/_caret.test.scss
@@ -72,13 +72,13 @@
         .t:after {
           content: '';
           display: inline-block;
-          vertical-align: 0.255em;
-          width: 0.3em;
-          height: 0.3em;
+          vertical-align: 0.306em;
+          width: 0.36em;
+          height: 0.36em;
           border-bottom: 1px var(--tblr-border-style);
           border-inline-start: 1px var(--tblr-border-style);
           margin-inline-end: 0.1em;
-          margin-inline-start: 0.255em;
+          margin-inline-start: 0.306em;
           transform: rotate(-45deg);
         }
       }
@@ -96,13 +96,13 @@
         .t:before {
           content: '';
           display: inline-block;
-          vertical-align: 0.255em;
-          width: 0.3em;
-          height: 0.3em;
+          vertical-align: 0.306em;
+          width: 0.36em;
+          height: 0.36em;
           border-bottom: 1px var(--tblr-border-style);
           border-inline-start: 1px var(--tblr-border-style);
           margin-inline-end: 0.1em;
-          margin-inline-end: 0.255em;
+          margin-inline-end: 0.306em;
           transform: rotate(45deg);
         }
         .t:after {


### PR DESCRIPTION
## Summary

- `$caret-width` dropped from `0.36em` to `0.3em` when the caret mixin was rewritten in #2536. This shrank the caret on every dropdown toggle and on nav links with a dropdown (for example, the docs top navbar).
- Restores `0.36em`, the value the reporter and a maintainer agreed was correct in the issue. `$caret-spacing` and `$caret-vertical-align` are derived from `$caret-width`, so they scale back up too.

## Preview

- **URL:** [preview link](https://tabler-git-fix-2564-docs-nav-caret-size-tabler-io.vercel.app/ui/)
- **How to test:** Open any docs page and look at a nav link with a dropdown in the top navbar, or open any dropdown button anywhere on the site. The caret should look a bit bigger than on `dev`.

## Notes / rollout

- Fixes #2564