### PR TITLE
Fix broken dropdowns, datepicker, and buttons with no event handlers in preview pages

### DIFF
--- a/preview/pages/playground-categories.astro
+++ b/preview/pages/playground-categories.astro
@@ -104,9 +104,9 @@ import CardBody from '@ui/CardBody.astro'
                   <div class="col-auto">
                     <ButtonGroup aria-label="Sort direction">
                       <input type="radio" class="btn-check" name="playgroundSortDir" id="playgroundSortAsc" autocomplete="off" checked />
-                      <label class="btn btn-light px-0 btn-icon" aria-label="Ascending"><Icon name="arrow-up" /></label>
+                      <label class="btn btn-light px-0 btn-icon" for="playgroundSortAsc" aria-label="Ascending"><Icon name="arrow-up" /></label>
                       <input type="radio" class="btn-check" name="playgroundSortDir" id="playgroundSortDesc" autocomplete="off" />
-                      <label class="btn btn-light px-0 btn-icon" aria-label="Descending"><Icon name="arrow-down" /></label>
+                      <label class="btn btn-light px-0 btn-icon" for="playgroundSortDesc" aria-label="Descending"><Icon name="arrow-down" /></label>
                     </ButtonGroup>
                   </div>
                 </div>

--- a/preview/pages/playground-categories.astro
+++ b/preview/pages/playground-categories.astro
@@ -39,7 +39,7 @@ import CardBody from '@ui/CardBody.astro'
         </div>
         <div class="col-auto">
           <div class="dropdown">
-            <Button element="button" type="button" icon="filter" iconOnly text="Open filters" />
+            <Button element="button" type="button" icon="filter" iconOnly text="Open filters" dropdown />
             <div class="dropdown-menu rounded-3 p-6">
               <h4 class="fs-lg mb-4">Filter</h4>
               <form id="playgroundCategoriesFilterForm" style="width: 350px">
@@ -88,7 +88,7 @@ import CardBody from '@ui/CardBody.astro'
         </div>
         <div class="col-auto ms-n2">
           <div class="dropdown">
-            <Button element="button" type="button" icon="sort-ascending-letters" iconOnly text="Open sort options" />
+            <Button element="button" type="button" icon="sort-ascending-letters" iconOnly text="Open sort options" dropdown />
             <div class="dropdown-menu rounded-3 p-6">
               <h4 class="fs-lg mb-4">Sort</h4>
               <form id="playgroundCategoriesSortForm" style="width: 350px">

--- a/preview/pages/playground.astro
+++ b/preview/pages/playground.astro
@@ -11,7 +11,7 @@ import FormGroup from '@ui/FormGroup.astro'
 import Trending from '@ui/Trending.astro'
 ---
 
-<DefaultLayout title="Playground" pageHeader="Project Settings" pageLibs={['vanilla-calendar-pro']}>
+<DefaultLayout title="Playground" pageHeader="Project Settings" pageLibs={['litepicker']}>
   <div class="row row-cards row-deck">
     <div class="col-12">
       <Card>

--- a/preview/pages/progress.astro
+++ b/preview/pages/progress.astro
@@ -158,6 +158,8 @@ import ProgressDescription from '@ui/ProgressDescription.astro'
               }, 2000)
 
               document.getElementById('progress-animated-0').addEventListener('click', () => setWidth(0))
+              document.getElementById('progress-animated-10').addEventListener('click', () => setWidth(10))
+              document.getElementById('progress-animated-50').addEventListener('click', () => setWidth(50))
               document.getElementById('progress-animated-add-10').addEventListener('click', () => setWidth(width + 10))
               document.getElementById('progress-animated-minus-10').addEventListener('click', () => setWidth(width - 10))
               document.getElementById('progress-animated-100').addEventListener('click', () => setWidth(100))

--- a/preview/pages/stars-rating.astro
+++ b/preview/pages/stars-rating.astro
@@ -13,7 +13,7 @@ import CardBody from '@ui/CardBody.astro'
           <Card>
             <CardBody>
               <h3 class="card-title">Basic</h3>
-              <div><Rating value={4} /></div>
+              <div><Rating id="basic" value={4} /></div>
             </CardBody>
           </Card>
         </div>
@@ -22,7 +22,7 @@ import CardBody from '@ui/CardBody.astro'
             <CardBody>
               <h3 class="card-title">Different icon</h3>
               <div class="space-y">
-                <Rating value={4} />
+                <Rating id="different-icon" value={4} />
                 <Rating icon="heart" value={4} color="red" />
                 <Rating icon="ghost" value={4} color="azure" />
                 <Rating icon="circle" value={4} color="green" />

--- a/shared/components/navbar/NavbarSideNotifications.astro
+++ b/shared/components/navbar/NavbarSideNotifications.astro
@@ -4,11 +4,12 @@ import Button from '@ui/Button.astro'
 import ListGroup from '@ui/ListGroup.astro'
 import ListGroupItem from '@ui/ListGroupItem.astro'
 import CardTitle from '@ui/CardTitle.astro'
+import CaptureScript from '../CaptureScript.astro'
 ---
 
 <!-- BEGIN NOTIFICATIONS -->
 <div class="nav-item dropdown d-none d-md-flex">
-  <a href="#" class="nav-link px-0" data-bs-toggle="dropdown" aria-label="Show notifications" data-bs-auto-close="outside" aria-expanded="false">
+  <a href="#" id="navbar-notifications-toggle" class="nav-link px-0" data-bs-toggle="dropdown" aria-label="Show notifications" data-bs-auto-close="outside" aria-expanded="false">
     <Icon name="bell" />
     <span class="badge bg-red"></span>
   </a>
@@ -17,7 +18,7 @@ import CardTitle from '@ui/CardTitle.astro'
     <div class="card">
       <div class="card-header d-flex">
         <CardTitle>Notifications</CardTitle>
-        <div class="btn-close ms-auto" data-bs-dismiss="dropdown"></div>
+        <div class="btn-close ms-auto" data-navbar-notifications-close aria-label="Close"></div>
       </div>
       <ListGroup flush hoverable>
         <ListGroupItem>
@@ -95,4 +96,14 @@ import CardTitle from '@ui/CardTitle.astro'
   </div>
   <!-- END NAVBAR NOTIFICATIONS -->
 </div>
+<CaptureScript>
+  <!-- BEGIN NAVBAR NOTIFICATIONS CLOSE -->
+  <script is:inline>
+    document.querySelector('[data-navbar-notifications-close]').addEventListener('click', () => {
+      const toggle = document.getElementById('navbar-notifications-toggle')
+      window.tabler.bootstrap.Dropdown.getOrCreateInstance(toggle).hide()
+    })
+  </script>
+  <!-- END NAVBAR NOTIFICATIONS CLOSE -->
+</CaptureScript>
 <!-- END NOTIFICATIONS -->

--- a/shared/components/navbar/NavbarSideNotifications.astro
+++ b/shared/components/navbar/NavbarSideNotifications.astro
@@ -18,7 +18,7 @@ import CaptureScript from '../CaptureScript.astro'
     <div class="card">
       <div class="card-header d-flex">
         <CardTitle>Notifications</CardTitle>
-        <div class="btn-close ms-auto" data-navbar-notifications-close aria-label="Close"></div>
+        <button type="button" class="btn-close ms-auto" data-navbar-notifications-close aria-label="Close"></button>
       </div>
       <ListGroup flush hoverable>
         <ListGroupItem>

--- a/shared/ui/Button.astro
+++ b/shared/ui/Button.astro
@@ -75,7 +75,7 @@ const classes = [
   target={external ? '_blank' : undefined}
   rel={external ? 'noreferrer' : undefined}
   data-bs-toggle={dropdown ? 'dropdown' : modalId ? 'modal' : toastId ? 'toast' : undefined}
-  data-bs-target={modalId ? `#modal-${modalId}` : toastId ? `#toast-${toastId}` : undefined}
+  data-bs-target={!dropdown && modalId ? `#modal-${modalId}` : !dropdown && toastId ? `#toast-${toastId}` : undefined}
   aria-label={iconOnly ? text : undefined}
   data-bs-dismiss={dismiss ? 'modal' : undefined}
 >

--- a/shared/ui/Button.astro
+++ b/shared/ui/Button.astro
@@ -39,9 +39,11 @@ interface Props {
   toastId?: string
   /** data-bs-dismiss="modal" */
   dismiss?: boolean
+  /** data-bs-toggle="dropdown" */
+  dropdown?: boolean
 }
 
-const { text = 'Button', href, external, element, type, id, color, outline, ghost, height, size, block, disabled, square, loading, action, pill, link, class: className, icon, iconColor, iconEnd, iconOnly, dots, modalId, toastId, dismiss } = Astro.props
+const { text = 'Button', href, external, element, type, id, color, outline, ghost, height, size, block, disabled, square, loading, action, pill, link, class: className, icon, iconColor, iconEnd, iconOnly, dots, modalId, toastId, dismiss, dropdown } = Astro.props
 
 // Without a real destination the control is an action, so render <button>; internal hrefs are prefixed with '/'.
 const Element = element ?? (href ? 'a' : 'button')
@@ -72,7 +74,7 @@ const classes = [
   class:list={classes}
   target={external ? '_blank' : undefined}
   rel={external ? 'noreferrer' : undefined}
-  data-bs-toggle={modalId ? 'modal' : toastId ? 'toast' : undefined}
+  data-bs-toggle={dropdown ? 'dropdown' : modalId ? 'modal' : toastId ? 'toast' : undefined}
   data-bs-target={modalId ? `#modal-${modalId}` : toastId ? `#toast-${toastId}` : undefined}
   aria-label={iconOnly ? text : undefined}
   data-bs-dismiss={dismiss ? 'modal' : undefined}


### PR DESCRIPTION
## Summary

- Fix the filter and sort dropdown buttons on the Categories playground page. They used the `Button` component, which did not forward `data-bs-toggle="dropdown"`, so the menus never opened. Added a new `dropdown` prop to `Button.astro` to support this.
- Fix the datepicker on the Playground page. It loaded the wrong library (`vanilla-calendar-pro`) instead of `litepicker`, so none of the 14 datepickers worked.
- Fix the Asc/Desc sort labels on the Categories playground page. They had no `for` attribute, so clicking the label text did not select the radio button.
- Fix the "10%" and "50%" buttons on the Progress page ("Animated with JavaScript" demo). They had no click handler.
- Fix duplicate `id="rating-default"` on the Star Ratings page. Two `<Rating>` components fell back to the same default id, so the second star widget controlled the first one's element.
- Fix the close button on the navbar notifications dropdown. It used `data-bs-dismiss="dropdown"`, which Bootstrap does not support, so with `data-bs-auto-close="outside"` there was no way to close it. Added a small script that calls the Bootstrap Dropdown API to close it.

## Preview

- **URL:** [preview link](https://tabler-git-fix-elements-with-no-event-handlers-tabler-io.vercel.app/)
- **How to test:**
  - [`playground-categories.html`](https://tabler-git-fix-elements-with-no-event-handlers-tabler-io.vercel.app/playground-categories.html): click the filter and sort icon buttons near the search box — the dropdowns should open. In the sort dropdown, click the "Ascending"/"Descending" label text (not just the icon) — it should select the radio button.
  - [`playground.html`](https://tabler-git-fix-elements-with-no-event-handlers-tabler-io.vercel.app/playground.html): the datepicker fields and inline calendars should open and work.
  - [`progress.html`](https://tabler-git-fix-elements-with-no-event-handlers-tabler-io.vercel.app/progress.html): in the "Animated with JavaScript" card, click "10%" and "50%" — the progress bar should jump to that value.
  - [`stars-rating.html`](https://tabler-git-fix-elements-with-no-event-handlers-tabler-io.vercel.app/stars-rating.html): the "Basic" and "Different icon" star widgets should work independently (check the page source — no duplicate `id="rating-default"`).
  - Any preview page: open the notifications bell in the top navbar, then click the "X" close button — the dropdown should close.

## Notes / rollout

- Closes #2817