### PR TITLE
Fix broken links, aria attributes, and demo data mismatches

### DIFF
--- a/docs/components/DocsToc.astro
+++ b/docs/components/DocsToc.astro
@@ -16,8 +16,8 @@ interface Props {
 
 const { toc = [] } = Astro.props
 
-// shared/data/illustrations.json has 100 entries.
-const illustrationsCount = 100
+// shared/data/illustrations.json has 125 entries.
+const illustrationsCount = 125
 ---
 
 <!-- BEGIN DOCS TOC -->{

--- a/preview/pages/dashboard-crypto.astro
+++ b/preview/pages/dashboard-crypto.astro
@@ -33,6 +33,7 @@ const btcBalance = 2.3
 const btcPriceNum = parseCurrency(btc.price)
 const totalUsd = Math.round(btcPriceNum * btcBalance).toLocaleString('en-US')
 // divided_by then round to 8 decimals (trailing zeros dropped in output)
+const usdBtc = roundTo(1 / btcPriceNum)
 const ltcBtc = roundTo(parseCurrency(ltc.price) / btcPriceNum)
 const ethBtc = roundTo(parseCurrency(eth.price) / btcPriceNum)
 const xmrBtc = roundTo(parseCurrency(xmr.price) / btcPriceNum)
@@ -81,7 +82,7 @@ const operationCurrencies = currencies.slice(0, 20)
                 </div>
               </div>
               <div class="mb-1">
-                <span class="h3">{btc.price}</span>
+                <span class="h3">{usdBtc}</span>
                 <span class="text-muted">{btc.price}</span>
               </div>
               <div class="mb-0">

--- a/preview/pages/emails.astro
+++ b/preview/pages/emails.astro
@@ -60,7 +60,7 @@ const emailEntries = Object.entries(emails)
             <div class="col-6">
               <div class="p-7">
                 <Prose>
-                  <h3 data-email-title></h3>
+                  <h3 id="email-modal-label" data-email-title></h3>
                   <p data-email-description></p>
                 </Prose>
 

--- a/preview/pages/form-elements.astro
+++ b/preview/pages/form-elements.astro
@@ -184,7 +184,7 @@ const rows = [
                 <div class="col-md-5"><FormGroup label="Country"><select class="form-control form-select"><option value="">Germany</option></select></FormGroup></div>
                 <div class="col-md-12">
                   <FormGroup label="About Me" class="mb-3 mb-0">
-                    <textarea rows="5" class="form-control" placeholder="Here can be your description" value="Mike">Oh so, your weak rhyme You doubt I'll bother, reading into it I'll probably won't, left to my own devices But that's the difference in our opinions.</textarea>
+                    <textarea rows="5" class="form-control" placeholder="Here can be your description">Oh so, your weak rhyme You doubt I'll bother, reading into it I'll probably won't, left to my own devices But that's the difference in our opinions.</textarea>
                   </FormGroup>
                 </div>
               </div>

--- a/preview/pages/form-layout.astro
+++ b/preview/pages/form-layout.astro
@@ -84,7 +84,7 @@ const countries = flags as { name: string }[]
             <CardBody>
               <form class="space-y">
                 <div><InputIcon icon="user" placeholder="Username" prepend /></div>
-                <div><InputIcon icon="mail" placeholder="Email address" prepend type="mail" /></div>
+                <div><InputIcon icon="mail" placeholder="Email address" prepend type="email" /></div>
                 <div><InputIcon icon="lock" placeholder="Password" prepend type="password" /></div>
                 <div><InputIcon icon="lock" placeholder="Confirm Password" prepend type="password" /></div>
                 <div>

--- a/preview/pages/modals.astro
+++ b/preview/pages/modals.astro
@@ -48,6 +48,7 @@ const cardClass = 'position-relative rounded d-block bg-surface-backdrop py-6 w-
             <a href="#modal-edit-profile" class="nav-link">Edit profile modal</a>
             <a href="#modal-confirm-delete" class="nav-link">Confirm delete modal</a>
             <a href="#modal-change-password" class="nav-link">Change password modal</a>
+            <a href="#modal-add-task" class="nav-link">Add task modal</a>
           </div>
         </div>
         <div class="col">

--- a/preview/pages/sortable.astro
+++ b/preview/pages/sortable.astro
@@ -11,7 +11,7 @@ import ListGroupItem from '@ui/ListGroupItem.astro'
   <div class="row row-cards">
     <div class="col-md-6">
       <Card>
-        <CardHeader title="Podstawowe użycie" />
+        <CardHeader title="Basic usage" />
         <CardBody>
           <ListGroup as="ul" data-sortable='{"animation":150}'>
             <ListGroupItem as="li">Element A</ListGroupItem>
@@ -24,7 +24,7 @@ import ListGroupItem from '@ui/ListGroupItem.astro'
     </div>
     <div class="col-md-6">
       <Card>
-        <CardHeader title="Dwie listy z przenoszeniem" />
+        <CardHeader title="Two lists with drag and drop" />
         <CardBody>
           <div class="row g-3">
             <div class="col-sm-6">

--- a/shared/components/cards/ChurnRisk.astro
+++ b/shared/components/cards/ChurnRisk.astro
@@ -16,7 +16,7 @@ const churn = crmDashboard.churn_risk
       <h3 class="card-title mb-0">Churn risk</h3>
     </div>
     <CardActions>
-      <Badge text="3 accounts" color="red" />
+      <Badge text="5 accounts" color="red" />
     </CardActions>
   </div>
 

--- a/shared/components/cards/ChurnRisk.astro
+++ b/shared/components/cards/ChurnRisk.astro
@@ -16,7 +16,7 @@ const churn = crmDashboard.churn_risk
       <h3 class="card-title mb-0">Churn risk</h3>
     </div>
     <CardActions>
-      <Badge text="5 accounts" color="red" />
+      <Badge text={`${churn.items.length} accounts`} color="red" />
     </CardActions>
   </div>
 

--- a/shared/components/cards/Icons.astro
+++ b/shared/components/cards/Icons.astro
@@ -10,10 +10,11 @@ interface Props {
 const { title, type = 'outline' } = Astro.props
 
 // Dev preview limits icons to 20 (see BaseLayout).
-// The limit applies before the svg[type] filter — the "filled" card shows only filled icons among the first 20.
 const limit = 20
 
-const entries = Object.entries(icons as Record<string, { svg?: Record<string, string | null> }>).slice(0, limit)
+const entries = Object.entries(icons as Record<string, { svg?: Record<string, string | null> }>)
+  .filter(([, icon]) => icon.svg?.[type])
+  .slice(0, limit)
 ---
 
 <div class="card">

--- a/shared/components/cards/SocialTraffic.astro
+++ b/shared/components/cards/SocialTraffic.astro
@@ -2,7 +2,7 @@
 import { formatNumber } from '@shared/lib/string-format'
 import CardTitle from '@ui/CardTitle.astro'
 
-const services = 'Instagram:3550,Twitter:1798,Facebook:1245,TikTok:986,Pinterest:854,VK:650,Pinterest:420'.split(',').map((service) => {
+const services = 'Instagram:3550,Twitter:1798,Facebook:1245,TikTok:986,Pinterest:854,VK:650,LinkedIn:420'.split(',').map((service) => {
   const [name, visitors] = service.split(':')
   return { name, visitors: Number(visitors) }
 })

--- a/shared/components/cards/StorageUsage.astro
+++ b/shared/components/cards/StorageUsage.astro
@@ -4,7 +4,7 @@
 
 <div class="card">
   <div class="card-body">
-    <p class="mb-3">Using Storage <strong>6854.45 MB </strong>of 8 GB</p>
+    <p class="mb-3">Using Storage <strong>5760 MB </strong>of 8 GB</p>
     <div class="progress progress-separated mb-3">
       <div class="progress-bar bg-primary" role="progressbar" style="width: 44%" aria-label="Regular"></div>
       <div class="progress-bar bg-info" role="progressbar" style="width: 19%" aria-label="System"></div>
@@ -14,22 +14,22 @@
       <div class="col-auto d-flex align-items-center pe-2">
         <span class="legend me-2 bg-primary"></span>
         <span>Regular</span>
-        <span class="d-none d-md-inline d-lg-none d-xxl-inline ms-2 text-secondary">915MB</span>
+        <span class="d-none d-md-inline d-lg-none d-xxl-inline ms-2 text-secondary">3520MB</span>
       </div>
       <div class="col-auto d-flex align-items-center px-2">
         <span class="legend me-2 bg-info"></span>
         <span>System</span>
-        <span class="d-none d-md-inline d-lg-none d-xxl-inline ms-2 text-secondary">415MB</span>
+        <span class="d-none d-md-inline d-lg-none d-xxl-inline ms-2 text-secondary">1520MB</span>
       </div>
       <div class="col-auto d-flex align-items-center px-2">
         <span class="legend me-2 bg-success"></span>
         <span>Shared</span>
-        <span class="d-none d-md-inline d-lg-none d-xxl-inline ms-2 text-secondary">201MB</span>
+        <span class="d-none d-md-inline d-lg-none d-xxl-inline ms-2 text-secondary">720MB</span>
       </div>
       <div class="col-auto d-flex align-items-center ps-2">
         <span class="legend me-2"></span>
         <span>Free</span>
-        <span class="d-none d-md-inline d-lg-none d-xxl-inline ms-2 text-secondary">612MB</span>
+        <span class="d-none d-md-inline d-lg-none d-xxl-inline ms-2 text-secondary">2240MB</span>
       </div>
     </div>
   </div>

--- a/shared/components/cards/UsersList2.astro
+++ b/shared/components/cards/UsersList2.astro
@@ -27,7 +27,7 @@ const rows = (people as Person[]).slice(offset, offset + limit).map((person, idx
   const status = colors[randomNumber(index + 5, 0, colors.length - 1)]
   return {
     person,
-    status,
+    status: status !== 'x' ? status : 'secondary',
     statusLabel: statusLabels[status],
     timeago: timeagoLabel(index, 6),
   }

--- a/shared/components/cards/music/TracksList.astro
+++ b/shared/components/cards/music/TracksList.astro
@@ -26,16 +26,14 @@ const items = tracks.slice(0, 12)
             </div>
             <div class="col-auto text-secondary">{millisecondsToMinutes(track.duration_ms)}</div>
             <div class="col-auto">
-              <a href="#" class="link-secondary">
-                <button class="switch-icon" data-bs-toggle="switch-icon">
-                  <span class="switch-icon-a text-muted">
-                    <Icon name="heart" />
-                  </span>
-                  <span class="switch-icon-b text-red">
-                    <Icon name="heart" class="icon-filled" />
-                  </span>
-                </button>
-              </a>
+              <button class="switch-icon" data-bs-toggle="switch-icon">
+                <span class="switch-icon-a text-muted">
+                  <Icon name="heart" />
+                </span>
+                <span class="switch-icon-b text-red">
+                  <Icon name="heart" class="icon-filled" />
+                </span>
+              </button>
             </div>
             <div class="col-auto lh-1">
               <div class="dropdown">

--- a/shared/components/modals/ReportModalContent.astro
+++ b/shared/components/modals/ReportModalContent.astro
@@ -27,7 +27,7 @@ const visibilityOptions = ['Private', 'Public', 'Hidden']
         reports.map((report, index) => (
           <div class="col-lg-6">
             <label class="form-selectgroup-item">
-              <input type="radio" name="report-type" value="1" class="form-selectgroup-input" checked={index === 0} />
+              <input type="radio" name="report-type" value={index + 1} class="form-selectgroup-input" checked={index === 0} />
               <span class="form-selectgroup-label d-flex align-items-center p-3">
                 <span class="me-3">
                   <span class="form-selectgroup-check" />

--- a/shared/layouts/MarketingLayout.astro
+++ b/shared/layouts/MarketingLayout.astro
@@ -14,7 +14,7 @@ interface Props {
 
 const { title, pageLibs } = Astro.props
 
-const base = ''
+const base = '..'
 ---
 
 <BaseLayout title={title} pageLibs={pageLibs} bodyClass="body-marketing body-gradient" base="..">

--- a/shared/layouts/MarketingLayout.astro
+++ b/shared/layouts/MarketingLayout.astro
@@ -17,7 +17,7 @@ const { title, pageLibs } = Astro.props
 const base = '..'
 ---
 
-<BaseLayout title={title} pageLibs={pageLibs} bodyClass="body-marketing body-gradient" base="..">
+<BaseLayout title={title} pageLibs={pageLibs} bodyClass="body-marketing body-gradient" base={base}>
   <!-- BEGIN NAVBAR  -->
   <MarketingNavbar />
   <!-- END NAVBAR  -->


### PR DESCRIPTION
## Summary

- Fix 15 small bugs in the preview demo pages: broken HTML (invalid nesting, bad `aria-labelledby`, wrong `type` attributes, duplicate radio values), stale or inconsistent demo data (mismatched counts, duplicated entries, self-contradicting numbers), and leftover Polish text in card titles.
- These are all cosmetic/demo-content fixes. No changes to core components' public API or build output.
- Closes #2815

## Preview

- **URL:** [preview link](https://tabler-git-fix-2815-tabler-io.vercel.app/)
- **How to test:**
  - [`/icons.html`](https://tabler-git-fix-2815-tabler-io.vercel.app/icons.html) — "Filled icons" card now shows a full row of icons (was showing almost none).
  - [`/sortable.html`](https://tabler-git-fix-2815-tabler-io.vercel.app/sortable.html) — card titles are in English now.
  - [`/modals.html`](https://tabler-git-fix-2815-tabler-io.vercel.app/modals.html) — side nav now has a link for the "Add task modal" (17 modals, 17 links).
  - [`/emails.html`](https://tabler-git-fix-2815-tabler-io.vercel.app/emails.html) — open an email preview modal; its heading now has a matching `id` for `aria-labelledby`.
  - [`/form-layout.html`](https://tabler-git-fix-2815-tabler-io.vercel.app/form-layout.html) — the email input in "Example Form with Icons" uses `type="email"`.
  - [`/form-elements.html`](https://tabler-git-fix-2815-tabler-io.vercel.app/form-elements.html) — the "About Me" textarea shows its intended text (no more invalid duplicate `value`).
  - [`/lists.html`](https://tabler-git-fix-2815-tabler-io.vercel.app/lists.html) — "Top users" offline status dot is now grey, not the black X/Twitter brand color.
  - [`/dashboard-crm.html`](https://tabler-git-fix-2815-tabler-io.vercel.app/dashboard-crm.html) — "Churn risk" badge now says "5 accounts" (matches the 5 listed items); "Social Media Traffic" no longer lists Pinterest twice; "Storage" card numbers now add up.
  - [`/dashboard-crypto.html`](https://tabler-git-fix-2815-tabler-io.vercel.app/dashboard-crypto.html) — "USD/BTC" card shows a ratio and a price, not the same price twice.
  - [`/music.html`](https://tabler-git-fix-2815-tabler-io.vercel.app/music.html) — the like button on each track is no longer a `<button>` nested inside an `<a>`.
  - Report modal (open from `/modals.html`) — "Simple"/"Advanced" radio options now have distinct values.
  - Docs illustrations banner — count updated from 100 to 125.
  - Marketing pages footer (e.g. `/marketing/`) — footer links now point to the site root instead of the current page.

## Notes / rollout

- No feature flags or migrations involved. All changes are isolated to preview/demo content and one accessibility/HTML-validity fix per file.