### PR TITLE
Fix stray line and indentation on the `.steps` component

### DIFF
--- a/.changeset/fix-steps-typography-collision.md
+++ b/.changeset/fix-steps-typography-collision.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed a stray vertical line and extra indentation on the `.steps` component, caused by the unrelated typographic `.steps` rule in `ui/_type.scss` leaking its guideline, padding and margins onto it. The typographic rule now skips any element with `.step-item` children, so the two no longer collide. It also no longer inherits the component's flex layout, and so works without `.steps-vertical` alongside it.

--- a/core/scss/ui/_type.scss
+++ b/core/scss/ui/_type.scss
@@ -282,15 +282,27 @@ $text-variants: (
   }
 }
 
-.steps {
+// Numbered walkthrough for long-form content: every `h3` inside becomes a
+// numbered step on a vertical guideline.
+//
+// This shares the `.steps` name with the progress-tracker component in
+// `ui/_steps.scss`, and this file is loaded after it — so the selector excludes
+// anything holding `.step-item` children, which is what makes an element that
+// component. Everything else keeps matching, exactly as before. The component's
+// unqualified `.steps` rule still applies here though, so the layout it sets up
+// (flex row, full width, scrollable below `sm`) has to be undone.
+.steps:not(:has(> .step-item)) {
   --steps-padding: #{$steps-padding};
   --steps-item-size: #{$steps-item-size};
   --steps-margin-start: #{$steps-margin-start};
   --steps-margin-bottom: #{$steps-margin-bottom};
   --steps-heading-margin-top: #{$steps-heading-margin-top};
+  display: block;
+  width: auto;
   padding-inline-start: var(--steps-padding);
   margin-inline-start: var(--steps-margin-start);
   margin-bottom: var(--steps-margin-bottom);
+  overflow: visible;
   counter-reset: step;
   border-inline-start: 1px solid var(--border-color);
 


### PR DESCRIPTION
## Summary

- `.steps` components showed a stray vertical line on their left and sat about 3rem too far to the right. This affected every variant, horizontal and vertical.
- The cause is two unrelated rules named `.steps` in core: the progress-tracker component in `ui/_steps.scss`, and a numbered walkthrough style for long-form content in `ui/_type.scss`. The second one is forwarded later (`_core.scss:94` vs `:85`), so at equal specificity it won and leaked its guideline, padding and margins onto the component.
- The walkthrough rule is now `.steps:not(:has(> .step-item))`. Those children are what make an element the component, so the two rules can no longer match the same element. The walkthrough still matches every markup it matched before.
- No class name and no SCSS variable was renamed. No markup changed. One file, 13 lines.

## Preview

- **URL:** [steps preview page](https://tabler-git-fix-2391-tabler-io.vercel.app/steps.html)
- **How to test:**
  - Open `/steps.html`. In both the "Steps horizontal" and "Steps vertical" cards, the steps should have no vertical line to their left, and their left edge should line up with the card title above them.
  - Open [`/ui/components/step/`](https://tabler-docs-git-fix-2391-tabler-io.vercel.app/ui/components/step/). All examples here sit inside the docs prose wrapper, which is the case that a simple `.prose` scope would not have fixed. They should be clean too.
  - Open [`/ui/getting-started/installation/`](https://tabler-docs-git-fix-2391-tabler-io.vercel.app/ui/getting-started/installation/). The numbered guide under "Setup" must look unchanged: vertical line on the left, numbered circle on each step.

## Notes / rollout

- Closes #2391
- No breaking change. Nothing was renamed, so any existing use of the typographic `.steps` markup keeps working, including `h2`/`h4` headings and headings nested deeper than a direct child.
- The rule uses `:has()`, which core already relies on in `ui/_tables.scss`, `ui/_type.scss` and `ui/_cards.scss`. No new browser requirement.
- Three declarations were added to the same rule (`display: block`, `width: auto`, `overflow: visible`). The component's plain `.steps` rule still matches the walkthrough, so its flex row, full width and below-`sm` scrolling have to be undone. This also fixes a smaller bug where the walkthrough stuck out 1rem past its parent, and it makes `.steps-vertical` in `docs/components/Steps.astro` redundant.
- Ships as a `patch` changeset for `@tabler/core`.