### PR TITLE
Fix docs UI bugs: tabs, redirect, docs-libs, colors grid, navbar link

### DIFF
--- a/docs/components/Colors.astro
+++ b/docs/components/Colors.astro
@@ -10,7 +10,7 @@ const { colors }: Props = Astro.props
   {
     Object.values(colors).map((color) => {
       return (
-        <div class="col-2 text-center">
+        <div class="text-center">
           <div class="p-6 rounded border" style={{ backgroundColor: `var(${color.prop})` }} />
           <div class="small">{color.title}</div>
         </div>

--- a/docs/components/DocsNavbar.astro
+++ b/docs/components/DocsNavbar.astro
@@ -14,8 +14,7 @@ const changelogUrl = 'https://tabler.io/changelog'
     <div class="row flex-fill align-items-md-center">
       <div class="col">
         <div class="d-flex align-items-center gap-4">
-          {/* href="." — relative link for docs root */}
-          <a href="." class="navbar-brand navbar-brand-autodark gap-4">
+          <a href="/" class="navbar-brand navbar-brand-autodark gap-4">
             <DocsLogo />
           </a>
           <div>

--- a/docs/components/TabsPackage.astro
+++ b/docs/components/TabsPackage.astro
@@ -14,7 +14,7 @@ const { name }: Props = Astro.props
     packageManagers.map((manager, i) => {
       return (
         <li class="nav-item" role="presentation">
-          <button class={`nav-link${i === 0 ? ' active' : ''}`} id={`${manager.name}-tab`} data-bs-toggle="tab" data-bs-target={`#${manager.name}`} type="button" role="tab" aria-controls="home" aria-selected={i === 0 ? 'true' : 'false'}>
+          <button class={`nav-link${i === 0 ? ' active' : ''}`} id={`${manager.name}-tab`} data-bs-toggle="tab" data-bs-target={`#${manager.name}`} type="button" role="tab" aria-controls={manager.name} aria-selected={i === 0 ? 'true' : 'false'}>
             <span set:html={manager.icon.replace('<svg ', '<svg class="me-2" ')} />
             {manager.name}
           </button>

--- a/docs/layouts/DocsMdxLayout.astro
+++ b/docs/layouts/DocsMdxLayout.astro
@@ -17,7 +17,7 @@ interface MdxFrontmatter {
   'description'?: string
   'seoDescription'?: string
   'added-in'?: string
-  'docs-libs'?: string[]
+  'docs-libs'?: string | string[]
   'hide-pagination'?: boolean
 }
 
@@ -37,7 +37,8 @@ const {
 // "docs/pages/ui/components/alert.mdx" (`file` is the absolute path of the MDX page).
 const editPath = file?.includes('/docs/pages/') ? file.replace(/^.*\/docs\/pages\//, 'docs/pages/') : undefined
 
-const docsLibs = frontmatter['docs-libs'] ?? []
+const rawDocsLibs = frontmatter['docs-libs']
+const docsLibs = rawDocsLibs == null ? [] : Array.isArray(rawDocsLibs) ? rawDocsLibs : [rawDocsLibs]
 
 const toc = headings
   .filter((heading) => heading.depth === 2 || heading.depth === 3)

--- a/docs/pages/ui/base/markdown/index.astro
+++ b/docs/pages/ui/base/markdown/index.astro
@@ -2,4 +2,4 @@
 import RedirectLayout from '@shared/layouts/RedirectLayout.astro'
 ---
 
-<RedirectLayout base="../../.." />
+<RedirectLayout base="../../.." url="/ui/base/prose/" />


### PR DESCRIPTION
## Summary

- Fix package-manager tabs on docs pages: every tab button pointed `aria-controls` at a non-existent `"home"` id instead of its own panel, so screen readers linked the wrong content.
- Fix the `/ui/base/markdown/` page so it redirects to `/ui/base/prose/` instead of landing on the docs homepage.
- Fix `docs-libs` page frontmatter handling: most pages write it as a plain string (e.g. `docs-libs: imask`), but the code treated it as an array. This made `.includes()` silently do a substring check instead of an exact match. Now the value is normalized to an array first.
- Fix the mobile color grid on `/ui/base/colors/`: a hardcoded `col-2` class was overriding the intended responsive 4-per-row (mobile) / 6-per-row (desktop) layout.
- Fix the docs navbar logo link: it used `href="."`, which just reloads the current page, instead of linking back to the docs root (`/`).

## Preview

- **URL:** [tabler-git-fix-2814-tabler-io.vercel.app](https://tabler-git-fix-2814-tabler-io.vercel.app/)
- **How to test:**
  - Go to `/ui/getting-started/download/`, click through the NPM/Yarn/PNPM/Bun tabs, and check each tab panel switches correctly (inspect `aria-controls` matches the panel id).
  - Go to `/ui/base/markdown/` and confirm it redirects to `/ui/base/prose/`, not the homepage.
  - Go to `/ui/base/colors/` and resize to mobile width — colors should show 4 per row (6 per row on desktop).
  - Go to `/ui/forms/form-input-mask/` and confirm the input mask still works (checks the `docs-libs` string-to-array fix didn't break lib loading).
  - Click the Tabler logo in the docs navbar and confirm it goes to the docs root instead of reloading the current page.

Closes #2814