### PR TITLE
Fix `NaN` transform on the jsVectorMap world map

### DIFF
--- a/shared/ui/MapVector.astro
+++ b/shared/ui/MapVector.astro
@@ -100,7 +100,7 @@ const mapOptions = data
 				<script define:vars={{ mapKey, mapSelector, mapName: data.map, mapOptions }}>
 					window.tabler_map_vector ??= {};
 
-					function initMapVector() {
+					function createMapVector() {
 						const map = (window.tabler_map_vector[mapKey] = new jsVectorMap({
 							selector: mapSelector,
 							map: mapName,
@@ -113,6 +113,27 @@ const mapOptions = data
 						window.addEventListener('resize', () => {
 							map.updateSize();
 						});
+					}
+
+					function initMapVector() {
+						const container = document.querySelector(mapSelector);
+
+						// jsVectorMap computes its initial scale from the container's layout
+						// size. If the container is still 0x0 (e.g. layout hasn't settled
+						// yet), that scale ends up 0, and a later resize divides by it,
+						// producing a NaN transform. Wait for real dimensions first.
+						if (container.offsetWidth && container.offsetHeight) {
+							createMapVector();
+							return;
+						}
+
+						const observer = new ResizeObserver((entries) => {
+							if (entries[0].contentRect.width && entries[0].contentRect.height) {
+								observer.disconnect();
+								createMapVector();
+							}
+						});
+						observer.observe(container);
 					}
 
 					document.readyState !== 'loading' ? initMapVector() : document.addEventListener('DOMContentLoaded', initMapVector, { once: true });


### PR DESCRIPTION
## Summary

- The jsVectorMap world map (`shared/ui/MapVector.astro`) could break with `scale(NaN) translate(NaN, NaN)` and a console error.
- Cause: jsVectorMap reads the map container's size when it starts up. If the container is still `0x0` at that moment (layout not settled yet), the map's internal scale becomes `0`. Later, a browser resize divides by that stale `0`, producing `NaN`.
- Fix: wait for the container to have a real size before creating the map. If it's already sized, create the map right away; otherwise watch it with a `ResizeObserver` and create the map once it gets a size.

## Preview

- **URL:** [preview link](https://tabler-git-claude-agitated-bassi-616c7b-tabler-io.vercel.app/)
- **How to test:** Open the homepage (world map card) or [`/maps-vector.html`](https://tabler-git-claude-agitated-bassi-616c7b-tabler-io.vercel.app/maps-vector.html) and confirm the map renders normally, with no `<g> attribute transform: Expected number` error in the console. This was reproducible on both the local dev server and the live production site.