### PR TITLE
Fix chat sidebar links using duplicate `#chat-1` id

### DIFF
--- a/preview/pages/chat.astro
+++ b/preview/pages/chat.astro
@@ -38,7 +38,7 @@ const messages = chats as Message[]
               sidebarPeople.map((person, i) => {
                 const index = i + 1
                 return (
-                  <a href="#chat-1" class:list={['nav-link text-start mw-100 p-3', index === 1 && 'active']} id="chat-1-tab" data-bs-toggle="pill" role="tab" aria-selected="true">
+                  <a href={`#chat-${i}`} class:list={['nav-link text-start mw-100 p-3', index === 1 && 'active']} id={`chat-${i}-tab`} data-bs-toggle="pill" role="tab" aria-selected="true">
                     <div class="row align-items-center flex-fill">
                       <div class="col-auto">
                         <Avatar person={person} />

--- a/preview/pages/chat.astro
+++ b/preview/pages/chat.astro
@@ -38,7 +38,7 @@ const messages = chats as Message[]
               sidebarPeople.map((person, i) => {
                 const index = i + 1
                 return (
-                  <a href={`#chat-${i}`} class:list={['nav-link text-start mw-100 p-3', index === 1 && 'active']} id={`chat-${i}-tab`} data-bs-toggle="pill" role="tab" aria-selected="true">
+                  <a href={`#chat-${index}`} class:list={['nav-link text-start mw-100 p-3', index === 1 && 'active']} id={`chat-${index}-tab`} data-bs-toggle="pill" role="tab" aria-selected={index === 1 ? 'true' : 'false'}>
                     <div class="row align-items-center flex-fill">
                       <div class="col-auto">
                         <Avatar person={person} />


### PR DESCRIPTION
## Summary

- The chat contact list in `preview/pages/chat.astro` rendered the same `href="#chat-1"` and `id="chat-1-tab"` for all 10 contacts, instead of using the loop index.
- This meant every contact link pointed to a non-existent target, and the page shipped 10 duplicate `id`s (invalid HTML, broken link behavior).
- Both `href` and `id` now use the loop index (`#chat-${i}` / `chat-${i}-tab`), so each contact link is unique.

## Preview

- **URL:** [preview link](https://tabler-git-fix-2809-tabler-io.vercel.app/chat.html)
- **How to test:** Open the Chat preview page and inspect the contact list on the left. Confirm each contact link has a unique `id` (e.g. `chat-0-tab`, `chat-1-tab`, …) and a unique `href` in the rendered HTML.

## Notes / rollout

- Closes #2809