### PR TITLE
Copy only runtime files into `dist/libs` instead of whole npm packages

### DIFF
--- a/.changeset/slim-down-dist-libs.md
+++ b/.changeset/slim-down-dist-libs.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed oversized `dist/libs` by copying only the runtime files each library declares in `libs.json`, plus the assets HugeRTE loads at runtime and every upstream license file.

--- a/core/.build/copy-libs.ts
+++ b/core/.build/copy-libs.ts
@@ -47,12 +47,26 @@ for (const name in libsData) {
       files.push(...matches)
     }
 
-    if (js || css) {
+    if (files) {
       for (const file of files) {
         copySync(join(pkgDir, file), join(to, file), {
           dereference: true,
         })
       }
+    }
+
+    // Ship each upstream license alongside its files — we redistribute the
+    // built bundles, and MIT/BSD/Apache all require the notice to travel with them.
+    const licenses = globSync('{license,licence,copying}*', { cwd: pkgDir, nodir: true, nocase: true })
+
+    if (licenses.length === 0) {
+      console.warn(`Warning: no license file found for ${npm}`)
+    }
+
+    for (const file of licenses) {
+      copySync(join(pkgDir, file), join(to, file), {
+        dereference: true,
+      })
     }
 
     console.log(`Successfully copied ${npm}`)

--- a/core/.build/copy-libs.ts
+++ b/core/.build/copy-libs.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync, mkdirSync } from 'node:fs'
+import { globSync } from 'glob'
 import { emptyDirSync, copySync } from 'fs-extra/esm'
 import libs from '../libs.json' with { type: 'json' }
 import { fileURLToPath } from 'node:url'
@@ -12,6 +13,7 @@ interface LibConfig {
   npm?: string
   js?: string[]
   css?: string[]
+  extra?: string[]
   head?: boolean
 }
 
@@ -24,10 +26,10 @@ const libsData = libs as Libs
 emptyDirSync(join(__dirname, '..', 'dist/libs'))
 
 for (const name in libsData) {
-  const { npm } = libsData[name]
+  const { npm, js, css, extra } = libsData[name]
 
   if (npm) {
-    const from = join(__dirname, '..', `node_modules/${npm}`)
+    const pkgDir = join(__dirname, '..', `node_modules/${npm}`)
     const to = join(__dirname, '..', `dist/libs/${npm}`)
 
     // create dir in dist/libs
@@ -35,9 +37,23 @@ for (const name in libsData) {
       mkdirSync(to, { recursive: true })
     }
 
-    copySync(from, to, {
-      dereference: true,
-    })
+    const files = [...(js || []), ...(css || [])]
+
+    for (const pattern of extra || []) {
+      const matches = globSync(pattern, { cwd: pkgDir, nodir: true, posix: true })
+      if (matches.length === 0) {
+        throw new Error(`copy-libs: ${name} — "${pattern}" matched no files in ${npm}`)
+      }
+      files.push(...matches)
+    }
+
+    if (js || css) {
+      for (const file of files) {
+        copySync(join(pkgDir, file), join(to, file), {
+          dereference: true,
+        })
+      }
+    }
 
     console.log(`Successfully copied ${npm}`)
   }

--- a/core/libs.json
+++ b/core/libs.json
@@ -100,15 +100,17 @@
       "hugerte.min.js"
     ],
     "extra": [
-    "themes/silver/theme.min.js",
-    "models/dom/model.min.js",
-    "icons/default/icons.min.js",
-    "plugins/*/plugin.min.js",
-    "skins/ui/oxide/*.min.css",
-    "skins/ui/oxide-dark/*.min.css",
-    "skins/content/default/content.min.css",
-    "skins/content/dark/content.min.css"
-  ]
+      "themes/silver/theme.min.js",
+      "models/dom/model.min.js",
+      "icons/default/icons.min.js",
+      "plugins/*/plugin.min.js",
+      "plugins/help/js/i18n/keynav/*.js",
+      "plugins/emoticons/js/*.min.js",
+      "skins/ui/oxide/*.min.css",
+      "skins/ui/oxide-dark/*.min.css",
+      "skins/content/default/content.min.css",
+      "skins/content/dark/content.min.css"
+    ]
   },
   "plyr": {
     "npm": "plyr",

--- a/core/libs.json
+++ b/core/libs.json
@@ -98,7 +98,17 @@
     "npm": "hugerte",
     "js": [
       "hugerte.min.js"
-    ]
+    ],
+    "extra": [
+    "themes/silver/theme.min.js",
+    "models/dom/model.min.js",
+    "icons/default/icons.min.js",
+    "plugins/*/plugin.min.js",
+    "skins/ui/oxide/*.min.css",
+    "skins/ui/oxide-dark/*.min.css",
+    "skins/content/default/content.min.css",
+    "skins/content/dark/content.min.css"
+  ]
   },
   "plyr": {
     "npm": "plyr",


### PR DESCRIPTION
## Summary

- `copy-libs.ts` copied every npm package in full, so `dist/libs` shipped 50 MB in 1543 files — sources, tests, type declarations and docs that the site never serves. It now copies only the files each library declares in `libs.json`.
- HugeRTE loads its theme, model, icons, plugins and skins at runtime, so `libs.json` gained an `extra` field with glob patterns for those files. A pattern that matches nothing fails the build, so an upstream rename cannot silently break the editor again.
- Each package's license file is copied next to its runtime files, so redistribution still carries the upstream notices.
- `dist/libs` is now 5.0 MB in 136 files, and the download zip drops from 79 MB to 69 MB.

## Preview

- **URL:** [WYSIWYG page](https://tabler-git-fix-copy-libs-in-core-tabler-io.vercel.app/wysiwyg.html)
- **How to test:** open the WYSIWYG page and check the editor renders with its toolbar and icons. In DevTools, every `dist/libs/hugerte/**` request should return 200. Switch to dark mode and reload — `skins/ui/oxide-dark/skin.min.css` should load. Then check the charts, form elements, vector maps, fullcalendar, dropzone and inline player pages.

## Notes / rollout

- Closes #2765
- Files that shipped only because whole packages were copied are gone — unminified builds, `src/`, `.d.ts`, other tom-select themes. Anyone deep-linking such a path under `dist/libs` must switch to a declared file or add it to `libs.json`.
