### PR TITLE
Fix `.card-tabs .nav-tabs` z-index colliding with dropdowns

### DIFF
--- a/.changeset/fix-card-tabs-dropdown-zindex.md
+++ b/.changeset/fix-card-tabs-dropdown-zindex.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed `.card-tabs .nav-tabs` sharing `z-index` with `.dropdown-menu`, which made dropdowns opened over card tabs render behind them.

--- a/core/scss/ui/_cards.scss
+++ b/core/scss/ui/_cards.scss
@@ -594,7 +594,7 @@ Card list group
 .card-tabs {
   .nav-tabs {
     position: relative;
-    z-index: $zindex-dropdown;
+    z-index: 1;
     border-bottom: 0;
 
     .nav-link {


### PR DESCRIPTION
## Summary

- `.card-tabs .nav-tabs` reused `$zindex-dropdown` just to sit above the card's own border below it. That gave it the same z-index as every real `.dropdown-menu`.
- A dropdown opened above the tab row would render behind the tabs, so clicks on its items were swallowed.
- Changed `.card-tabs .nav-tabs` to `z-index: 1`, the same local-stacking value already used elsewhere in this file (`.card-chart`).

## Preview

- **URL:** [preview link](https://tabler-git-fix-1581-dropdown-navtabs-zindex-tabler-io.vercel.app/cards.html)
- **How to test:** Open the Cards preview page, find a card with tabs (`.card-tabs`), place a dropdown so it opens over the tab row, and open it. The dropdown should now render above the tabs and its items should be clickable.

## Notes / rollout

- Fixes #1581