### PR TITLE
Add `SelectCustom` component using the CSS customizable select API

### DIFF
--- a/core/scss/_core.scss
+++ b/core/scss/_core.scss
@@ -65,6 +65,7 @@
 @forward 'ui/forms/form-colorinput';
 @forward 'ui/forms/form-imagecheck';
 @forward 'ui/forms/form-selectgroup';
+@forward 'ui/forms/form-select-custom';
 @forward 'ui/forms/form-custom';
 @forward 'ui/forms/form-check';
 @forward 'ui/forms/validation';

--- a/core/scss/ui/forms/_form-select-custom.scss
+++ b/core/scss/ui/forms/_form-select-custom.scss
@@ -1,0 +1,221 @@
+/**
+Customizable <select>, built on the experimental `appearance: base-select`
+API (https://developer.chrome.com/blog/introducing-base-select). Chromium
+only for now — everything below lives behind an `@supports` guard, so
+unsupported browsers keep rendering a plain, fully working native select;
+the extra button/selectedcontent/div markup isn't part of the option list
+model there and simply isn't rendered.
+ */
+@use '../../config' as *;
+
+.form-select-custom {
+  @supports (appearance: base-select) {
+    padding: 0;
+    appearance: base-select;
+    background: none;
+    border: 0;
+    box-shadow: none;
+
+    &::picker(select) {
+      min-inline-size: calc(anchor-size(self-inline) + #{$dropdown-item-padding-x * 2}); // stylelint-disable-line function-disallowed-list
+      padding: $dropdown-padding-y $dropdown-padding-x;
+      margin-block: $dropdown-spacer;
+      color: $dropdown-color;
+      appearance: base-select;
+      background-color: $dropdown-bg;
+      border: $dropdown-border-width solid $dropdown-border-color;
+      @include border-radius($dropdown-border-radius);
+      @include box-shadow($dropdown-box-shadow);
+      @include transition(opacity 0.15s ease, transform 0.15s ease, display 0.15s allow-discrete, overlay 0.15s allow-discrete);
+
+      &:not(:popover-open) {
+        opacity: 0;
+        transform: scale(0.96);
+      }
+
+      &:popover-open {
+        opacity: 1;
+        transform: scale(1);
+      }
+
+      @starting-style {
+        &:popover-open {
+          opacity: 0;
+          transform: scale(0.96);
+        }
+      }
+    }
+
+    &::picker-icon {
+      display: none;
+    }
+
+    > button {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      inline-size: 100%;
+      padding: $form-select-padding-y $form-select-padding-x;
+      font-family: $form-select-font-family;
+      @include font-size($form-select-font-size);
+      font-weight: $form-select-font-weight;
+      color: $form-select-color;
+      text-align: start;
+      background-color: $form-select-bg;
+      border: $form-select-border-width solid $form-select-border-color;
+      @include border-radius($form-select-border-radius);
+      @include box-shadow($form-select-box-shadow);
+      @include transition($form-select-transition);
+
+      &:focus-visible {
+        border-color: $form-select-focus-border-color;
+        outline: 0;
+        box-shadow: $form-select-focus-box-shadow;
+      }
+    }
+
+    &:disabled > button {
+      color: $form-select-disabled-color;
+      background-color: $form-select-disabled-bg;
+      border-color: $form-select-disabled-border-color;
+    }
+
+    &:open > button .form-select-custom-caret {
+      transform: rotate(0.5turn);
+    }
+
+    .form-select-custom-toggle {
+      display: block;
+      overflow: hidden;
+      text-align: start;
+    }
+
+    .form-select-custom-label {
+      display: block;
+      @include font-size($font-size-sm);
+      color: $form-secondary-color;
+    }
+
+    selectedcontent {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      > * {
+        @include transition(opacity 0.2s ease, translate 0.2s ease);
+
+        @starting-style {
+          opacity: 0;
+          translate: 0 0.25rem;
+        }
+      }
+    }
+
+    .form-select-custom-caret {
+      flex-shrink: 0;
+      inline-size: 1.2em;
+      color: $form-select-indicator-color;
+      @include transition(transform 0.2s ease);
+    }
+
+    .form-select-custom-listbox {
+      &.scrollable {
+        max-block-size: 20lh;
+        overflow-y: auto;
+        scrollbar-width: thin;
+      }
+
+      .form-select-custom-group-label {
+        position: sticky;
+        inset-block-start: 0;
+        z-index: 1;
+        display: block;
+        padding: $dropdown-header-padding-y $dropdown-header-padding-x;
+        font-weight: var(--font-weight-medium);
+        color: $dropdown-header-color;
+        background: var(--bg-surface-tertiary);
+        @include font-size($font-size-sm);
+      }
+    }
+
+    option {
+      display: flex;
+      gap: $dropdown-item-gap;
+      align-items: center;
+      padding: $dropdown-item-padding-y $dropdown-item-padding-x;
+      cursor: pointer;
+
+      &::checkmark {
+        color: $dropdown-link-active-color;
+      }
+
+      &:is(:hover, :focus-visible) {
+        color: $dropdown-link-hover-color;
+        background: $dropdown-link-hover-bg;
+      }
+
+      &:checked {
+        color: $dropdown-link-active-color;
+        background: $dropdown-link-active-bg;
+      }
+
+      &:disabled {
+        color: $dropdown-link-disabled-color;
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  &.form-select-custom-primary {
+    @supports (appearance: base-select) {
+      > button {
+        color: var(--white);
+        background-color: var(--primary);
+        border-color: var(--primary);
+      }
+
+      .form-select-custom-label {
+        color: inherit;
+        opacity: 0.7;
+      }
+
+      .form-select-custom-caret {
+        color: inherit;
+      }
+    }
+  }
+}
+
+.form-select-custom-option {
+  display: flex;
+  flex: 1;
+  gap: $dropdown-item-gap;
+  align-items: center;
+  justify-content: space-between;
+
+  &:has(.form-select-custom-option-description) {
+    display: grid;
+    gap: 0.125rem;
+    justify-items: start;
+  }
+}
+
+.form-select-custom-option-text {
+  flex: 1;
+}
+
+.form-select-custom-option-description {
+  display: block;
+  @include font-size($font-size-sm);
+  color: $form-secondary-color;
+
+  option:checked & {
+    color: inherit;
+    opacity: 0.75;
+  }
+
+  selectedcontent & {
+    display: none;
+  }
+}

--- a/core/scss/ui/forms/_form-select-custom.scss
+++ b/core/scss/ui/forms/_form-select-custom.scss
@@ -1,10 +1,6 @@
 /**
-Customizable <select>, built on the experimental `appearance: base-select`
-API (https://developer.chrome.com/blog/introducing-base-select). Chromium
-only for now — everything below lives behind an `@supports` guard, so
-unsupported browsers keep rendering a plain, fully working native select;
-the extra button/selectedcontent/div markup isn't part of the option list
-model there and simply isn't rendered.
+Customizable <select> (appearance: base-select, Chromium only). Unsupported
+browsers keep a plain native select — the extra markup isn't rendered there.
  */
 @use '../../config' as *;
 
@@ -26,7 +22,7 @@ model there and simply isn't rendered.
       border: $dropdown-border-width solid $dropdown-border-color;
       @include border-radius($dropdown-border-radius);
       @include box-shadow($dropdown-box-shadow);
-      @include transition(opacity 0.15s ease, transform 0.15s ease, display 0.15s allow-discrete, overlay 0.15s allow-discrete);
+      @include transition(opacity 0.15s ease, transform 0.15s ease);
 
       &:not(:popover-open) {
         opacity: 0;
@@ -36,13 +32,6 @@ model there and simply isn't rendered.
       &:popover-open {
         opacity: 1;
         transform: scale(1);
-      }
-
-      @starting-style {
-        &:popover-open {
-          opacity: 0;
-          transform: scale(0.96);
-        }
       }
     }
 
@@ -56,10 +45,6 @@ model there and simply isn't rendered.
       justify-content: space-between;
       inline-size: 100%;
       padding: $form-select-padding-y $form-select-padding-x;
-      font-family: $form-select-font-family;
-      @include font-size($form-select-font-size);
-      font-weight: $form-select-font-weight;
-      color: $form-select-color;
       text-align: start;
       background-color: $form-select-bg;
       border: $form-select-border-width solid $form-select-border-color;
@@ -87,7 +72,6 @@ model there and simply isn't rendered.
     .form-select-custom-toggle {
       display: block;
       overflow: hidden;
-      text-align: start;
     }
 
     .form-select-custom-label {
@@ -101,15 +85,6 @@ model there and simply isn't rendered.
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-
-      > * {
-        @include transition(opacity 0.2s ease, translate 0.2s ease);
-
-        @starting-style {
-          opacity: 0;
-          translate: 0 0.25rem;
-        }
-      }
     }
 
     .form-select-custom-caret {
@@ -165,10 +140,8 @@ model there and simply isn't rendered.
         cursor: not-allowed;
       }
     }
-  }
 
-  &.form-select-custom-primary {
-    @supports (appearance: base-select) {
+    &.form-select-custom-primary {
       > button {
         color: var(--white);
         background-color: var(--primary);

--- a/preview/pages/form-elements.astro
+++ b/preview/pages/form-elements.astro
@@ -10,6 +10,7 @@ import FormElements6 from '@shared/components/forms/FormElements6.astro'
 import Layout from '@shared/components/cards/form/Layout.astro'
 import InputIcon from '@ui/form/InputIcon.astro'
 import InputMask from '@ui/form/InputMask.astro'
+import SelectCustom from '@ui/SelectCustom.astro'
 import Button from '@ui/Button.astro'
 import Avatar from '@ui/Avatar.astro'
 import Card from '@ui/Card.astro'
@@ -114,6 +115,129 @@ const rows = [
           </select>
         </CardBody>
         <CardFooter>Learn more about <a href="#">Node.js Version</a></CardFooter>
+      </Card>
+    </div>
+
+    <div class="col-12">
+      <Card>
+        <CardBody>
+          <CardTitle>Customizable select <span class="badge bg-orange-lt ms-2">Experimental</span></CardTitle>
+          <CardSubtitle>Zero-JS rich &lt;select&gt; via the CSS "customizable select" API. Chromium only for now — other browsers fall back to a plain, working native select.</CardSubtitle>
+          <div class="row row-cols-1 row-cols-sm-2 row-cols-xl-4 g-3">
+            <div class="col">
+              <div class="form-label">Status dot</div>
+              <SelectCustom
+                id="select-custom-status"
+                options={[
+                  { value: 'on', text: 'On', dot: 'success', selected: true },
+                  { value: 'off', text: 'Off', dot: 'danger' },
+                  { value: 'disabled', text: 'Disable', dot: 'secondary' },
+                ]}
+              />
+            </div>
+            <div class="col">
+              <div class="form-label">Avatar</div>
+              <SelectCustom
+                id="select-custom-people"
+                options={[
+                  { value: '1', text: 'Paweł Kuna', personId: 1 },
+                  { value: '2', text: 'Jeffie Lewzey', personId: 2, selected: true },
+                  { value: '3', text: 'Mallory Hulme', personId: 3 },
+                ]}
+              />
+            </div>
+            <div class="col">
+              <div class="form-label">Flag</div>
+              <SelectCustom
+                id="select-custom-flag"
+                options={[
+                  { value: 'pl', text: 'Poland', flag: 'pl', selected: true },
+                  { value: 'de', text: 'Germany', flag: 'de' },
+                  { value: 'cz', text: 'Czech Republic', flag: 'cz' },
+                  { value: 'br', text: 'Brazil', flag: 'br' },
+                ]}
+              />
+            </div>
+            <div class="col">
+              <div class="form-label">Badge</div>
+              <SelectCustom
+                id="select-custom-badge"
+                options={[
+                  { value: 'copy', text: 'Copy', badge: 'cmd + C', badgeColor: 'secondary' },
+                  { value: 'paste', text: 'Paste', badge: 'cmd + V', badgeColor: 'secondary', selected: true },
+                  { value: 'cut', text: 'Cut', badge: 'cmd + X', badgeColor: 'secondary' },
+                ]}
+              />
+            </div>
+            <div class="col">
+              <div class="form-label">Grouped, sticky headers</div>
+              <SelectCustom
+                id="select-custom-groups"
+                label="Color space"
+                scrollable
+                groups={[
+                  {
+                    label: 'Standard',
+                    options: [
+                      { value: 'srgb', text: 'srgb' },
+                      { value: 'hsl', text: 'hsl' },
+                      { value: 'hwb', text: 'hwb' },
+                    ],
+                  },
+                  {
+                    label: 'HD',
+                    options: [
+                      { value: 'display-p3', text: 'display-p3' },
+                      { value: 'a98-rgb', text: 'a98-rgb' },
+                    ],
+                  },
+                  {
+                    label: 'Ultra HD',
+                    options: [
+                      { value: 'lch', text: 'lch' },
+                      { value: 'oklch', text: 'oklch', selected: true },
+                      { value: 'oklab', text: 'oklab' },
+                    ],
+                  },
+                ]}
+              />
+            </div>
+            <div class="col">
+              <div class="form-label">Primary, with description</div>
+              <SelectCustom
+                id="select-custom-primary"
+                primary
+                options={[
+                  { value: 'published', text: 'Published', description: 'Live on the web, available to anyone with the link.', selected: true },
+                  { value: 'draft', text: 'Draft', description: 'Not available on the web, no public access.' },
+                ]}
+              />
+            </div>
+            <div class="col">
+              <div class="form-label">Disabled option</div>
+              <SelectCustom
+                id="select-custom-disabled"
+                options={[
+                  { value: 'starter', text: 'Starter', selected: true },
+                  { value: 'pro', text: 'Pro' },
+                  { value: 'enterprise', text: 'Enterprise', disabled: true, badge: 'Contact us', badgeColor: 'secondary' },
+                ]}
+              />
+            </div>
+            <div class="col">
+              <div class="form-label">Plain (no indicators)</div>
+              <SelectCustom
+                id="select-custom-plain"
+                options={[
+                  { value: 'html', text: 'HTML' },
+                  { value: 'js', text: 'JavaScript', selected: true },
+                  { value: 'css', text: 'CSS' },
+                  { value: 'bootstrap', text: 'Bootstrap' },
+                ]}
+              />
+            </div>
+          </div>
+        </CardBody>
       </Card>
     </div>
 

--- a/shared/ui/SelectCustom.astro
+++ b/shared/ui/SelectCustom.astro
@@ -1,0 +1,82 @@
+---
+// Rich, zero-JS <select> built on the experimental "customizable select" CSS
+// API (`appearance: base-select`, `<selectedcontent>`, `::picker(select)`).
+// Chromium-only today — see core/scss/ui/forms/_form-select-custom.scss for
+// the fallback story. Not wired to TomSelect; see Select.astro for the
+// cross-browser rich-select approach used elsewhere in the docs.
+import Icon from './Icon.astro'
+import StatusDot from './StatusDot.astro'
+import Avatar from './Avatar.astro'
+import Flag from './Flag.astro'
+import Badge from './Badge.astro'
+
+interface Option {
+  value: string
+  text: string
+  description?: string
+  selected?: boolean
+  disabled?: boolean
+  dot?: string
+  personId?: number
+  flag?: string
+  badge?: string
+  badgeColor?: string
+}
+
+interface Group {
+  label?: string
+  options: Option[]
+}
+
+interface Props {
+  id: string
+  class?: string
+  label?: string
+  primary?: boolean
+  scrollable?: boolean
+  options?: Option[]
+  groups?: Group[]
+}
+
+const { id, class: className, label, primary, scrollable, options = [], groups = [] } = Astro.props
+
+const selectClasses = ['form-select', 'form-select-custom', primary && 'form-select-custom-primary', className]
+const listboxClasses = ['form-select-custom-listbox', scrollable && 'scrollable']
+
+// Ungrouped options are just a single unlabeled group — keeps the option
+// markup below to one call site instead of one per grouped/flat branch.
+const renderGroups: Group[] = groups.length > 0 ? groups : [{ options }]
+---
+
+<select id={id} class:list={selectClasses}>
+  <button type="button">
+    <span class="form-select-custom-toggle">
+      {label && <small class="form-select-custom-label">{label}</small>}
+      <selectedcontent></selectedcontent>
+    </span>
+    <Icon name="chevron-down" class="form-select-custom-caret" />
+  </button>
+  <div class:list={listboxClasses}>
+    {
+      renderGroups.map((group) => (
+        <div role={group.label ? 'group' : undefined}>
+          {group.label && <label class="form-select-custom-group-label">{group.label}</label>}
+          {group.options.map((option) => (
+            <option value={option.value} selected={option.selected || undefined} disabled={option.disabled || undefined}>
+              <div class="form-select-custom-option">
+                {option.dot && <StatusDot color={option.dot} />}
+                {option.personId && <Avatar personId={option.personId} size="xs" />}
+                {option.flag && <Flag flag={option.flag} size="xs" />}
+                <span class="form-select-custom-option-text">
+                  {option.text}
+                  {option.description && <span class="form-select-custom-option-description">{option.description}</span>}
+                </span>
+                {option.badge && <Badge text={option.badge} color={option.badgeColor ?? 'primary'} light />}
+              </div>
+            </option>
+          ))}
+        </div>
+      ))
+    }
+  </div>
+</select>

--- a/shared/ui/SelectCustom.astro
+++ b/shared/ui/SelectCustom.astro
@@ -52,7 +52,8 @@ const renderGroups: Group[] = groups.length > 0 ? groups : [{ options }]
   <button type="button">
     <span class="form-select-custom-toggle">
       {label && <small class="form-select-custom-label">{label}</small>}
-      <selectedcontent></selectedcontent>
+      {/* set:html: Astro renders <selectedcontent> as void otherwise, breaking the post-build HTML prettify pass */}
+      <Fragment set:html="<selectedcontent></selectedcontent>" />
     </span>
     <Icon name="chevron-down" class="form-select-custom-caret" />
   </button>


### PR DESCRIPTION
## Summary

- Add zero-JS `SelectCustom.astro`, a rich `<select>` built on the experimental `appearance: base-select` CSS API (button + `<selectedcontent>` + custom `<option>` markup, no JS dropdown library).
- Style it in `core/scss/ui/forms/_form-select-custom.scss`, reusing existing dropdown/form-select tokens. Everything sits behind `@supports (appearance: base-select)`, so unsupported browsers keep rendering a plain, working native select.
- Show 8 usage examples (status dot, avatar, flag, badge, grouped list with sticky headers, primary + description, disabled option, plain) on the Form elements preview page.

## Preview

- **URL:** [preview link](https://tabler-git-select-custom-tabler-io.vercel.app/form-elements.html)
- **How to test:** Open the "Customizable select" card on Form elements. In a Chromium-based browser, click each of the 8 selects and check the rich picker (dots, avatars, flags, badges, sticky group headers, disabled option). In Firefox/Safari, confirm they still work as plain native selects.

## Notes / rollout

- Experimental: depends on `appearance: base-select`, which is Chromium-only today. The demo card is labeled "Experimental" so it's clear this isn't production-ready everywhere yet.