### PR TITLE
Fix component props silently ignored or misapplied in shared/ui

### DIFF
--- a/preview/pages/all-elements.astro
+++ b/preview/pages/all-elements.astro
@@ -365,9 +365,9 @@ function greetUser(name) {
               <Avatar placeholder="AB" size="xl" />
             </div>
             <div>
-              <Avatar placeholder="RD" shape="avatar-rounded" />
-              <Avatar placeholder="PR" color="primary" shape="avatar-rounded" />
-              <Avatar placeholder="SC" color="success" shape="avatar-rounded" />
+              <Avatar placeholder="RD" shape="rounded" />
+              <Avatar placeholder="PR" color="primary" shape="rounded" />
+              <Avatar placeholder="SC" color="success" shape="rounded" />
             </div>
             <div>
               <Avatar icon="user" />

--- a/preview/pages/card-gradients.astro
+++ b/preview/pages/card-gradients.astro
@@ -65,7 +65,7 @@ import people from '@data/people.json'
     <div class="col-3">
       <div class="row row-cards">
         <div class="col-12">
-          <Weather city="Warsaw, PL" temperature={3} color="rain" icon="cloud-rain" description="Cloudy morning" />
+          <Weather city="Warsaw, PL" temperature={3} color="ocean" icon="cloud-rain" description="Cloudy morning" />
         </div>
         <div class="col-12">
           <Weather city="Oslo, NO" temperature="-5" color="snow" icon="cloud" description="Snowy day" />

--- a/preview/pages/logs.astro
+++ b/preview/pages/logs.astro
@@ -52,8 +52,8 @@ import { site } from '@shared/lib/site'
             <div class="mb-2">
               <Badge text="INFO" color="success" />
               <Badge text="WARNING" color="warning" />
-              <Badge text="ERROR" color="disabled" />
-              <Badge text="DEBUG" color="disabled" />
+              <Badge text="ERROR" color="danger" />
+              <Badge text="DEBUG" color="secondary" />
             </div>
           </div>
         </CardBody>

--- a/shared/components/cards/RecentActivity.astro
+++ b/shared/components/cards/RecentActivity.astro
@@ -22,7 +22,7 @@ const activity = crmDashboard.recent_activity
             <div class="row align-items-center">
               <div class="col-auto">
                 <span class={`avatar bg-${item.icon_color}-lt`}>
-                  <Icon name={item.icon} class={`icon text-${item.icon_color}`} />
+                  <Icon name={item.icon} color={item.icon_color} />
                 </span>
               </div>
               <div class="col">

--- a/shared/components/cards/RecentActivity.astro
+++ b/shared/components/cards/RecentActivity.astro
@@ -1,5 +1,4 @@
 ---
-// Icon class is a literal template string (color token is not interpolated).
 import CardActions from '@ui/CardActions.astro'
 import Icon from '@ui/Icon.astro'
 import CardTitle from '@ui/CardTitle.astro'
@@ -23,7 +22,7 @@ const activity = crmDashboard.recent_activity
             <div class="row align-items-center">
               <div class="col-auto">
                 <span class={`avatar bg-${item.icon_color}-lt`}>
-                  <Icon name={item.icon} class={'icon text-{{ item.icon_color }}'} />
+                  <Icon name={item.icon} class={`icon text-${item.icon_color}`} />
                 </span>
               </div>
               <div class="col">

--- a/shared/ui/Icon.astro
+++ b/shared/ui/Icon.astro
@@ -17,7 +17,7 @@ const icon = (icons as unknown as Record<string, { svg: Record<string, string> }
 const classes = ['icon', className, color && `text-${color}`, inline && 'icon-inline', size && `icon-${size}`].filter(Boolean).join(' ')
 
 let svg = icon?.svg?.[type] ?? ''
-svg = svg.replace('<path stroke="none" d="M0 0h24v24H0z" fill="none"/>', '')
+svg = svg.replace('<path stroke="none" d="M0 0h24v24H0z" fill="none" />', '')
 svg = svg.replace(/class="[^"]+"/, `aria-hidden="true" focusable="false" class="${classes}"`)
 ---
 

--- a/shared/ui/Icon.astro
+++ b/shared/ui/Icon.astro
@@ -17,7 +17,7 @@ const icon = (icons as unknown as Record<string, { svg: Record<string, string> }
 const classes = ['icon', className, color && `text-${color}`, inline && 'icon-inline', size && `icon-${size}`].filter(Boolean).join(' ')
 
 let svg = icon?.svg?.[type] ?? ''
-svg = svg.replace('<path stroke="none" d="M0 0h24v24H0z" fill="none" />', '')
+svg = svg.replace(/<path stroke="none" d="M0 0h24v24H0z" fill="none"\s*\/>/, '')
 svg = svg.replace(/class="[^"]+"/, `aria-hidden="true" focusable="false" class="${classes}"`)
 ---
 

--- a/shared/ui/MapVector.astro
+++ b/shared/ui/MapVector.astro
@@ -71,7 +71,7 @@ const mapOptions = data
 								stroke: '#fff',
 								opacity: 1,
 								strokeWidth: 3,
-								stokeOpacity: 0.5,
+								strokeOpacity: 0.5,
 								fill: `var(--tblr-${color})`,
 							},
 							hover: { fill: `var(--tblr-${color})`, stroke: `var(--tblr-${color})` },

--- a/shared/ui/Rating.astro
+++ b/shared/ui/Rating.astro
@@ -18,7 +18,7 @@ const starClasses = ['icon', 'gl-star-full', color && `text-${color}`, size && `
 
 const iconData = (icons as Record<string, { svg: Record<string, string | null> }>)[icon]
 let star = iconData?.svg?.filled ?? ''
-star = star.replace('<path stroke="none" d="M0 0h24v24H0z" fill="none" />', '')
+star = star.replace(/<path stroke="none" d="M0 0h24v24H0z" fill="none"\s*\/>/, '')
 star = star.replace(/class="[^"]+"/, `aria-hidden="true" focusable="false" class="${starClasses}"`)
 
 const ratingSelector = `#rating-${id}`

--- a/shared/ui/Rating.astro
+++ b/shared/ui/Rating.astro
@@ -18,7 +18,7 @@ const starClasses = ['icon', 'gl-star-full', color && `text-${color}`, size && `
 
 const iconData = (icons as Record<string, { svg: Record<string, string | null> }>)[icon]
 let star = iconData?.svg?.filled ?? ''
-star = star.replace('<path stroke="none" d="M0 0h24v24H0z" fill="none"/>', '')
+star = star.replace('<path stroke="none" d="M0 0h24v24H0z" fill="none" />', '')
 star = star.replace(/class="[^"]+"/, `aria-hidden="true" focusable="false" class="${starClasses}"`)
 
 const ratingSelector = `#rating-${id}`


### PR DESCRIPTION
## Summary

- Fix `RecentActivity` icon color: it used a literal, unconverted template string (`'icon text-{{ item.icon_color }}'`), so every activity icon rendered with no color at all.
- Fix `Weather` gradient (`color="rain"`) and `Avatar` shape (`shape="avatar-rounded"`) on demo pages: both built class names that don't exist in the compiled CSS (`card-gradient-rain`, `avatar-avatar-rounded`), so the styling was silently dropped.
- Fix `Badge` colors on the Logs page: `color="disabled"` isn't a real theme color, so ERROR/DEBUG badges had no background or text color. Now ERROR uses `danger` and DEBUG uses `secondary`.
- Fix a typo (`stokeOpacity` → `strokeOpacity`) in `MapVector` marker styling, which jsVectorMap was silently ignoring.
- Fix the placeholder-path removal in `Icon` and `Rating`: the search string was missing a space that's present in every icon in `icons.json`, so the invisible background path never got stripped and shipped in every rendered icon.

## Preview

- **URL:** [preview](https://tabler-git-fix-2812-tabler-io.vercel.app/)
- **How to test:**
  - Open [`/logs.html`](https://tabler-git-fix-2812-tabler-io.vercel.app/logs.html) — ERROR and DEBUG badges should now have visible red/gray backgrounds.
  - Open [`/all-elements.html`](https://tabler-git-fix-2812-tabler-io.vercel.app/all-elements.html), Avatars section — the three "rounded" avatars should have rounded corners.
  - Open [`/card-gradients.html`](https://tabler-git-fix-2812-tabler-io.vercel.app/card-gradients.html) — the Warsaw weather card should show a blue "ocean" gradient instead of a plain background.
  - Open a CRM dashboard page that uses `RecentActivity` — each activity icon should be colored (primary/purple/green/red/yellow) instead of plain gray.
  - Open any icon-heavy page (e.g. `/icons.html`) and inspect an icon's SVG — it should contain only the visible path, not the invisible `M0 0h24v24H0z` background path.

## Notes / rollout

- Closes #2812.