### PR TITLE
fix: resolve Windows cmd.exe build errors

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://tabler.io",
   "scripts": {
     "dev": "pnpm run watch",
+    "test-escape": "concurrently \"echo '/@license^|@preserve^|^^!/'\"",
     "dev-prepare": "pnpm run clean && pnpm run copy && concurrently \"pnpm run css-build\" \"pnpm run js-build\"",
     "build": "pnpm run clean && pnpm run build-assets && pnpm run copy && pnpm run generate-sri",
     "build-assets": "concurrently \"pnpm run css\" \"pnpm run js\"",
@@ -20,8 +21,8 @@
     "js-build-theme": "cross-env BASE_NAME=tabler-theme vite build --config .build/vite.config.mts",
     "js-build-standalone": "cross-env BASE_NAME=tabler vite build --config .build/vite.config.mts",
     "js-build-min": "concurrently \"pnpm run js-build-min-standalone\" \"pnpm run js-build-min-theme\"",
-    "js-build-min-standalone": "concurrently \"terser dist/js/tabler.js --compress --mangle --comments '/@license|@preserve|^!/' --source-map \\\"content=dist/js/tabler.js.map,filename=dist/js/tabler.min.js.map,url=tabler.min.js.map\\\" -o dist/js/tabler.min.js\" \"terser dist/js/tabler.esm.js --module --compress --mangle --comments '/@license|@preserve|^!/' --source-map \\\"content=dist/js/tabler.esm.js.map,filename=dist/js/tabler.esm.min.js.map,url=tabler.esm.min.js.map\\\" -o dist/js/tabler.esm.min.js\"",
-    "js-build-min-theme": "concurrently \"terser dist/js/tabler-theme.js --compress --mangle --comments '/@license|@preserve|^!/' --source-map \\\"content=dist/js/tabler-theme.js.map,filename=dist/js/tabler-theme.min.js.map,url=tabler-theme.min.js.map\\\" -o dist/js/tabler-theme.min.js\" \"terser dist/js/tabler-theme.esm.js --module --compress --mangle --comments '/@license|@preserve|^!/' --source-map \\\"content=dist/js/tabler-theme.esm.js.map,filename=dist/js/tabler-theme.esm.min.js.map,url=tabler-theme.esm.min.js.map\\\" -o dist/js/tabler-theme.esm.min.js\"",
+    "js-build-min-standalone": "concurrently \"terser dist/js/tabler.js --compress --mangle --comments --source-map \\\"content=dist/js/tabler.js.map,filename=dist/js/tabler.min.js.map,url=tabler.min.js.map\\\" -o dist/js/tabler.min.js\" \"terser dist/js/tabler.esm.js --module --compress --mangle --comments --source-map \\\"content=dist/js/tabler.esm.js.map,filename=dist/js/tabler.esm.min.js.map,url=tabler.esm.min.js.map\\\" -o dist/js/tabler.esm.min.js\"",
+    "js-build-min-theme": "concurrently \"terser dist/js/tabler-theme.js --compress --mangle --comments --source-map \\\"content=dist/js/tabler-theme.js.map,filename=dist/js/tabler-theme.min.js.map,url=tabler-theme.min.js.map\\\" -o dist/js/tabler-theme.min.js\" \"terser dist/js/tabler-theme.esm.js --module --compress --mangle --comments --source-map \\\"content=dist/js/tabler-theme.esm.js.map,filename=dist/js/tabler-theme.esm.min.js.map,url=tabler-theme.esm.min.js.map\\\" -o dist/js/tabler-theme.esm.min.js\"",
     "copy": "concurrently \"pnpm run copy-img\" \"pnpm run copy-libs\" \"pnpm run copy-fonts\"",
     "copy-img": "shx mkdir -p dist/img && shx cp -rf img/* dist/img",
     "copy-libs": "tsx .build/copy-libs.ts",

--- a/core/package.json
+++ b/core/package.json
@@ -5,7 +5,6 @@
   "homepage": "https://tabler.io",
   "scripts": {
     "dev": "pnpm run watch",
-    "test-escape": "concurrently \"echo '/@license^|@preserve^|^^!/'\"",
     "dev-prepare": "pnpm run clean && pnpm run copy && concurrently \"pnpm run css-build\" \"pnpm run js-build\"",
     "build": "pnpm run clean && pnpm run build-assets && pnpm run copy && pnpm run generate-sri",
     "build-assets": "concurrently \"pnpm run css\" \"pnpm run js\"",
@@ -21,8 +20,8 @@
     "js-build-theme": "cross-env BASE_NAME=tabler-theme vite build --config .build/vite.config.mts",
     "js-build-standalone": "cross-env BASE_NAME=tabler vite build --config .build/vite.config.mts",
     "js-build-min": "concurrently \"pnpm run js-build-min-standalone\" \"pnpm run js-build-min-theme\"",
-    "js-build-min-standalone": "concurrently \"terser dist/js/tabler.js --compress --mangle --comments --source-map \\\"content=dist/js/tabler.js.map,filename=dist/js/tabler.min.js.map,url=tabler.min.js.map\\\" -o dist/js/tabler.min.js\" \"terser dist/js/tabler.esm.js --module --compress --mangle --comments --source-map \\\"content=dist/js/tabler.esm.js.map,filename=dist/js/tabler.esm.min.js.map,url=tabler.esm.min.js.map\\\" -o dist/js/tabler.esm.min.js\"",
-    "js-build-min-theme": "concurrently \"terser dist/js/tabler-theme.js --compress --mangle --comments --source-map \\\"content=dist/js/tabler-theme.js.map,filename=dist/js/tabler-theme.min.js.map,url=tabler-theme.min.js.map\\\" -o dist/js/tabler-theme.min.js\" \"terser dist/js/tabler-theme.esm.js --module --compress --mangle --comments --source-map \\\"content=dist/js/tabler-theme.esm.js.map,filename=dist/js/tabler-theme.esm.min.js.map,url=tabler-theme.esm.min.js.map\\\" -o dist/js/tabler-theme.esm.min.js\"",
+    "js-build-min-standalone": "concurrently \"terser dist/js/tabler.js --compress --mangle --source-map \\\"content=dist/js/tabler.js.map,filename=dist/js/tabler.min.js.map,url=tabler.min.js.map\\\" -o dist/js/tabler.min.js\" \"terser dist/js/tabler.esm.js --module --compress --mangle --source-map \\\"content=dist/js/tabler.esm.js.map,filename=dist/js/tabler.esm.min.js.map,url=tabler.esm.min.js.map\\\" -o dist/js/tabler.esm.min.js\"",
+    "js-build-min-theme": "concurrently \"terser dist/js/tabler-theme.js --compress --mangle --source-map \\\"content=dist/js/tabler-theme.js.map,filename=dist/js/tabler-theme.min.js.map,url=tabler-theme.min.js.map\\\" -o dist/js/tabler-theme.min.js\" \"terser dist/js/tabler-theme.esm.js --module --compress --mangle --source-map \\\"content=dist/js/tabler-theme.esm.js.map,filename=dist/js/tabler-theme.esm.min.js.map,url=tabler-theme.esm.min.js.map\\\" -o dist/js/tabler-theme.esm.min.js\"",
     "copy": "concurrently \"pnpm run copy-img\" \"pnpm run copy-libs\" \"pnpm run copy-fonts\"",
     "copy-img": "shx mkdir -p dist/img && shx cp -rf img/* dist/img",
     "copy-libs": "tsx .build/copy-libs.ts",

--- a/preview/astro.config.mjs
+++ b/preview/astro.config.mjs
@@ -3,7 +3,9 @@ import { defineConfig } from 'astro/config'
 import mdx from '@astrojs/mdx'
 import { satteri } from '@astrojs/markdown-satteri'
 import beautify from 'js-beautify'
-import { execSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+import { execFileSync } from 'node:child_process'
 import { globSync, readFileSync, writeFileSync } from 'node:fs'
 import { devNull } from 'node:os'
 import { fileURLToPath } from 'node:url'
@@ -38,10 +40,9 @@ function prettifyHtml() {
           const cleaned = content.replaceAll('; overflow-x: auto;', '')
           if (cleaned !== content) writeFileSync(file, cleaned)
         }
-        execSync(
-          `npx prettier --write --parser html --ignore-path "${devNull}" "${outDir}**/*.html" "!${outDir}preview/**" "!${outDir}dist/**"`,
-          { stdio: 'inherit' }
-        )
+        // .gitignore and .prettierignore both list dist, so without pointing at devNull
+        // the pass silently no-ops on the very directory it's meant to format.
+        execFileSync(process.execPath, [require.resolve('prettier/bin/prettier.cjs'), '--write', '--parser', 'html', '--ignore-path', devNull, `${outDir}**/*.html`, `!${outDir}preview/**`, `!${outDir}dist/**`], { stdio: 'inherit' })
         logger.info('HTML formatted with prettier')
       },
     },

--- a/preview/astro.config.mjs
+++ b/preview/astro.config.mjs
@@ -3,7 +3,7 @@ import { defineConfig } from 'astro/config'
 import mdx from '@astrojs/mdx'
 import { satteri } from '@astrojs/markdown-satteri'
 import beautify from 'js-beautify'
-import { execFileSync } from 'node:child_process'
+import { execSync } from 'node:child_process'
 import { globSync, readFileSync, writeFileSync } from 'node:fs'
 import { devNull } from 'node:os'
 import { fileURLToPath } from 'node:url'
@@ -38,24 +38,9 @@ function prettifyHtml() {
           const cleaned = content.replaceAll('; overflow-x: auto;', '')
           if (cleaned !== content) writeFileSync(file, cleaned)
         }
-        execFileSync(
-          'npx',
-          [
-            'prettier',
-            '--write',
-            '--parser',
-            'html',
-            // Prettier's default ignore-path is [.gitignore, .prettierignore], and both
-            // list "dist" (needed elsewhere so normal lint/format passes skip build
-            // output) — that silently no-ops this pass on the very directory it targets.
-            // Point at devNull to opt this one deliberate pass out of those ignores.
-            '--ignore-path',
-            devNull,
-            `${outDir}**/*.html`,
-            `!${outDir}preview/**`,
-            `!${outDir}dist/**`,
-          ],
-          { stdio: 'inherit' },
+        execSync(
+          `npx prettier --write --parser html --ignore-path "${devNull}" "${outDir}**/*.html" "!${outDir}preview/**" "!${outDir}dist/**"`,
+          { stdio: 'inherit' }
         )
         logger.info('HTML formatted with prettier')
       },

--- a/preview/package.json
+++ b/preview/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "assets": "shx rm -rf tmp-assets && pnpm run css && pnpm run js",
     "css": "tsx ../.build/build-css.ts scss tmp-assets/css --minify",
-    "js": "vite build --config .build/vite.config.mts && terser tmp-assets/js/demo.js --module --compress --mangle --comments '/@license|@preserve|^!/' --source-map \"content=tmp-assets/js/demo.js.map,filename=tmp-assets/js/demo.min.js.map,url=demo.min.js.map\" -o tmp-assets/js/demo.min.js",
+    "js": "vite build --config .build/vite.config.mts && terser tmp-assets/js/demo.js --module --compress --mangle --comments --source-map \"content=tmp-assets/js/demo.js.map,filename=tmp-assets/js/demo.min.js.map,url=demo.min.js.map\" -o tmp-assets/js/demo.min.js",
     "watch-css": "nodemon --watch scss/ --ext scss --exec \"tsx ../.build/build-css.ts scss public/preview/css\"",
     "watch-js": "cross-env PREVIEW_JS_OUT_DIR=public/preview/js vite build --watch --config .build/vite.config.mts",
     "watch": "concurrently \"pnpm run watch-css\" \"pnpm run watch-js\"",

--- a/preview/package.json
+++ b/preview/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "assets": "shx rm -rf tmp-assets && pnpm run css && pnpm run js",
     "css": "tsx ../.build/build-css.ts scss tmp-assets/css --minify",
-    "js": "vite build --config .build/vite.config.mts && terser tmp-assets/js/demo.js --module --compress --mangle --comments --source-map \"content=tmp-assets/js/demo.js.map,filename=tmp-assets/js/demo.min.js.map,url=demo.min.js.map\" -o tmp-assets/js/demo.min.js",
+    "js": "vite build --config .build/vite.config.mts && terser tmp-assets/js/demo.js --module --compress --mangle --source-map \"content=tmp-assets/js/demo.js.map,filename=tmp-assets/js/demo.min.js.map,url=demo.min.js.map\" -o tmp-assets/js/demo.min.js",
     "watch-css": "nodemon --watch scss/ --ext scss --exec \"tsx ../.build/build-css.ts scss public/preview/css\"",
     "watch-js": "cross-env PREVIEW_JS_OUT_DIR=public/preview/js vite build --watch --config .build/vite.config.mts",
     "watch": "concurrently \"pnpm run watch-css\" \"pnpm run watch-js\"",


### PR DESCRIPTION
### What does this PR do?
This PR fixes two critical issues that break the build process on Windows environments using `cmd.exe`:

1. **Terser Pipe Syntax Error (`@tabler/core`, `@tabler/preview`)**: 
   The `--comments` flag in `package.json` used `'/@license|@preserve|^!/'`. In Windows `cmd.exe`, the pipe character (`|`) is parsed as a shell pipe, causing the build to fail with `'preserve' is not recognized as an internal or external command`. Since `terser`'s default behavior already preserves `@license`, `@preserve`, and `!` comments, passing the regex explicitly was unnecessary. I simplified this by removing the explicit regex, which safely relies on Terser's defaults.
2. **`npx` EINVAL Error on Node 20.12+ (`@tabler/preview`)**: 
   The `prettify-html` Astro hook previously spawned `npx` via `execFileSync`. With the recent `BatBadBut` security mitigation introduced in Node v20.12+, spawning `.cmd` binaries without `shell: true` immediately throws an `EINVAL` error on Windows. I refactored the execution to use `execSync` with a single command string, which gracefully bypasses the deprecation warnings and safely leverages `cmd.exe` execution across all platforms.

### Test Plan
Ran `npm run build` locally on Windows. Both `@tabler/core` and `@tabler/preview` now compile successfully without throwing `ENOENT` or `EINVAL` errors.
