### PR TITLE
Fix dead and miswired props in shared UI/card components

### DIFF
--- a/preview/pages/widgets.astro
+++ b/preview/pages/widgets.astro
@@ -99,12 +99,12 @@ import Configuration from '@shared/components/cards/Configuration.astro'
 
     <div class="col-md-6 col-lg-4">
       <div class="row row-cards">
-        <div class="col-12"><SmallStats chartType="line" chartData="20,0,40,30,40,30,80,60" /></div>
-        <div class="col-12"><SmallStats chartType="bar" chartData="20,40,30,10,40,60,80,70" color="red" icon="heart" /></div>
-        <div class="col-12"><SmallStats chartType="bar" chartData="20,40,20,-10,-30,10,40,60,80,70" color="green" icon="brand-github" /></div>
-        <div class="col-12"><SmallStats chartType="donut" chartData="12" personId={10} /></div>
-        <div class="col-12"><SmallStats chartType="donut" chartData="12" personId={11} /></div>
-        <div class="col-12"><SmallStats chartType="donut" chartData="56" personId={1} /></div>
+        <div class="col-12"><SmallStats id="widget-line" chartType="line" chartData="20,0,40,30,40,30,80,60" /></div>
+        <div class="col-12"><SmallStats id="widget-bar-red" chartType="bar" chartData="20,40,30,10,40,60,80,70" color="red" icon="heart" /></div>
+        <div class="col-12"><SmallStats id="widget-bar-green" chartType="bar" chartData="20,40,20,-10,-30,10,40,60,80,70" color="green" icon="brand-github" /></div>
+        <div class="col-12"><SmallStats id="widget-donut-10" chartType="donut" chartData="12" personId={10} /></div>
+        <div class="col-12"><SmallStats id="widget-donut-11" chartType="donut" chartData="12" personId={11} /></div>
+        <div class="col-12"><SmallStats id="widget-donut-1" chartType="donut" chartData="56" personId={1} /></div>
         <div class="col-12"><SmallStats color="green" personId={4} /></div>
         <div class="col-12"><SmallStats smallIcon="trending-down" color="red" personId={3} /></div>
         <div class="col-12"><Code /></div>

--- a/shared/components/cards/ProjectKanban.astro
+++ b/shared/components/cards/ProjectKanban.astro
@@ -1,5 +1,4 @@
 ---
-// NOTE: widgets page passes `value=` but only `percentage` (default 20) drives the bar — `value` is accepted but ignored.
 import Progress from '@ui/Progress.astro'
 import AvatarList from '@ui/AvatarList.astro'
 import Icon from '@ui/Icon.astro'
@@ -13,15 +12,14 @@ interface Props {
   percentage?: number | string
   percentageColor?: string
   due?: string
-  /** unused — see note above */
   value?: number | string
 }
 
-const { title = 'Task Title', badge, offset = 40, limit = 7, percentage = 20, percentageColor = 'green', due = '2 days' } = Astro.props
+const { title = 'Task Title', badge, offset = 40, limit = 7, percentage, percentageColor = 'green', due = '2 days', value = 20 } = Astro.props
 ---
 
 <div class="card">
-  <Progress value={percentage} class="card-progress" color={percentageColor} />
+  <Progress value={percentage ?? value} class="card-progress" color={percentageColor} />
   <div class="card-body">
     <CardTitle>
       <a href="#">{title}</a>

--- a/shared/components/cards/ProjectProgress.astro
+++ b/shared/components/cards/ProjectProgress.astro
@@ -1,5 +1,4 @@
 ---
-// NOTE: `days-ago` param accepted but unused ("Updated 2 hours ago" is hardcoded).
 import Progress from '@ui/Progress.astro'
 import CardDropdown from '@ui/CardDropdown.astro'
 import projects from '@data/projects.json'
@@ -16,7 +15,7 @@ interface Props {
   daysAgo?: number
 }
 
-const { projectId = 0, progress = 25 } = Astro.props
+const { projectId = 0, progress = 25, daysAgo = 2 } = Astro.props
 const project = (projects as Project[])[projectId]
 ---
 
@@ -30,7 +29,7 @@ const project = (projects as Project[])[projectId]
         <h3 class="card-title mb-1">
           <a href="#" class="text-reset">{project.title}</a>
         </h3>
-        <div class="text-secondary">Updated 2 hours ago</div>
+        <div class="text-secondary">Updated {daysAgo} days ago</div>
 
         <div class="mt-3">
           <div class="row g-2 align-items-center">

--- a/shared/components/cards/UserCardBg.astro
+++ b/shared/components/cards/UserCardBg.astro
@@ -1,7 +1,5 @@
 ---
 // person = people[person-id]; the cover photo is photos[person-id].file.
-// Base card-cover already carries `card-cover-blurred`; `blurred` adds it a 2nd time
-// Base card-cover already carries `card-cover-blurred`; `blurred` adds it a second time.
 import Avatar from '@ui/Avatar.astro'
 import people from '@data/people.json'
 import photos from '@data/photos.json'
@@ -29,7 +27,7 @@ const photo = (photos as Photo[])[personId]
 ---
 
 <a class="card card-link" href="#">
-  <div class={`card-cover card-cover-blurred text-center${blurred ? ' card-cover-blurred' : ''}`} style={`background-image: url(./static/photos/${photo.file})`}>
+  <div class={`card-cover text-center${blurred ? ' card-cover-blurred' : ''}`} style={`background-image: url(./static/photos/${photo.file})`}>
     <Avatar size="xl" person={person} thumb />
   </div>
   <div class="card-body text-center">

--- a/shared/ui/Pagination.astro
+++ b/shared/ui/Pagination.astro
@@ -36,7 +36,7 @@ if (offset < count) {
       firstLast && (
         <li class="page-item disabled">
           <a class={`page-link${text ? ' page-text' : ''}`} href="#" tabindex="-1" aria-disabled="true" aria-label={!text ? 'First page' : undefined}>
-            {!text ? <Icon name="chevrons-left" /> : 'Previous'}
+            {!text ? <Icon name="chevrons-left" /> : 'First'}
           </a>
         </li>
       )
@@ -82,7 +82,7 @@ if (offset < count) {
         </>
       )
     }
-    <li class={`page-item${prevDescription ? ' page-next' : ''}`}>
+    <li class={`page-item${nextDescription ? ' page-next' : ''}`}>
       <a class={`page-link${text ? ' page-text' : ''}`} href="#" aria-label={!nextDescription && !text ? 'Next page' : undefined}>
         {
           nextDescription ? (
@@ -102,7 +102,7 @@ if (offset < count) {
       firstLast && (
         <li class="page-item">
           <a class={`page-link${text ? ' page-text' : ''}`} href="#" aria-label={!text ? 'Last page' : undefined}>
-            {!text ? <Icon name="chevrons-right" /> : 'Next'}
+            {!text ? <Icon name="chevrons-right" /> : 'Last'}
           </a>
         </li>
       )

--- a/shared/ui/Select.astro
+++ b/shared/ui/Select.astro
@@ -140,7 +140,7 @@ const selectId = id ? `select-${id}` : undefined;
 						(window.tabler_select[selectId] = new TomSelect(document.getElementById(selectId), {
 							copyClassesToDropdown: false,
 							dropdownParent: 'body',
-							...(showSearch ? {} : { controlInput: '<input>' }),
+							...(showSearch === false ? { controlInput: null } : {}),
 							render: {
 								item: renderOption,
 								option: renderOption,

--- a/shared/ui/Tag.astro
+++ b/shared/ui/Tag.astro
@@ -49,7 +49,7 @@ const { text, flag, icon, person, personId, payment, status, legend, checkbox, c
     ) : null
   }
   {text}
-  {badge && <Badge class="tag-badge" text={String(badge)} />}
+  {badge != null && <Badge class="tag-badge" text={String(badge)} />}
 
   <button type="button" class="btn-close" aria-label={text ? `Remove ${text}` : 'Remove'}></button>
 </span>


### PR DESCRIPTION
## Summary

- Several shared UI components declared a prop that had no effect or checked the wrong condition, so the prop looked configurable but always rendered the same result.
- Fixes `blurred` on `UserCardBg`, `id` on `SmallStats` (charts were never rendering), `value` on `ProjectKanban`, `daysAgo` on `ProjectProgress`, the `page-next` class and `firstLast` + `text` labels on `Pagination`, `showSearch` on `Select`, and the `badge={0}` case on `Tag`.
- No new props or markup, just wiring existing props to the behavior they were meant to have.

## Preview

- **URL:** [preview link](https://tabler-git-fix-2811-tabler-io.vercel.app/widgets.html)
- **How to test:**
  - Open `/widgets.html`. In the "Task Kanban" cards, "Tabler UI" and "Tabler React" should show 30% and 80% progress (not both 20%). In "Project Progress", the "Updated X days ago" text should match each card's `daysAgo` value. In the sparkline row, all 6 small chart cards (line, bar, donut) should now show a visible chart instead of an empty space. The `UserCardBg` avatars should show two clear photos and two blurred photos.
  - Open `/pagination.html`. The pagination example with `nextDescription` set should have its "Next" control get the `page-next` class (inspect the DOM, or diff against `dev`).
  - `Select`'s `showSearch={false}` and `Tag`'s `badge={0}` are not currently used on any preview page, so they were verified by reading the rendered TomSelect config / DOM output directly rather than a visual page.

## Notes / rollout

- No feature flags, no breaking changes. Pure bug fixes to existing components.
- Closes #2811