### PR TITLE
Add `tom-select` to modals page libs so task-modal selects work

### DIFF
--- a/preview/pages/modals.astro
+++ b/preview/pages/modals.astro
@@ -26,7 +26,7 @@ import AddTaskModalContent from '@shared/components/modals/AddTaskModalContent.a
 const cardClass = 'position-relative rounded d-block bg-surface-backdrop py-6 w-auto h-auto z-0'
 ---
 
-<DefaultLayout title="Modals" pageHeader="Modals" pageMenu="base.modals" pageLibs={['signature_pad', 'hugerte', 'litepicker']}>
+<DefaultLayout title="Modals" pageHeader="Modals" pageMenu="base.modals" pageLibs={['signature_pad', 'hugerte', 'litepicker', 'tom-select']}>
   <Card>
     <CardBody>
       <div class="row g-5">


### PR DESCRIPTION
## Summary

- The Modals demo page (`preview/pages/modals.astro`) did not load the `tom-select` library.
- The "New task modal" uses two `<Select>` fields ("Assigned to" and "Category/Tags") that need `tom-select` to render as enhanced dropdowns.
- Without the library, these fields fell back to plain, unstyled HTML `<select>` elements.
- Added `'tom-select'` to the page's `pageLibs` list, matching every other page that uses `<Select>`.

## Preview

- **URL:** [preview link](https://tabler-git-fix-2816-tabler-io.vercel.app/modals.html#modal-new-task)
- **How to test:** Open the Modals page, scroll to (or click) "New task modal" in the sidebar, and open it. Check that "Assigned to" and "Category/Tags" render as styled TomSelect widgets (search box, tag pills) instead of plain browser `<select>` dropdowns.

## Notes / rollout

- Closes #2816