### PR TITLE
Fix radio input groups missing shared `name` across preview forms

### DIFF
--- a/preview/pages/job-listing.astro
+++ b/preview/pages/job-listing.astro
@@ -19,7 +19,7 @@ interface Job {
 const jobs = jobsData as Job[]
 
 const types = ['Programming', 'Design', 'Management / Finance', 'Customer Support', 'Sales / Marketing']
-const salaries = ['$20K - $50K', '$50K - $100K', '> $100K', 'Drawing / Painting']
+const salaries = ['$20K - $50K', '$50K - $100K', '> $100K']
 ---
 
 <DefaultLayout title="Search for Jobs" pageHeader="Search for Jobs" actions="add-job" pageMenu="extra.job-listing">
@@ -48,7 +48,7 @@ const salaries = ['$20K - $50K', '$50K - $100K', '> $100K', 'Drawing / Painting'
           {
             salaries.map((salary, i) => (
               <label class="form-check">
-                <input type="radio" class="form-check-input" name="form-salary" value={i + 1} checked={i + 1 <= 2} />
+                <input type="radio" class="form-check-input" name="form-salary" value={i + 1} checked={i === 0} />
                 <span class="form-check-label">{salary}</span>
               </label>
             ))

--- a/preview/pages/onboarding.astro
+++ b/preview/pages/onboarding.astro
@@ -72,19 +72,19 @@ import FormGroup from '@ui/FormGroup.astro'
           <fieldset class="border-0 p-0 m-0">
             <legend class="form-label float-none mb-0" style="font-size: inherit;">What are you planning to use this for?</legend>
             <div class="form-check">
-              <input class="form-check-input" type="radio" value="personal" id="use-personal" checked />
+              <input class="form-check-input" type="radio" name="use-for" value="personal" id="use-personal" checked />
               <label class="form-check-label" for="use-personal"> Personal projects </label>
             </div>
             <div class="form-check">
-              <input class="form-check-input" type="radio" value="business" id="use-business" />
+              <input class="form-check-input" type="radio" name="use-for" value="business" id="use-business" />
               <label class="form-check-label" for="use-business"> Business applications </label>
             </div>
             <div class="form-check">
-              <input class="form-check-input" type="radio" value="client" id="use-client" />
+              <input class="form-check-input" type="radio" name="use-for" value="client" id="use-client" />
               <label class="form-check-label" for="use-client"> Client work </label>
             </div>
             <div class="form-check">
-              <input class="form-check-input" type="radio" value="learning" id="use-learning" />
+              <input class="form-check-input" type="radio" name="use-for" value="learning" id="use-learning" />
               <label class="form-check-label" for="use-learning"> Learning and experimentation </label>
             </div>
           </fieldset>

--- a/shared/components/forms/FormElements3.astro
+++ b/shared/components/forms/FormElements3.astro
@@ -46,7 +46,7 @@ const blueHex = (site as { colors: { blue: { hex: string } } }).colors.blue.hex
           return (
             <div class="col-6 col-sm-4">
               <label class="form-imagecheck mb-2">
-                <input name="form-imagecheck-radio" type="radio" value={index} class="form-imagecheck-input" checked={index === 2 || index === 4 || index === 7} />
+                <input name="form-imagecheck-radio" type="radio" value={index} class="form-imagecheck-input" checked={index === 2} />
                 <span class="form-imagecheck-figure">
                   <img src={`./static/photos/${photo.file}`} alt={photo.title} class="form-imagecheck-image" />
                 </span>

--- a/shared/ui/DropdownMenu.astro
+++ b/shared/ui/DropdownMenu.astro
@@ -59,7 +59,7 @@ const countryItems = (countries as { name: string; flag: string }[]).slice(0, 5)
     ) : check || radio ? (
       [1, 2, 3].map((i) => (
         <label class="dropdown-item">
-          <input class="form-check-input m-0 me-2" type={radio ? 'radio' : 'checkbox'} /> Option {i}
+          <input class="form-check-input m-0 me-2" type={radio ? 'radio' : 'checkbox'} name={radio ? 'dropdown-menu-radio' : undefined} /> Option {i}
         </label>
       ))
     ) : showPeople ? (

--- a/shared/ui/DropdownMenuAll.astro
+++ b/shared/ui/DropdownMenuAll.astro
@@ -24,7 +24,7 @@ const peopleItems = (people as { id: number | string; full_name: string }[]).sli
       Public
     </label>
   </div>
-  <label class="dropdown-item"><input class="form-check-input m-0 me-2" type="radio" /> Radio input</label>
+  <label class="dropdown-item"><input class="form-check-input m-0 me-2" type="radio" name="dropdown-menu-all-radio" /> Radio input</label>
   <label class="dropdown-item"><input class="form-check-input m-0 me-2" type="checkbox" /> Checkbox input</label>
   <label class="dropdown-item form-switch"><input class="form-check-input m-0 me-2" type="checkbox" /> Checkbox input</label>
 


### PR DESCRIPTION
## Summary

- Add missing `name` attributes so radio buttons in the same group act as one choice, not independent checkboxes.
- Fix `checked` conditions that were copy-pasted from nearby checkbox loops, which marked more than one radio as selected (job listing salary filter, image-check radio demo).
- Remove a stray `'Drawing / Painting'` entry from the job listing salary options.

## Preview

- **URL:** [preview link](https://tabler-git-fix-2010-tabler-io.vercel.app/)
- **How to test:**
  - Open `/onboarding.html`, click through the "What are you planning to use this for?" radios. Only one should stay checked at a time.
  - Open `/job-listing.html`, check the "Salary Range" filter. Only one option is checked, and the bogus "Drawing / Painting" option is gone.
  - Open `/form-elements.html`, scroll to "Image Check Radio". Only one photo can be selected.
  - Open `/dropdowns.html`, open the dropdown menus with radio options. Only one option per group can be selected.

## Notes / rollout

- Closes #2810