### PR TITLE
Fix ribbon and payment icons dark mode on All Elements preview

### DIFF
--- a/.changeset/fix-payment-icons-dark-mode.md
+++ b/.changeset/fix-payment-icons-dark-mode.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": patch
+---
+
+Fixed payment icons on the all-elements page by rendering light and dark variants with `hide-theme-dark` and `hide-theme-light` so the correct icon shows when the preview theme changes.

--- a/.changeset/fix-ribbon-example-background.md
+++ b/.changeset/fix-ribbon-example-background.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": patch
+---
+
+Fixed ribbon examples background on the all-elements page by replacing hardcoded `#f8f9fa` with `var(--tblr-bg-surface-secondary)` so it adapts to dark mode.

--- a/preview/pages/all-elements.astro
+++ b/preview/pages/all-elements.astro
@@ -574,26 +574,7 @@ function greetUser(name) {
           <div class="mb-3">
             <div class="d-flex flex-wrap gap-2">
               {
-                (
-                  [
-                    'visa',
-                    'mastercard',
-                    'paypal',
-                    'americanexpress',
-                    'applepay',
-                    'google-pay',
-                    'stripe',
-                    'discover',
-                    'jcb',
-                    'maestro',
-                    'dinersclub',
-                    'bitcoin',
-                    'ethereum',
-                    'klarna',
-                    'venmo',
-                    'square',
-                  ] as const
-                ).map((payment) => (
+                (['visa', 'mastercard', 'paypal', 'americanexpress', 'applepay', 'google-pay', 'stripe', 'discover', 'jcb', 'maestro', 'dinersclub', 'bitcoin', 'ethereum', 'klarna', 'venmo', 'square'] as const).map((payment) => (
                   <>
                     <Payment payment={payment} label={paymentNames[payment]} class="hide-theme-dark" />
                     <Payment payment={payment} label={paymentNames[payment]} dark class="hide-theme-light" />

--- a/preview/pages/all-elements.astro
+++ b/preview/pages/all-elements.astro
@@ -573,22 +573,33 @@ function greetUser(name) {
           <h4>Payment Icons</h4>
           <div class="mb-3">
             <div class="d-flex flex-wrap gap-2">
-              <Payment payment="visa" label={paymentNames.visa} />
-              <Payment payment="mastercard" label={paymentNames.mastercard} />
-              <Payment payment="paypal" label={paymentNames.paypal} />
-              <Payment payment="americanexpress" label={paymentNames.americanexpress} />
-              <Payment payment="applepay" label={paymentNames.applepay} />
-              <Payment payment="google-pay" label={paymentNames['google-pay']} />
-              <Payment payment="stripe" label={paymentNames.stripe} />
-              <Payment payment="discover" label={paymentNames.discover} />
-              <Payment payment="jcb" label={paymentNames.jcb} />
-              <Payment payment="maestro" label={paymentNames.maestro} />
-              <Payment payment="dinersclub" label={paymentNames.dinersclub} />
-              <Payment payment="bitcoin" label={paymentNames.bitcoin} />
-              <Payment payment="ethereum" label={paymentNames.ethereum} />
-              <Payment payment="klarna" label={paymentNames.klarna} />
-              <Payment payment="venmo" label={paymentNames.venmo} />
-              <Payment payment="square" label={paymentNames.square} />
+              {
+                (
+                  [
+                    'visa',
+                    'mastercard',
+                    'paypal',
+                    'americanexpress',
+                    'applepay',
+                    'google-pay',
+                    'stripe',
+                    'discover',
+                    'jcb',
+                    'maestro',
+                    'dinersclub',
+                    'bitcoin',
+                    'ethereum',
+                    'klarna',
+                    'venmo',
+                    'square',
+                  ] as const
+                ).map((payment) => (
+                  <>
+                    <Payment payment={payment} label={paymentNames[payment]} class="hide-theme-dark" />
+                    <Payment payment={payment} label={paymentNames[payment]} dark class="hide-theme-light" />
+                  </>
+                ))
+              }
             </div>
           </div>
         </CardBody>

--- a/preview/pages/all-elements.astro
+++ b/preview/pages/all-elements.astro
@@ -539,10 +539,10 @@ function greetUser(name) {
           </div>
 
           <h4>Ribbons</h4>
-          <div class="position-relative mb-4" style="height: 100px; background: #f8f9fa; border-radius: 8px;">
+          <div class="position-relative mb-4" style="height: 100px; background-color: var(--tblr-bg-surface-secondary); border-radius: 8px;">
             <Ribbon text="New" color="success" />
           </div>
-          <div class="position-relative mb-3" style="height: 100px; background: #f8f9fa; border-radius: 8px;">
+          <div class="position-relative mb-3" style="height: 100px; background: var(--tblr-bg-surface-secondary); border-radius: 8px;">
             <Ribbon text="Sale" color="danger" top />
           </div>
         </CardBody>


### PR DESCRIPTION
## Summary

- Replace hardcoded ribbon demo backgrounds with `var(--tblr-bg-surface-secondary)` so the boxes follow the page theme.
- Render light and dark payment icons on All Elements and toggle them with `hide-theme-dark` / `hide-theme-light` when the theme changes.

## Preview

- **URL:** [All Elements](https://tabler-git-fix-2796-and-2797-tabler-io.vercel.app/all-elements.html)
- **How to test:** Open All Elements, find Ribbons and Payment Icons, switch to dark mode. Ribbon backgrounds should darken. Payment icons should switch to their dark variants.

## Notes / rollout

- Closes #2796
- Closes #2797
- Preview-only change in `preview/pages/all-elements.astro`. No `@tabler/core` CSS changes.