### PR TITLE
Enable `astro/tsconfigs/strictest` in the docs package

### DIFF
--- a/docs/components/DocsCard.astro
+++ b/docs/components/DocsCard.astro
@@ -4,7 +4,7 @@ import Icon from '@ui/Icon.astro'
 interface Props {
   /** When omitted, the card renders as a non-interactive "Coming soon" tile. */
   href?: string
-  icon?: string
+  icon?: string | undefined
   title: string
   description: string
 }

--- a/docs/layouts/DocsLayout.astro
+++ b/docs/layouts/DocsLayout.astro
@@ -18,15 +18,15 @@ interface Props {
 	/** front matter: the page's h1 heading */
 	title: string;
 	/** front matter: optional SEO title override */
-	seoTitle?: string;
+	seoTitle?: string | undefined;
 	/** front matter: lead below the title (p.text-secondary.fs-3.lh-3) */
-	summary?: string;
+	summary?: string | undefined;
 	/** front matter: SEO description */
-	description?: string;
+	description?: string | undefined;
 	/** front matter: optional SEO description override */
-	seoDescription?: string;
+	seoDescription?: string | undefined;
 	/** front matter `added-in`: renders the "Added in X" badge next to the h1 */
-	addedIn?: string;
+	addedIn?: string | undefined;
 	/** Table of contents (h2/h3 from the markdown content) — see DocsToc.astro */
 	toc?: TocItem[];
 	/**
@@ -35,13 +35,13 @@ interface Props {
 	 * Drives the active menu entry, pagination, the "Edit this page" link, and
 	 * the relative favicon path.
 	 */
-	url?: string;
+	url?: string | undefined;
 	/** Extra libraries from libs.json (css+js) */
 	docsLibs?: string[];
 	/** hides child and previous/next page navigation */
-	hidePagination?: boolean;
+	hidePagination?: boolean | undefined;
 	/** repo-relative source path for the "Edit this page" link, e.g. "docs/pages/ui/components/alert.mdx" */
-	editPath?: string;
+	editPath?: string | undefined;
 }
 
 const {

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "astro/tsconfigs/strict",
+  "extends": "astro/tsconfigs/strictest",
   "include": [
     ".astro/types.d.ts",
     "**/*"


### PR DESCRIPTION
## Summary

- Switch `docs/tsconfig.json` from `astro/tsconfigs/strict` to `astro/tsconfigs/strictest` and fix the 2 resulting type errors (`exactOptionalPropertyTypes`).
- Widen `DocsCard.astro`'s `icon` prop and `DocsLayout.astro`'s front-matter pass-through props (`seoTitle`, `summary`, `description`, `seoDescription`, `addedIn`, `url`, `hidePagination`, `editPath`) to `?: T | undefined`, since they receive `string | undefined` from optional MDX front matter fields.
- No behavior change: these are type-level widenings only, not new logic.

Companion PR for the `preview` package: #2834.

## Notes / rollout

- This is type-checking only, no rendered output changes. `astro check` passes with 0 errors (one pre-existing `ClipboardJS` global-name hint remains, unrelated to this change) and `astro build` still produces all 128 pages.