### PR TITLE
Fix icon-to-text spacing in navbar nav links

### DIFF
--- a/core/scss/layout/_navbar.scss
+++ b/core/scss/layout/_navbar.scss
@@ -108,6 +108,7 @@ Navbar
   }
 
   .navbar-nav {
+    --#{$prefix}nav-link-icon-margin-end: #{$nav-link-icon-margin-end};
     min-height: subtract($navbar-height, 2 * $navbar-padding-y);
 
     .nav-link {


### PR DESCRIPTION
## Summary

- Set `--tblr-nav-link-icon-margin-end` on `.navbar-nav` so navbar links use the same icon spacing token as other nav components.
- Fixes missing gap between `.nav-link-icon` and link text inside the navbar (the variable was defined on `.nav` but not passed into the navbar tree).

## Preview

- **URL:** [preview homepage](https://tabler-git-fix-icon-text-spacing-in-navbar-tabler-io.vercel.app/)
- **How to test:** Open any preview page with the main navbar (e.g. dashboard). Check nav items with icons — the icon and label should have consistent spacing. Compare with a page that uses standalone `.nav` if helpful; spacing should now match.

## Notes / rollout

- Closes #2755
- Regression from #2745: `.nav-link-icon` reads `--tblr-nav-link-icon-margin-end`, but `.navbar-nav` never set that token.
- One-line SCSS change in `@tabler/core`; rebuild CSS to pick it up in dist.