### PR TITLE
Add bundlewatch size budgets for all built `dist` assets

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -107,12 +107,60 @@
         "maxSize": "2.1 kB"
       },
       {
+        "path": "./dist/css/tabler-flags.rtl.css",
+        "maxSize": "2.6 kB"
+      },
+      {
+        "path": "./dist/css/tabler-flags.rtl.min.css",
+        "maxSize": "2.1 kB"
+      },
+      {
+        "path": "./dist/css/tabler-marketing.css",
+        "maxSize": "9.5 kB"
+      },
+      {
+        "path": "./dist/css/tabler-marketing.min.css",
+        "maxSize": "8.5 kB"
+      },
+      {
+        "path": "./dist/css/tabler-marketing.rtl.css",
+        "maxSize": "9.5 kB"
+      },
+      {
+        "path": "./dist/css/tabler-marketing.rtl.min.css",
+        "maxSize": "8.5 kB"
+      },
+      {
         "path": "./dist/css/tabler-payments.css",
         "maxSize": "2.4 kB"
       },
       {
         "path": "./dist/css/tabler-payments.min.css",
         "maxSize": "2.1 kB"
+      },
+      {
+        "path": "./dist/css/tabler-payments.rtl.css",
+        "maxSize": "2.4 kB"
+      },
+      {
+        "path": "./dist/css/tabler-payments.rtl.min.css",
+        "maxSize": "2.1 kB"
+      },
+      {
+        "path": "./dist/css/tabler-props.css",
+        "maxSize": "5 kB"
+      },
+      {
+        "path": "./dist/css/tabler-props.min.css",
+        "maxSize": "4.6 kB"
+      },
+      {
+        "path": "./dist/css/tabler-props.rtl.css",
+        "maxSize": "5 kB"
+      },
+      {
+        "path": "./dist/css/tabler-props.rtl.min.css",
+        "maxSize": "4.6 kB"
       },
       {
         "path": "./dist/css/tabler-socials.css",
@@ -123,11 +171,43 @@
         "maxSize": "2.1 kB"
       },
       {
+        "path": "./dist/css/tabler-socials.rtl.css",
+        "maxSize": "2.1 kB"
+      },
+      {
+        "path": "./dist/css/tabler-socials.rtl.min.css",
+        "maxSize": "2.1 kB"
+      },
+      {
+        "path": "./dist/css/tabler-themes.css",
+        "maxSize": "1.7 kB"
+      },
+      {
+        "path": "./dist/css/tabler-themes.min.css",
+        "maxSize": "1.4 kB"
+      },
+      {
+        "path": "./dist/css/tabler-themes.rtl.css",
+        "maxSize": "1.7 kB"
+      },
+      {
+        "path": "./dist/css/tabler-themes.rtl.min.css",
+        "maxSize": "1.4 kB"
+      },
+      {
         "path": "./dist/css/tabler-vendors.css",
         "maxSize": "7.7 kB"
       },
       {
         "path": "./dist/css/tabler-vendors.min.css",
+        "maxSize": "6.7 kB"
+      },
+      {
+        "path": "./dist/css/tabler-vendors.rtl.css",
+        "maxSize": "7.7 kB"
+      },
+      {
+        "path": "./dist/css/tabler-vendors.rtl.min.css",
         "maxSize": "6.7 kB"
       },
       {
@@ -145,6 +225,22 @@
       {
         "path": "./dist/js/tabler.esm.min.js",
         "maxSize": "48 kB"
+      },
+      {
+        "path": "./dist/js/tabler-theme.js",
+        "maxSize": "1 kB"
+      },
+      {
+        "path": "./dist/js/tabler-theme.esm.js",
+        "maxSize": "1 kB"
+      },
+      {
+        "path": "./dist/js/tabler-theme.min.js",
+        "maxSize": "800 B"
+      },
+      {
+        "path": "./dist/js/tabler-theme.esm.min.js",
+        "maxSize": "800 B"
       }
     ]
   },


### PR DESCRIPTION
## Summary

- The `bundlewatch` config in `core/package.json` covered only 16 of the 40 JS and CSS files the build writes to `dist/`. The other 24 are published to npm, served from the CDN, and SRI-hashed — but no size check watched them, so unexpected growth passed CI unnoticed.
- Adds the 24 missing entries: the four `tabler-theme` JS bundles, the `tabler-marketing`, `tabler-props` and `tabler-themes` CSS families, and the RTL variants of `tabler-flags`, `tabler-payments`, `tabler-socials` and `tabler-vendors`.
- Budgets are set from measured gzip sizes on a clean build, with headroom. Each RTL file gets the same budget as its LTR sibling, because the real difference between them is under 10 bytes.
- No existing budget is touched. New entries follow the alphabetical order the list already used.

## Preview

- **How to review:** the whole diff is one file, `core/package.json`. Only the `bundlewatch.files` array changes, and only by adding entries.
- **How to test:**
`pnpm --filter @tabler/core build`
`pnpm --filter @tabler/core bundlewatch`
It should print 40 `PASS` lines. Before this change it printed 16.
- To confirm nothing is still missing, compare the `path` values in `bundlewatch.files` with `ls core/dist/css/*.css core/dist/js/*.js`. Both lists should hold the same 40 files.
## Notes / rollout
- Closes #2767
- No changeset. This only changes the CI size budget. Nothing in the published `dist`, `scss` or `js` output changes.
- Possible follow-up: make the `bundlewatch` script fail when a built file has no entry, so the list cannot drift again when new entry points are added.