### PR TITLE
Add ARIA dialog attributes to the signature modal

### DIFF
--- a/preview/pages/signatures.astro
+++ b/preview/pages/signatures.astro
@@ -125,11 +125,11 @@ document.querySelector("#signature-advanced-png").addEventListener("click", func
   </div>
 
   <CaptureModal>
-    <div class="modal" tabindex="-1" id="modal-signature">
+    <div class="modal" tabindex="-1" id="modal-signature" role="dialog" aria-modal="true" aria-labelledby="modal-signature-save-title">
       <div class="modal-dialog">
         <div class="modal-content">
           <div class="modal-body">
-            <h5 class="modal-title">Save your signature</h5>
+            <h5 class="modal-title" id="modal-signature-save-title">Save your signature</h5>
             <Signature id="modal" clear event="shown.bs.modal" />
 
             <div class="text-secondary fs-5 mt-4">I agree that the signature and initials will be the electronic representation of my signature and initials for all purposes when I (or my agent) use them on documents, including legally binding contracts - just the same as a pen-and-paper signature or initial.</div>


### PR DESCRIPTION
## Summary

- The signature modal in `preview/pages/signatures.astro` is hand-written markup, not the shared `Modal`/`ModalInline` component, so a recent accessibility pass missed it.
- Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` to the modal root, matching the pattern used by the shared modal components.
- Added a matching `id` on the modal title so `aria-labelledby` points to it.

## Preview

- **URL:** [signatures.html](https://tabler-git-claude-signature-modal-a11y-tabler-io.vercel.app/signatures.html)
- **How to test:** Open the "Save your signature" modal and inspect the `#modal-signature` element. It should have `role="dialog"`, `aria-modal="true"`, and `aria-labelledby="modal-signature-save-title"`, and that id should exist on the `<h5>` title. No visual change.