### PR TITLE
Remove unused `bootstrapLink` frontmatter field

### DIFF
--- a/.changeset/remove-unused-bootstraplink.md
+++ b/.changeset/remove-unused-bootstraplink.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Removed the unused `bootstrapLink` front matter field from `DocsLayout`, `DocsMdxLayout`, and all docs pages.

--- a/docs/pages/ui/base/colors.mdx
+++ b/docs/pages/ui/base/colors.mdx
@@ -3,7 +3,6 @@ title: Colors
 summary:
   The choice of colors for a website or app interface has a big influence on how users interact with the product and what decisions they make. Harmonious colors can contribute to a nice first impression and encourage users to engage with your product, so it's a very important aspect of a successful design, which needs
   to be well thought out.
-bootstrapLink: utilities/colors/
 description: Impact of colors on user interface design.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/base/prose.mdx
+++ b/docs/pages/ui/base/prose.mdx
@@ -1,7 +1,6 @@
 ---
 title: Prose
 summary: Use the `.prose` wrapper to style long-form content without adding classes to every element.
-bootstrapLink: content/prose/
 description: Long-form content styles for markdown-like HTML.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/base/typography.mdx
+++ b/docs/pages/ui/base/typography.mdx
@@ -1,7 +1,6 @@
 ---
 title: Typography
 summary: Typography plays an important role in creating an attractive and clear interface design. Good typography will make the content easy to follow and improve the usability of your website.
-bootstrapLink: content/typography/
 description: Role of typography in interface design.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/alert.mdx
+++ b/docs/pages/ui/components/alert.mdx
@@ -1,7 +1,6 @@
 ---
 title: Alert
 summary: An alert message is used to inform users about the status of their action and help them solve problems that may occur. Good alert design is important for the overall user experience of a website or app.
-bootstrapLink: components/alerts/
 description: An alert message for user notification.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/badge.mdx
+++ b/docs/pages/ui/components/badge.mdx
@@ -2,7 +2,6 @@
 title: Badge
 summary: A badge is a small count and labeling component used to add extra information to an interface element. You can use it to draw user attention to a new element, notify about unread messages, or provide additional context.
 description: Add extra information with a badge.
-bootstrapLink: components/badge/
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---
 import BadgesList from '@ui/BadgesList.astro';

--- a/docs/pages/ui/components/breadcrumb.mdx
+++ b/docs/pages/ui/components/breadcrumb.mdx
@@ -1,7 +1,6 @@
 ---
 title: Breadcrumb
 summary: A breadcrumb is used to show the current website or app location and reduce the number of actions users need to take. It helps users navigate the website hierarchy and better understand its structure.
-bootstrapLink: components/breadcrumb/
 description: A navigation aid for better structure.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/button.mdx
+++ b/docs/pages/ui/components/button.mdx
@@ -1,7 +1,6 @@
 ---
 title: Button
 summary: Use a button style that best suits your design and encourages users to take the desired action. You can customize button properties to improve user experience by changing size, shape, color, and more.
-bootstrapLink: components/buttons/
 description: A customizable button for user actions.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/card.mdx
+++ b/docs/pages/ui/components/card.mdx
@@ -1,7 +1,6 @@
 ---
 title: Card
 summary: A card is a flexible user interface element that helps organize content into meaningful sections and display it across different screen sizes. It can contain smaller elements such as images, text, links, and buttons, and can act as an entry point to more detailed information.
-bootstrapLink: components/card/
 description: Organize content with a flexible card.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/carousel.mdx
+++ b/docs/pages/ui/components/carousel.mdx
@@ -1,7 +1,6 @@
 ---
 title: Carousel
 summary: A carousel is used to display multiple pieces of visual content without taking up too much space. It eliminates the need to scroll down the page to see all content and is a popular method of presenting marketing information.
-bootstrapLink: components/carousel/
 description: Display visual content with a carousel.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/dropdown.mdx
+++ b/docs/pages/ui/components/dropdown.mdx
@@ -1,7 +1,6 @@
 ---
 title: Dropdown
 summary: A dropdown is used to display a list of options or include more items in a menu without overwhelming users with too many buttons and long lists. It improves interaction with your website or software and keeps the interface clear.
-bootstrapLink: components/dropdowns
 description: Organize options with a dropdown menu.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/popover.mdx
+++ b/docs/pages/ui/components/popover.mdx
@@ -1,7 +1,6 @@
 ---
 title: Popover
 summary: A popover is used to provide additional information for elements where a simple tooltip is not sufficient.
-bootstrapLink: components/popovers
 description: Provide extra information with a popover.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/progress.mdx
+++ b/docs/pages/ui/components/progress.mdx
@@ -1,7 +1,6 @@
 ---
 title: Progress Bar
 summary: A progress bar is used to provide feedback on an action status and inform users about current progress. Although it is a small interface element, it is extremely helpful in managing user expectations and preventing abandonment of an initiated process.
-bootstrapLink: components/progress
 description: Track and display progress with a progress bar.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/spinner.mdx
+++ b/docs/pages/ui/components/spinner.mdx
@@ -1,7 +1,6 @@
 ---
 title: Spinner
 summary: A spinner is used to show the loading state of a component or page. It provides feedback for an action that takes longer to complete.
-bootstrapLink: components/spinners/
 description: Indicate loading state with a spinner.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/tab.mdx
+++ b/docs/pages/ui/components/tab.mdx
@@ -1,7 +1,6 @@
 ---
 title: Tab
 summary: A tab allows users to alternate between equally important views within the same context. By dividing content into meaningful sections, it improves organization and makes navigation easier.
-bootstrapLink: components/navs/
 description: Organize content with an interactive tab.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/table.mdx
+++ b/docs/pages/ui/components/table.mdx
@@ -1,7 +1,6 @@
 ---
 title: Table
 summary: A table is a useful interface element that lets you visualize data and arrange it clearly. It allows users to browse a lot of information at once, and a good table design improves readability.
-bootstrapLink: content/tables/
 description: Visualize data clearly with a table.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/toast.mdx
+++ b/docs/pages/ui/components/toast.mdx
@@ -1,7 +1,6 @@
 ---
 title: Toast
 summary: A toast is a lightweight alert box that displays for a few seconds after a user action to communicate state or outcome. It is useful after actions like clicking a button or submitting a form, where feedback is needed without prompting another action.
-bootstrapLink: components/toasts/
 description: Display a lightweight alert notification with a toast.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/components/tooltip.mdx
+++ b/docs/pages/ui/components/tooltip.mdx
@@ -1,7 +1,6 @@
 ---
 title: Tooltip
 summary: A tooltip is a text label that appears when a user hovers over an interface element. It explains unclear elements and guides users when they need help. When used properly, it can significantly enhance user experience and add value to your website or software.
-bootstrapLink: components/tooltips/
 description: Guide users with an informative tooltip.
 layout: '@shared/layouts/DocsMdxLayout.astro'
 ---

--- a/docs/pages/ui/forms/form-elements.mdx
+++ b/docs/pages/ui/forms/form-elements.mdx
@@ -1,7 +1,6 @@
 ---
 title: Form elements
 summary: Forms are one of the most important types of interaction with a website or app. Since their aim is to enable users to make a purchase, subscribe to a service or sign up to create an account, it's important to make sure they are easy to complete and help increase conversion rates. Use the available elements to create forms which are well-structured and user-friendly.
-bootstrapLink: components/forms/
 docs-libs: nouislider
 description: Design user-friendly and effective forms.
 order: 1

--- a/shared/layouts/DocsLayout.astro
+++ b/shared/layouts/DocsLayout.astro
@@ -24,12 +24,6 @@ interface Props {
 	description?: string;
 	/** front matter: optional SEO description override */
 	seoDescription?: string;
-	/**
-	 * front matter: path to the Bootstrap docs (e.g. "components/alerts/").
-	 * Unused by the layout or any docs include — it doesn't appear in the
-	 * reference output either; accepted for front matter parity.
-	 */
-	bootstrapLink?: string;
 	/** front matter `added-in`: renders the "Added in X" badge next to the h1 */
 	addedIn?: string;
 	/** table of contents (h2/h3 from the markdown content) — see DocsToc.astro */

--- a/shared/layouts/DocsMdxLayout.astro
+++ b/shared/layouts/DocsMdxLayout.astro
@@ -16,7 +16,6 @@ interface MdxFrontmatter {
 	summary?: string;
 	description?: string;
 	seoDescription?: string;
-	bootstrapLink?: string;
 	'added-in'?: string;
 	'docs-libs'?: string[];
 	'hide-pagination'?: boolean;
@@ -52,7 +51,6 @@ const toc = headings
 	summary={frontmatter.summary}
 	description={frontmatter.description}
 	seoDescription={frontmatter.seoDescription}
-	bootstrapLink={frontmatter.bootstrapLink}
 	addedIn={frontmatter['added-in']}
 	docsLibs={docsLibs}
 	hidePagination={frontmatter['hide-pagination']}


### PR DESCRIPTION
## Summary

- `bootstrapLink` was a frontmatter field accepted by `DocsLayout` and `DocsMdxLayout`, but neither layout ever read or rendered it.
- Removed the prop from both layouts and deleted the `bootstrapLink:` line from all 18 docs pages that still set it.
- No visual or behavior change. Docs pages don't use Astro content collections, so there is no schema to update.

## Notes / rollout

- Fixes #2339