### PR TITLE
Make `.card-header` background transparent by default, add override hooks

### DIFF
--- a/.changeset/card-header-footer-bg-vars.md
+++ b/.changeset/card-header-footer-bg-vars.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": minor
+---
+
+Added `--card-header-bg` and `--card-footer-bg` CSS variables (with `$card-header-bg` and `$card-footer-bg` Sass defaults) so `.card-header` and `.card-footer` backgrounds can be overridden independently, and made `.card-header` transparent by default instead of using `--card-cap-bg`.

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -1241,6 +1241,8 @@ $card-cap-padding-y: $card-spacer-y !default;
 $card-cap-padding-x: $card-spacer-x !default;
 $card-cap-bg: var(--bg-surface-tertiary) !default;
 $card-cap-color: inherit !default;
+$card-header-bg: transparent !default;
+$card-footer-bg: null !default;
 $card-height: null !default;
 $card-color: inherit !default;
 $card-bg: var(--bg-surface) !default;

--- a/core/scss/bootstrap/_card.scss
+++ b/core/scss/bootstrap/_card.scss
@@ -106,10 +106,13 @@
 //
 
 .card-header {
+  @if $card-header-bg != null {
+    --card-header-bg: #{$card-header-bg};
+  }
   padding: var(--card-cap-padding-y) var(--card-cap-padding-x);
   margin-bottom: 0; // Removes the default margin-bottom of <hN>
   color: var(--card-cap-color);
-  background-color: var(--card-cap-bg);
+  background-color: var(--card-header-bg, var(--card-cap-bg));
   border-bottom: var(--card-border-width) solid var(--card-border-color);
 
   &:first-child {
@@ -118,9 +121,12 @@
 }
 
 .card-footer {
+  @if $card-footer-bg != null {
+    --card-footer-bg: #{$card-footer-bg};
+  }
   padding: var(--card-cap-padding-y) var(--card-cap-padding-x);
   color: var(--card-cap-color);
-  background-color: var(--card-cap-bg);
+  background-color: var(--card-footer-bg, var(--card-cap-bg));
   border-top: var(--card-border-width) solid var(--card-border-color);
 
   &:last-child {

--- a/core/scss/ui/_cards.scss
+++ b/core/scss/ui/_cards.scss
@@ -221,7 +221,7 @@ Stacked card
   display: flex;
   align-items: center;
   color: inherit;
-  background-color: var(--card-cap-bg);
+  background-color: var(--card-header-bg, var(--card-cap-bg));
 
   &:first-child {
     @include border-radius(var(--card-border-radius) var(--card-border-radius) 0 0);


### PR DESCRIPTION
## Summary

- `.card-header` now defaults to a **transparent** background instead of the shared cap background (`--card-cap-bg`), so headers blend into the card body unless overridden.
- `.card-footer` keeps its previous cap-background default, unchanged visually.
- Both now expose independent override hooks: `--card-header-bg` and `--card-footer-bg` (backed by new `$card-header-bg` / `$card-footer-bg` Sass variables), falling back to `--card-cap-bg` when unset.

## Preview

- **URL:** [preview link](https://tabler-git-feat-card-header-footer-bg-vars-tabler-io.vercel.app/cards.html)
- **How to test:** Open `/cards.html` or `/card-actions.html` and check that card headers no longer show the darker cap background — they should blend with the card body. Card footers should look unchanged. Try setting `--card-header-bg` or `--card-footer-bg` inline on a `.card-header`/`.card-footer` to confirm the override works.