### PR TITLE
Fix instance-scoping bugs in AdvancedTable, Chart, Colorpicker, Dropzone, and TabsCard

### DIFF
--- a/shared/components/cards/TabsCard.astro
+++ b/shared/components/cards/TabsCard.astro
@@ -25,7 +25,7 @@ const paneClass = `tab-pane${animation ? ' fade' : ''}`
 
 <div class="card">
   <div class="card-header">
-    <ul class={navClass} role="tablist" data-bs-toggle="tab">
+    <ul class={navClass} role="tablist">
       <li class="nav-item" role="presentation">
         <a href={`#tabs-home-${id}`} id={`tabs-home-${id}-tab`} class="nav-link active" data-bs-toggle="tab" data-bs-target={`#tabs-home-${id}`} role="tab" aria-controls={`tabs-home-${id}`} aria-selected="true">{icons && <Icon name="home" class={iconClass} />}{!hideText && 'Home'}</a>
       </li>
@@ -47,7 +47,7 @@ const paneClass = `tab-pane${animation ? ' fade' : ''}`
       {
         disabled && (
           <li class="nav-item" role="presentation">
-            <a href={`#tabs-activity-${id}`} class="nav-link disabled" data-bs-toggle="tab" role="tab" aria-selected="false" aria-disabled="true" tabindex="-1">
+            <a href="#" class="nav-link disabled" data-bs-toggle="tab" role="tab" aria-selected="false" aria-disabled="true" tabindex="-1">
               {icons && <Icon name="x" class={iconClass} />}
               {!hideText && 'Disabled'}
             </a>

--- a/shared/ui/AdvancedTable.astro
+++ b/shared/ui/AdvancedTable.astro
@@ -135,9 +135,9 @@ const perPageDefault = perPage[1]
         </table>
       </div>
       <div class="card-footer d-flex align-items-center">
-        <div class="dropdown">
+        <div class="dropdown" data-table-id={tableId}>
           <button type="button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-            <span id="page-count" class="me-1">{perPage[1]}</span>
+            <span id={`${tableId}-page-count`} class="me-1">{perPage[1]}</span>
             <span>records</span>
           </button>
           <div class="dropdown-menu">
@@ -162,11 +162,16 @@ const perPageDefault = perPage[1]
   <script define:vars={{ tableId, advancedTable, perPageDefault }}>
     // Astro wraps define:vars scripts in an IIFE, so this needs an explicit window
     // assignment to stay reachable from the onclick="setPageListItems(event)" markup below.
+    // Each AdvancedTable instance redefines this identically, so it stays safe to share:
+    // the table id is resolved from the clicked element instead of being closed over.
     window.setPageListItems = function setPageListItems(e) {
-      window.tabler_list[tableId].page = parseInt(e.target.dataset.value)
-      window.tabler_list[tableId].update()
+      const id = e.target.closest('[data-table-id]')?.dataset.tableId
+      if (!id || !window.tabler_list?.[id]) return
 
-      document.querySelector('#page-count').innerHTML = e.target.dataset.value
+      window.tabler_list[id].page = parseInt(e.target.dataset.value)
+      window.tabler_list[id].update()
+
+      document.querySelector(`#${id}-page-count`).innerHTML = e.target.dataset.value
     }
 
     function initAdvancedTable() {

--- a/shared/ui/Chart.astro
+++ b/shared/ui/Chart.astro
@@ -18,6 +18,11 @@ const chartsData = charts as Record<string, ChartData>;
 let data = chartsData[chartId];
 
 let className = classProp;
+
+if (data?.extend) {
+	data = { ...chartsData[data.extend], ...chartsData[chartId] };
+}
+
 let height = heightProp ?? data?.height ?? 10;
 
 if (size === 'sm') {
@@ -28,15 +33,11 @@ if (size === 'sm') {
 	height = 15;
 }
 
-if (data?.extend) {
-	data = { ...chartsData[data.extend], ...chartsData[chartId] };
-}
-
 // The :root custom-property block stays a plain string rendered via set:html — it's
 // inert CSS text (no injection surface), not executable code.
 const style = data ? chartStyle({ id, data }) : '';
 const { config, xFormatterExpr } = data ? chartConfig({ id, data, height }) : { config: undefined, xFormatterExpr: undefined };
-const chartKey = `chart-${chartId}`;
+const chartKey = `chart-${id}`;
 const elementId = `chart-${id}`;
 ---
 

--- a/shared/ui/ChartSparkline.astro
+++ b/shared/ui/ChartSparkline.astro
@@ -80,7 +80,7 @@ const chartOptions = id
 				: {}),
 			...(type === 'area' ? { fill: { gradient: { opacityFrom: [0.1, 0.1] } } } : {}),
 			...(type === 'area' || type === 'line' ? { stroke: { width: 2, lineCap: 'round' } } : {}),
-			...(type === 'donut'
+			...(type === 'donut' || type === 'pie'
 				? { colors: [`var(--tblr-${color})`], series: seriesData }
 				: { series: [{ color: `var(--tblr-${color})`, data: seriesData }] }),
 		}

--- a/shared/ui/Colorpicker.astro
+++ b/shared/ui/Colorpicker.astro
@@ -31,15 +31,20 @@ const colorpickerSelector = `#colorpicker-${id}`
 
       const swatches = swatchProps.map((prop) => window.getComputedStyle(document.body).getPropertyValue(prop))
 
-      window.Coloris &&
-        (window.tabler_colorpicker[colorpickerId] = Coloris({
-          el: colorpickerSelector,
+      if (window.Coloris) {
+        // `el` can only be configured globally, but Coloris.setInstance() scopes the rest
+        // (alpha, format, swatches, ...) to this selector so multiple pickers with
+        // different options don't clobber each other's settings.
+        Coloris({ el: colorpickerSelector })
+        Coloris.setInstance(colorpickerSelector, {
           selectInput: false,
           alpha,
           ...(format ? { format } : {}),
           ...(swatchesOnly ? { swatchesOnly: true } : {}),
           swatches,
-        }))
+        })
+        window.tabler_colorpicker[colorpickerId] = colorpickerSelector
+      }
     }
 
     document.readyState !== 'loading' ? initColorpicker() : document.addEventListener('DOMContentLoaded', initColorpicker, { once: true })

--- a/shared/ui/Dropzone.astro
+++ b/shared/ui/Dropzone.astro
@@ -9,7 +9,7 @@ interface Props {
   label?: string
 }
 
-const { id, multiple, custom, text = 'Text', description = 'Description', label = 'Upload file' } = Astro.props
+const { id = 'default', multiple, custom, text = 'Text', description = 'Description', label = 'Upload file' } = Astro.props
 
 const dropzoneId = `dropzone-${id}`
 const dropzoneSelector = `#dropzone-${id}`


### PR DESCRIPTION
## Summary

- Fix six bugs where `shared/ui` and `shared/components/cards` components used hardcoded ids or shared global state instead of scoping by their own `id` prop, so they broke when two instances appeared on one page.
- `AdvancedTable`: the "records" count and its click handler now use the table's own `id` instead of a single global `page-count` id and function.
- `Chart`: `height` now reads from the merged (`extend`-applied) chart data, and the chart registry key uses the instance `id` instead of the shared `chartId`.
- `ChartSparkline`: `type="pie"` now gets the correct series shape, so pie sparklines render instead of being rejected by ApexCharts.
- `Colorpicker`: uses Coloris's per-instance API so multiple pickers on one page keep their own alpha/format/swatches settings instead of the last one winning for all.
- `Dropzone`: a missing `id` prop no longer renders the literal `id="dropzone-undefined"`.
- `TabsCard`: removed a stray `data-bs-toggle="tab"` on the tab list container, and fixed the "Disabled" tab's href, which was copy-pasted from the "Activity" tab.

## Preview

- **URL:** [preview link](https://tabler-git-fix-2813-tabler-io.vercel.app/)
- **How to test:**
  - `/tables.html` — open the "records" dropdown on the Employee table, pick a value, confirm the count and pagination update.
  - `/charts.html` — check charts render without console errors, including the pie chart and any `extend`-based charts.
  - `/colorpicker.html` — open a few different color pickers, confirm each keeps its own settings.
  - `/dropzone.html` — confirm dropzones render with proper ids (inspect the DOM, no `dropzone-undefined`).
  - `/tabs.html` — click around the "Disabled" tab; it should not navigate to the Activity pane.

## Notes / rollout

- Closes #2813