### PR TITLE
Fix signature pad clear button accessibility and canvas height drift

### DIFF
--- a/core/scss/ui/_signature.scss
+++ b/core/scss/ui/_signature.scss
@@ -3,6 +3,7 @@
 .signature {
   --#{$prefix}signature-padding: var(--#{$prefix}spacer-1);
   --#{$prefix}signature-border-radius: var(--#{$prefix}border-radius);
+  --#{$prefix}signature-canvas-height: 12.5rem;
   border: var(--#{$prefix}border-width) solid var(--#{$prefix}border-color);
   padding: var(--#{$prefix}signature-padding);
   @include border-radius(var(--#{$prefix}border-radius));
@@ -14,4 +15,8 @@
   display: block;
   cursor: crosshair;
   width: 100%;
+  // A fixed height is required: without it the canvas height comes from its own
+  // width/height attributes, which `resizeCanvas()` rewrites on every resize —
+  // each run then measures a different `offsetHeight` and the pad drifts.
+  height: var(--#{$prefix}signature-canvas-height);
 }

--- a/shared/ui/Signature.astro
+++ b/shared/ui/Signature.astro
@@ -50,8 +50,6 @@ ${clearSnippet}
 		function resizeCanvas() {
         const ratio = Math.max(window.devicePixelRatio || 1, 1);
 
-		  console.log(canvas.offsetWidth, canvas.offsetHeight);
-
         canvas.width = canvas.offsetWidth * ratio;
         canvas.height = canvas.offsetHeight * ratio;
         canvas.getContext("2d").scale(ratio, ratio);
@@ -72,9 +70,9 @@ ${extraSnippet}
   {
     clear && (
       <div class="position-absolute top-0 end-0 p-2">
-        <div class="btn btn-icon" id={`signature-${id}-clear`} title="Clear signature" data-bs-toggle="tooltip">
+        <button type="button" class="btn btn-icon" id={`signature-${id}-clear`} title="Clear signature" data-bs-toggle="tooltip">
           <Icon name="trash" />{' '}
-        </div>
+        </button>
       </div>
     )
   }


### PR DESCRIPTION
Three small fixes to `shared/ui/Signature.astro`, found while writing the docs page for the component.

## What changed

**1. Removed a leftover debug statement.** The generated init script contained `console.log(canvas.offsetWidth, canvas.offsetHeight)` inside `resizeCanvas()`, which ran on every page using the component and on every window resize.

**2. The clear control is now a real button.** It was rendered as `<div class="btn btn-icon">`, which is not focusable and cannot be activated with a keyboard — keyboard users had no way to clear the pad. It is now `<button type="button" class="btn btn-icon">`. The explicit `type` matters: both preview usages place the pad inside a `<form>`, so without it the button would submit.

**3. Gave the canvas a CSS height.** The canvas got `width`/`height` attributes but no CSS height, while `.signature-canvas` sets `width: 100%`. The rendered height therefore came from the canvas's own attributes — which `resizeCanvas()` rewrites on every run — so each resize measured a different `offsetHeight` and the pad drifted. Added a `--tblr-signature-canvas-height` variable (12.5rem = 200px, matching the height the pads already rendered at, so the preview pages look unchanged).

## Verification

Checked on the running preview at `/signatures` and `/modals`.

Clear button:

- The accessibility tree now exposes it as `button "Clear signature"` with `tabIndex` 0, so it is in the tab order. As a `div` it was not a control at all.
- A real mouse click both focuses it (`document.activeElement` is the button — a `div` never would be) and runs the handler: canvas ink pixels went 426 → 0.
- Both preview pages still look right — icon button top-right of the pad, tooltip intact.

One caveat on evidence: an actual Enter keystroke could not be demonstrated, because the browser tool's synthetic key events never reached the page (a `keydown` listener on `document` recorded zero events for any key). The keyboard claim rests on it being a native focusable `<button>` whose click handler clears the pad, both of which were verified directly.

Canvas height, measured on `/signatures` while dispatching three resize events:

| | `offsetHeight` across 4 measurements | backing store |
| --- | --- | --- |
| before | 202 → 203 → 204 → 205 (drift) | 1216×402 vs 608×202 CSS |
| after | 200 → 200 → 200 → 200 | 1216×400 = exactly 2× CSS at `devicePixelRatio` 2 |

The drift direction depends on the layout — a narrower pad shrinks (199px → 102px → 103px → 104px), the card pad above grows — but the cause is the same feedback loop. The reasoning is left as a comment above the new rule so it does not get "cleaned up" later.

`pnpm run lint-scss-vars` and `prettier --check` on both files pass.

## Note for reviewers

The `width`/`height` props still set the canvas's initial attributes, but they no longer influence the rendered height. Consumers who want a taller or shorter pad should override `--tblr-signature-canvas-height`. Worth covering in the docs page for this component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)