### PR TITLE
Fix Sponsor card layout on RTL preview pages

### DIFF
--- a/preview/pages/layout-rtl.astro
+++ b/preview/pages/layout-rtl.astro
@@ -4,5 +4,5 @@ import HomepageContent from '@shared/components/HomepageContent.astro'
 ---
 
 <DefaultLayout title="RTL mode" pageHeader="RTL mode" pretitle="Overview" actions="buttons" pageMenu="home" pageLibs={['apexcharts', 'jsvectormap']} rtl>
-  <HomepageContent />
+  <HomepageContent rtl />
 </DefaultLayout>

--- a/shared/components/HomepageContent.astro
+++ b/shared/components/HomepageContent.astro
@@ -20,6 +20,12 @@ import Sponsor from './cards/Sponsor.astro'
 import SocialTraffic from './cards/SocialTraffic.astro'
 import Tasks from './cards/Tasks.astro'
 import Invoices from './cards/Invoices.astro'
+
+interface Props {
+  rtl?: boolean
+}
+
+const { rtl = false } = Astro.props
 ---
 
 <div class="row row-deck row-cards">
@@ -100,7 +106,7 @@ import Invoices from './cards/Invoices.astro'
   </div>
 
   <div class="col-md-6 col-lg-4">
-    <Sponsor />
+    <Sponsor rtl={rtl} />
   </div>
 
   <div class="col-md-6 col-lg-4">

--- a/shared/components/cards/Sponsor.astro
+++ b/shared/components/cards/Sponsor.astro
@@ -1,6 +1,12 @@
 ---
 import Icon from '@ui/Icon.astro'
 import { site } from '@shared/lib/site'
+
+interface Props {
+  rtl?: boolean
+}
+
+const { rtl = false } = Astro.props
 ---
 
 <a href={site.githubSponsorsUrl} class="card border-primary" target="_blank" rel="noopener" aria-label="Sponsor Tabler!" style="background: color-mix(in srgb, var(--tblr-primary) 4%, var(--tblr-bg-surface))">
@@ -194,13 +200,13 @@ import { site } from '@shared/lib/site'
       opacity=".3"></path>
   </svg>
   <div class="card-body d-flex flex-column justify-content-center p-5">
-    <div class="row">
-      <div class="col-7 offset-5 text-primary">
+    <div class="row justify-content-end" dir="ltr">
+      <div class="col-7 text-primary">
         <div class="h1 text-uppercase">Help Tabler Grow and Thrive</div>
         <p class="h3 fw-normal">Sponsor Tabler and help us make a difference!</p>
         <div class="mt-4">
-          <button class="btn w-100 pe-none" type="button">
-            <Icon name="heart" type="filled" color="pink" />
+          <button class="btn w-100 pe-none" type="button" dir="ltr">
+            <Icon name="heart" type="filled" color="pink" class={rtl ? 'icon-end' : undefined} />
             Become a Sponsor
           </button>
         </div>


### PR DESCRIPTION
## Summary

- Keep Sponsor card text and CTA on the right in RTL mode by replacing `offset-5` with `justify-content-end` and `dir="ltr"` on the content row.
- Fix the sponsor button icon order and spacing in RTL using `dir="ltr"` on the button and Tabler’s `icon-end` class when `rtl` is true.
- Pass an `rtl` prop from `HomepageContent` into `Sponsor`; enable it on the RTL preview page.

## Preview

- **URL:** [RTL layout preview](https://tabler-git-fix-sponsor-text-position-on-rtl-tabler-io.vercel.app/layout-rtl.html)
- **How to test:** Open the RTL layout page and scroll to the Sponsor card (homepage grid, right column). Text and button should stay on the right like in LTR, with the heart icon before “Become a Sponsor”. Compare with the normal dashboard — Sponsor should look the same in both modes.

## Notes / rollout

- Preview-only change in `shared/` components; no `@tabler/core` CSS changes.
- Other pages that use `<HomepageContent />` without `rtl` keep the current LTR behavior.