### PR TITLE
Enable `astro/tsconfigs/strictest` in the shared package

### DIFF
--- a/shared/components/cards/AuthLockCard.astro
+++ b/shared/components/cards/AuthLockCard.astro
@@ -3,8 +3,9 @@ import Button from '@ui/Button.astro'
 import Avatar from '@ui/Avatar.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import people from '@data/people.json'
+import { requireIndex } from '@shared/lib/array'
 
-const person = people[0]
+const person = requireIndex(people, 0)
 ---
 
 <form class="card card-md" action="./" method="get" novalidate>

--- a/shared/components/cards/Card.astro
+++ b/shared/components/cards/Card.astro
@@ -5,6 +5,7 @@ import AvatarList from '@ui/AvatarList.astro';
 import Empty from '@ui/Empty.astro';
 import Progress from '@ui/Progress.astro';
 import photos from '@data/photos.json';
+import { requireIndex } from '@shared/lib/array';
 
 interface Props {
 	link?: boolean;
@@ -61,7 +62,7 @@ const {
 	footerButtons,
 	footerElements,
 	progress,
-} = Astro.props;
+}: Props = Astro.props;
 
 const Element = link ? 'a' : 'div';
 
@@ -86,8 +87,8 @@ const footerEls = (footerElements ?? []).map((element: string) => {
 const hasHeader = header || headerTitle || headerTabs || headerPills;
 const hasFooter = footer || footerButton || footerButtons || footerElements;
 
-const imgTopPhoto = (photos as { file: string; title: string }[])[7];
-const imgBottomPhoto = (photos as { file: string; title: string }[])[11];
+const imgTopPhoto = requireIndex(photos as { file: string; title: string }[], 7);
+const imgBottomPhoto = requireIndex(photos as { file: string; title: string }[], 11);
 ---
 
 <Element href={link ? '#' : undefined} class:list={classes}>

--- a/shared/components/cards/CardImage.astro
+++ b/shared/components/cards/CardImage.astro
@@ -1,5 +1,6 @@
 ---
 import photos from '@data/photos.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Props {
   title?: string
@@ -9,7 +10,7 @@ interface Props {
 
 const { title, right, imgId = 1 } = Astro.props
 
-const photo = (photos as { file: string; title: string }[])[imgId]
+const photo = requireIndex(photos as { file: string; title: string }[], imgId)
 const imgClass = `w-100 h-100 object-cover ${right ? 'card-img-end' : 'card-img-start'}`
 ---
 

--- a/shared/components/cards/CarouselCard.astro
+++ b/shared/components/cards/CarouselCard.astro
@@ -2,7 +2,6 @@
 // Photos filtered to horizontal=true, then sliced by offset/limit.
 import photos from '@data/photos.json'
 import CardTitle from '@ui/CardTitle.astro'
-import Carousel from '@ui/Carousel.astro'
 
 interface Props {
   id?: string

--- a/shared/components/cards/ProjectProgress.astro
+++ b/shared/components/cards/ProjectProgress.astro
@@ -2,6 +2,7 @@
 import Progress from '@ui/Progress.astro'
 import CardDropdown from '@ui/CardDropdown.astro'
 import projects from '@data/projects.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Project {
   title?: string
@@ -16,7 +17,7 @@ interface Props {
 }
 
 const { projectId = 0, progress = 25, daysAgo = 2 } = Astro.props
-const project = (projects as Project[])[projectId]
+const project = requireIndex(projects as Project[], projectId)
 ---
 
 <div class="card">

--- a/shared/components/cards/Subscribe.astro
+++ b/shared/components/cards/Subscribe.astro
@@ -2,6 +2,7 @@
 import Avatar from '@ui/Avatar.astro'
 import CardDropdown from '@ui/CardDropdown.astro'
 import people from '@data/people.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Person {
   full_name?: string
@@ -15,7 +16,7 @@ interface Props {
 }
 
 const { personId = 0 } = Astro.props
-const person = (people as Person[])[personId]
+const person = requireIndex(people as Person[], personId)
 ---
 
 <div class="card">

--- a/shared/components/cards/UserCard.astro
+++ b/shared/components/cards/UserCard.astro
@@ -2,6 +2,7 @@
 // person = people[person-id] (no -1: the object is passed straight to Avatar).
 import Avatar from '@ui/Avatar.astro'
 import people from '@data/people.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Person {
   full_name?: string
@@ -16,7 +17,7 @@ interface Props {
 }
 
 const { personId = 0, right } = Astro.props
-const person = (people as Person[])[personId]
+const person = requireIndex(people as Person[], personId)
 ---
 
 <a class="card card-link" href="#">

--- a/shared/components/cards/UserCardBg.astro
+++ b/shared/components/cards/UserCardBg.astro
@@ -3,6 +3,7 @@
 import Avatar from '@ui/Avatar.astro'
 import people from '@data/people.json'
 import photos from '@data/photos.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Person {
   full_name?: string
@@ -22,8 +23,8 @@ interface Props {
 }
 
 const { personId = 0, blurred } = Astro.props
-const person = (people as Person[])[personId]
-const photo = (photos as Photo[])[personId]
+const person = requireIndex(people as Person[], personId)
+const photo = requireIndex(photos as Photo[], personId)
 ---
 
 <a class="card card-link" href="#">

--- a/shared/components/cards/UserCardBig.astro
+++ b/shared/components/cards/UserCardBig.astro
@@ -1,6 +1,7 @@
 ---
 import Avatar from '@ui/Avatar.astro'
 import people from '@data/people.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Person {
   full_name?: string
@@ -14,7 +15,7 @@ interface Props {
 }
 
 const { personId = 0 } = Astro.props
-const person = (people as Person[])[personId]
+const person = requireIndex(people as Person[], personId)
 ---
 
 <div class="card">

--- a/shared/components/cards/UserInfo.astro
+++ b/shared/components/cards/UserInfo.astro
@@ -3,6 +3,7 @@
 import Icon from '@ui/Icon.astro'
 import Flag from '@ui/Flag.astro'
 import people from '@data/people.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Person {
   university?: string
@@ -21,7 +22,7 @@ interface Props {
 }
 
 const { title = 'Basic info', personId = 25 } = Astro.props
-const person = (people as Person[])[personId - 1]
+const person = requireIndex(people as Person[], personId - 1)
 ---
 
 <div class="card">

--- a/shared/components/cards/UsersList2.astro
+++ b/shared/components/cards/UsersList2.astro
@@ -3,6 +3,7 @@ import Avatar from '@ui/Avatar.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import people from '@data/people.json'
 import { randomNumber, timeagoLabel } from '@shared/lib/pseudo-random'
+import { requireIndex } from '@shared/lib/array'
 
 interface Person {
   full_name?: string
@@ -19,12 +20,12 @@ interface Props {
 
 const { limit = 10, offset = 0, title = 'Top users', class: className } = Astro.props
 
-const colors = 'green,red,yellow,x,x'.split(',')
-const statusLabels: Record<string, string> = { green: 'Online', red: 'Busy', yellow: 'Away', x: 'Offline' }
+const colors = ['green', 'red', 'yellow', 'x', 'x'] as const
+const statusLabels: Record<(typeof colors)[number], string> = { green: 'Online', red: 'Busy', yellow: 'Away', x: 'Offline' }
 
 const rows = (people as Person[]).slice(offset, offset + limit).map((person, idx) => {
   const index = idx + 1 // forloop.index (1-based)
-  const status = colors[randomNumber(index + 5, 0, colors.length - 1)]
+  const status = requireIndex(colors, randomNumber(index + 5, 0, colors.length - 1))
   return {
     person,
     status: status !== 'x' ? status : 'secondary',

--- a/shared/components/cards/music/TrackInfo.astro
+++ b/shared/components/cards/music/TrackInfo.astro
@@ -1,5 +1,6 @@
 ---
 import tracks from '@data/tracks.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Props {
   trackId?: number
@@ -7,13 +8,14 @@ interface Props {
 
 const { trackId = 5 } = Astro.props
 
-const track = tracks[trackId]
+const track = requireIndex(tracks, trackId)
+const trackImage = requireIndex(track.album.images, 1)
 ---
 
 <div class="card">
   <div class="row row-0">
     <div class="col-auto">
-      <img src={`./static/tracks/${track.album.images[1].path}`} class="rounded-start" alt={track.name} width="80" height="80" />
+      <img src={`./static/tracks/${trackImage.path}`} class="rounded-start" alt={track.name} width="80" height="80" />
     </div>
     <div class="col">
       <div class="card-body">

--- a/shared/components/cards/music/TracksList.astro
+++ b/shared/components/cards/music/TracksList.astro
@@ -6,6 +6,7 @@ import ListGroup from '@ui/ListGroup.astro'
 import ListGroupItem from '@ui/ListGroupItem.astro'
 import tracks from '@data/tracks.json'
 import { millisecondsToMinutes } from '@shared/lib/string-format'
+import { requireIndex } from '@shared/lib/array'
 
 const items = tracks.slice(0, 12)
 ---
@@ -18,7 +19,7 @@ const items = tracks.slice(0, 12)
           <div class="row g-2 align-items-center">
             <div class="col-auto fs-3">{index + 1}</div>
             <div class="col-auto">
-              <img src={`./static/tracks/${track.album.images[1].path}`} class="rounded" alt={track.name} width="40" height="40" />
+              <img src={`./static/tracks/${requireIndex(track.album.images, 1).path}`} class="rounded" alt={track.name} width="40" height="40" />
             </div>
             <div class="col">
               {track.name}

--- a/shared/components/layout/HeaderActionsButtons.astro
+++ b/shared/components/layout/HeaderActionsButtons.astro
@@ -8,7 +8,7 @@ import ReportModalContent from '../modals/ReportModalContent.astro'
 
 interface Props {
   /** layout-navbar-overlap && layout-navbar-dark → the "New view" button is color="dark" */
-  dark?: boolean
+  dark?: boolean | undefined
 }
 
 const { dark } = Astro.props

--- a/shared/components/layout/HeaderProfile.astro
+++ b/shared/components/layout/HeaderProfile.astro
@@ -4,8 +4,9 @@ import Icon from '@ui/Icon.astro'
 import Button from '@ui/Button.astro'
 import ButtonList from '@ui/ButtonList.astro'
 import people from '@data/people.json'
+import { requireIndex } from '@shared/lib/array'
 
-const person = people[3]
+const person = requireIndex(people, 3)
 ---
 
 <!-- BEGIN HEADER PROFILE -->

--- a/shared/components/layout/PageHeader.astro
+++ b/shared/components/layout/PageHeader.astro
@@ -15,21 +15,21 @@ import HeaderUptime from './HeaderUptime.astro';
 
 interface Props {
 	/** page-header — the page title; without it the whole block is not rendered */
-	title?: string;
+	title?: string | undefined;
 	/** page-header-pretitle */
-	pretitle?: string;
+	pretitle?: string | undefined;
 	/** page-header-description */
-	description?: string;
+	description?: string | undefined;
 	/** page-header-actions — name of an include from layout/header-actions/, e.g. "buttons" */
-	actions?: string;
+	actions?: string | undefined;
 	/** page-header-class */
 	class?: string;
 	/** page-header-icon */
 	icon?: string;
 	/** page-header-file — name of an include from layout/headers/, e.g. "profile" */
-	file?: string;
+	file?: string | undefined;
 	/** layout-navbar-overlap && layout-navbar-dark → text-white on .page-header */
-	textWhite?: boolean;
+	textWhite?: boolean | undefined;
 }
 
 const { title, pretitle, description, actions, class: className, icon, file, textWhite } = Astro.props;

--- a/shared/components/marketing/SectionDivider.astro
+++ b/shared/components/marketing/SectionDivider.astro
@@ -1,7 +1,7 @@
 ---
 // Renders nothing unless divider is 'waves' or 'arc'.
 interface Props {
-  divider?: string
+  divider?: string | undefined
 }
 
 const { divider } = Astro.props

--- a/shared/components/modals/AddTaskModalContent.astro
+++ b/shared/components/modals/AddTaskModalContent.astro
@@ -2,13 +2,14 @@
 // selected ids "5,6,2,3" → people[id-1].
 import people from '@data/people.json'
 import FormGroup from '@ui/FormGroup.astro'
+import { requireIndex } from '@shared/lib/array'
 
 interface Person {
   id: string
   full_name: string
 }
 
-const selectedPeople = ['5', '6', '2', '3'].map((idStr) => (people as Person[])[Number(idStr) - 1])
+const selectedPeople = ['5', '6', '2', '3'].map((idStr) => requireIndex(people as Person[], Number(idStr) - 1))
 ---
 
 <div class="modal-header">

--- a/shared/components/modals/ChangePasswordModalContent.astro
+++ b/shared/components/modals/ChangePasswordModalContent.astro
@@ -60,8 +60,8 @@ import FormGroup from '@ui/FormGroup.astro'
       const strengthLevels = ['bg-danger', 'bg-danger', 'bg-danger', 'bg-warning', 'bg-info', 'bg-success']
       const strengthLabels = ['Weak', 'Weak', 'Weak', 'Fair', 'Good', 'Strong']
       strengthBar.className = `progress-bar ${strengthLevels[strength]}`
-      strengthBar.setAttribute('aria-valuetext', password ? strengthLabels[strength] : 'Empty')
-      strengthText.textContent = password ? strengthLabels[strength] : ''
+      strengthBar.setAttribute('aria-valuetext', password ? (strengthLabels[strength] ?? '') : 'Empty')
+      strengthText.textContent = password ? (strengthLabels[strength] ?? '') : ''
     })
   }
 

--- a/shared/components/navbar/Navbar.astro
+++ b/shared/components/navbar/Navbar.astro
@@ -16,14 +16,14 @@ import NavbarSearch from './NavbarSearch.astro';
 interface Props {
 	hideSearch?: boolean;
 	/** equivalent of the page-menu front matter (active menu entry), e.g. "dashboards.default" */
-	pageMenu?: string;
+	pageMenu?: string | undefined;
 	breakpoint?: string;
-	condensed?: boolean;
-	dark?: boolean;
+	condensed?: boolean | undefined;
+	dark?: boolean | undefined;
 	transparent?: boolean;
-	overlap?: boolean;
-	sticky?: boolean;
-	hideBrand?: boolean;
+	overlap?: boolean | undefined;
+	sticky?: boolean | undefined;
+	hideBrand?: boolean | undefined;
 	/** use the sample menu (menu-sample.json) instead of the real one */
 	sample?: boolean;
 	/** 1-based index into people.json for the user menu avatar */
@@ -40,7 +40,7 @@ interface Props {
 	/** no-op — see the fluid-search note above */
 	fluidSearch?: boolean;
 	/** layout-navbar-class */
-	class?: string;
+	class?: string | undefined;
 }
 
 // pageMenu is the front matter `page-menu` value; when a page has none, nothing

--- a/shared/components/navbar/NavbarMenu.astro
+++ b/shared/components/navbar/NavbarMenu.astro
@@ -20,7 +20,7 @@ interface Level1 {
 
 interface Props {
   /** equivalent of the page-menu front matter, e.g. "dashboards.default" */
-  pageMenu?: string
+  pageMenu?: string | undefined
   sample?: boolean
   hideIcons?: boolean
   longTitles?: boolean

--- a/shared/components/navbar/NavbarSide.astro
+++ b/shared/components/navbar/NavbarSide.astro
@@ -11,7 +11,7 @@ interface Props {
   class?: string
   breakpoint?: string
   condensed?: boolean
-  personId?: number
+  personId?: number | undefined
   hideUsername?: boolean
   dark?: boolean
   showThemeToggle?: boolean

--- a/shared/components/navbar/NavbarSideUser.astro
+++ b/shared/components/navbar/NavbarSideUser.astro
@@ -3,6 +3,7 @@
 import Icon from '@ui/Icon.astro'
 import Avatar from '@ui/Avatar.astro'
 import people from '@data/people.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Props {
   personId?: number
@@ -12,7 +13,7 @@ interface Props {
 
 const { personId = 1, hideUsername = false, dark = false } = Astro.props
 
-const person = people[personId - 1]
+const person = requireIndex(people, personId - 1)
 ---
 
 <!-- BEGIN USER MENU -->

--- a/shared/components/navbar/Sidebar.astro
+++ b/shared/components/navbar/Sidebar.astro
@@ -5,14 +5,14 @@ import NavbarSide from './NavbarSide.astro'
 import NavbarMenu from './NavbarMenu.astro'
 
 interface Props {
-  dark?: boolean
+  dark?: boolean | undefined
   breakpoint?: string
   /** layout-sidebar-end — navbar-end class */
-  end?: boolean
+  end?: boolean | undefined
   /** layout-navbar-transparent — navbar-transparent class */
-  transparent?: boolean
+  transparent?: boolean | undefined
   /** equivalent of the page-menu front matter (active menu entry), e.g. "layout.vertical" */
-  pageMenu?: string
+  pageMenu?: string | undefined
 }
 
 const { dark = false, breakpoint = 'lg', end = false, transparent = false, pageMenu } = Astro.props

--- a/shared/components/parts/Datagrid.astro
+++ b/shared/components/parts/Datagrid.astro
@@ -6,6 +6,7 @@ import Icon from '@ui/Icon.astro'
 import Datagrid from '@ui/Datagrid.astro'
 import DatagridItem from '@ui/DatagridItem.astro'
 import people from '@data/people.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Person {
   full_name?: string
@@ -13,7 +14,7 @@ interface Person {
   [key: string]: unknown
 }
 
-const creator = (people as Person[])[0]
+const creator = requireIndex(people as Person[], 0)
 ---
 
 <Datagrid>

--- a/shared/layouts/BaseLayout.astro
+++ b/shared/layouts/BaseLayout.astro
@@ -6,13 +6,13 @@ import PageScripts from '@shared/components/PageScripts.astro'
 import libs from '@tabler/core/libs.json'
 
 interface Props {
-  title?: string
+  title?: string | undefined
   /** Third-party libs from libs.json, e.g. ['apexcharts', 'jsvectormap'] */
-  pageLibs?: string[]
+  pageLibs?: string[] | undefined
   /** Extra body classes, e.g. "layout-boxed" / "layout-fluid" */
-  bodyClass?: string
+  bodyClass?: string | undefined
   /** dir="rtl" + RTL variants of the tabler/plugin stylesheets */
-  rtl?: boolean
+  rtl?: boolean | undefined
   /** Relative asset base: '.' for root pages, '..' one level deep */
   base?: string
 }

--- a/shared/layouts/DefaultLayout.astro
+++ b/shared/layouts/DefaultLayout.astro
@@ -7,21 +7,21 @@ import PageHeader from '@shared/components/layout/PageHeader.astro'
 import Footer from '@shared/components/layout/Footer.astro'
 
 interface Props {
-  title?: string
+  title?: string | undefined
   /** Script/CSS library keys passed to BaseLayout */
   pageLibs?: string[]
   /** page-header — the title in the page header */
-  pageHeader?: string
+  pageHeader?: string | undefined
   /** page-header-file — renders a layout/headers/{file} component instead of the title block */
-  pageHeaderFile?: string
+  pageHeaderFile?: string | undefined
   /** page-header-pretitle */
-  pretitle?: string
+  pretitle?: string | undefined
   /** page-header-description */
-  description?: string
+  description?: string | undefined
   /** page-header-actions, e.g. "buttons" */
-  actions?: string
+  actions?: string | undefined
   /** page-menu from the front matter, e.g. "layout.vertical" — active menu entry */
-  pageMenu?: string
+  pageMenu?: string | undefined
   /** layout-sidebar */
   sidebar?: boolean
   /** layout-sidebar-dark */

--- a/shared/lib/chart-script.ts
+++ b/shared/lib/chart-script.ts
@@ -108,7 +108,7 @@ export function chartStyle(opts: { id: string; data: ChartData }): string {
  * Chart.astro. This is data-driven (from our own charts.json, not user input),
  * same trust level as everything else here.
  */
-export function chartConfig(opts: { id: string; data: ChartData; height: number }): { config: Record<string, unknown>; xFormatterExpr?: string } {
+export function chartConfig(opts: { id: string; data: ChartData; height: number }): { config: Record<string, unknown>; xFormatterExpr?: string | undefined } {
   const { id, data, height } = opts
   const type = data.type ?? 'bar'
   const series = data.series ?? []

--- a/shared/lib/pseudo-random.ts
+++ b/shared/lib/pseudo-random.ts
@@ -1,6 +1,8 @@
 // Deterministic pseudo-random values seeded by a loop index, used to generate
 // stable-looking demo data (numbers, dates, "time ago" labels) without a real RNG.
 
+import { requireIndex } from './array'
+
 export function randomNumber(x: number, min = 0, max = 100, round = 0): number {
   let value = ((x * x * Math.PI * Math.E * (max + 1) * (Math.sin(x) / Math.cos(x * x))) % (max + 1 - min)) + min
 
@@ -24,7 +26,7 @@ export function randomDate(x: number): Date {
 }
 
 export function randomItem<T>(x: number, items: T[]): T {
-  return items[randomNumber(x, 0, items.length - 1)]
+  return requireIndex(items, randomNumber(x, 0, items.length - 1))
 }
 
 /** A date up to `maxDays` days ago, formatted as "now" / "N day(s) ago". */

--- a/shared/lib/string-format.test.ts
+++ b/shared/lib/string-format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { capitalize, firstLetters, formatNumber, millisecondsToMinutes, parseCurrency, parsePercentage, pathSlug, roundTo, slugifyWord, sortBy, splitDropTrailingEmpty, ucFirst } from './string-format'
+import { requireIndex } from './array'
 
 describe('capitalize', () => {
   it('uppercases the first char and lowercases the rest', () => {
@@ -106,6 +107,6 @@ describe('sortBy', () => {
   it('does not mutate the input array', () => {
     const people = [{ last_name: 'Smith' }, { last_name: 'Adams' }]
     sortBy(people, (p) => p.last_name)
-    expect(people[0].last_name).toBe('Smith')
+    expect(requireIndex(people, 0).last_name).toBe('Smith')
   })
 })

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "astro/tsconfigs/strict",
+	"extends": "astro/tsconfigs/strictest",
 	"include": [
 		"**/*"
 	],

--- a/shared/ui/AdvancedTable.astro
+++ b/shared/ui/AdvancedTable.astro
@@ -2,7 +2,7 @@
 import BadgesList from './BadgesList.astro'
 import Icon from './Icon.astro'
 import { formatLongDate } from '@shared/lib/date-format'
-import { randomNumber, randomItem, randomDate } from '@shared/lib/pseudo-random'
+import { randomItem, randomDate } from '@shared/lib/pseudo-random'
 import Avatar from './Avatar.astro'
 import Button from './Button.astro'
 import ButtonList from './ButtonList.astro'
@@ -10,9 +10,21 @@ import Pagination from './Pagination.astro'
 import people from '@data/people.json'
 import tableProperties from '@data/table-properties.json'
 import CaptureScript from '../components/CaptureScript.astro'
+import { requireIndex } from '@shared/lib/array'
 
 interface Props {
   id?: string
+}
+
+interface Person {
+  full_name?: string
+  city?: string
+  country?: string
+  [key: string]: unknown
+}
+
+interface AdvancedTableProperties {
+  headers: { 'data-sort': string; 'name': string }[]
 }
 
 const { id: tableId = 'advanced-table' } = Astro.props
@@ -22,12 +34,10 @@ const perPage = ['10', '20', '50', '100']
 const categories = ['Agencies', 'Individual', 'Event', 'Ticket']
 const tags = ['QTA,Event,Tickets,TODO', 'Event,Tickets', 'QTA,Event', 'Tickets']
 
-const headers = (tableProperties as Record<string, any>)['advanced-table'].headers as {
-  'data-sort': string
-  'name': string
-}[]
+const advancedTable = (tableProperties as { 'advanced-table': AdvancedTableProperties })['advanced-table']
+const headers = advancedTable.headers
 
-const rows = (people as Record<string, any>[]).map((person, i) => {
+const rows = (people as Person[]).map((person, i) => {
   const index = i + 1
   const status = randomItem(index + 5, statuses)
   const itemTags = randomItem(index + 5, tags).split(',')
@@ -36,8 +46,7 @@ const rows = (people as Record<string, any>[]).map((person, i) => {
   return { person, index, status, itemTags, category, date }
 })
 
-const advancedTable = (tableProperties as Record<string, any>)['advanced-table']
-const perPageDefault = perPage[1]
+const perPageDefault = requireIndex(perPage, 1)
 ---
 
 <div class="card">
@@ -104,23 +113,23 @@ const perPageDefault = perPage[1]
                   <td>
                     <input class="form-check-input m-0 align-middle table-selectable-check" type="checkbox" aria-label="Select invoice" value="true" />
                   </td>
-                  <td class={headers[0]['data-sort']}>
+                  <td class={requireIndex(headers, 0)['data-sort']}>
                     <Avatar person={person} size="xs" class="me-2" />
                     {person.full_name}
                   </td>
-                  <td class={headers[1]['data-sort']}>
+                  <td class={requireIndex(headers, 1)['data-sort']}>
                     {person.city}, {person.country}
                   </td>
-                  <td class={headers[2]['data-sort']}>{status === 'Active' ? <span class="badge bg-success-lt">Active</span> : status === 'Inactive' ? <span class="badge bg-danger-lt">Inactive</span> : <span class="badge">Requested</span>}</td>
-                  <td class={headers[3]['data-sort']}>{date}</td>
-                  <td class={headers[4]['data-sort']}>
+                  <td class={requireIndex(headers, 2)['data-sort']}>{status === 'Active' ? <span class="badge bg-success-lt">Active</span> : status === 'Inactive' ? <span class="badge bg-danger-lt">Inactive</span> : <span class="badge">Requested</span>}</td>
+                  <td class={requireIndex(headers, 3)['data-sort']}>{date}</td>
+                  <td class={requireIndex(headers, 4)['data-sort']}>
                     <BadgesList>
                       {itemTags.map((tag) => (
                         <span class="badge">{tag}</span>
                       ))}
                     </BadgesList>
                   </td>
-                  <td class={`${headers[5]['data-sort']} py-0`}>
+                  <td class={`${requireIndex(headers, 5)['data-sort']} py-0`}>
                     <span class="on-unchecked">{category}</span>
                     <div class="on-checked">
                       <div class="d-flex justify-content-end">
@@ -137,7 +146,7 @@ const perPageDefault = perPage[1]
       <div class="card-footer d-flex align-items-center">
         <div class="dropdown" data-table-id={tableId}>
           <button type="button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-            <span id={`${tableId}-page-count`} class="me-1">{perPage[1]}</span>
+            <span id={`${tableId}-page-count`} class="me-1">{perPageDefault}</span>
             <span>records</span>
           </button>
           <div class="dropdown-menu">

--- a/shared/ui/Avatar.astro
+++ b/shared/ui/Avatar.astro
@@ -13,14 +13,14 @@ interface Props {
   src?: string
   placeholder?: string | undefined
   personId?: number
-  person?: Person
+  person?: Person | undefined
   link?: boolean
   dropdown?: boolean
-  size?: string
+  size?: string | undefined
   thumb?: boolean
   class?: string
   shape?: string
-  color?: string
+  color?: string | undefined
   square?: boolean
   status?: string
   statusText?: string

--- a/shared/ui/AvatarList.astro
+++ b/shared/ui/AvatarList.astro
@@ -12,8 +12,8 @@ interface Person {
 }
 
 interface Props {
-  limit?: number
-  offset?: number
+  limit?: number | undefined
+  offset?: number | undefined
   stacked?: boolean
   /** avatar-list-{size} + forwarded to default Avatars */
   size?: string

--- a/shared/ui/BackgroundPattern.astro
+++ b/shared/ui/BackgroundPattern.astro
@@ -14,7 +14,7 @@ interface Props {
   [key: string]: unknown
 }
 
-const { pattern, color, size, as: Element = 'div', class: className, ...rest } = Astro.props
+const { pattern, color, size, as: Element = 'div', class: className, ...rest }: Props = Astro.props
 ---
 
 <Element class:list={[`bg-pattern-${pattern}`, color && `bg-pattern-${color}`, size && `bg-pattern-${size}`, className]} {...rest}>

--- a/shared/ui/Badge.astro
+++ b/shared/ui/Badge.astro
@@ -2,7 +2,6 @@
 import Icon from './Icon.astro'
 import Avatar from './Avatar.astro'
 import people from '@data/people.json'
-import { firstLetters } from '@shared/lib/string-format'
 
 interface Person {
   full_name?: string

--- a/shared/ui/Button.astro
+++ b/shared/ui/Button.astro
@@ -12,7 +12,7 @@ interface Props {
   element?: 'a' | 'button'
   type?: 'button' | 'reset' | 'submit'
   id?: string
-  color?: string
+  color?: string | undefined
   outline?: boolean
   ghost?: boolean
   /** btn-{height} right after btn */

--- a/shared/ui/Card.astro
+++ b/shared/ui/Card.astro
@@ -11,7 +11,7 @@ interface Props {
   [key: string]: unknown
 }
 
-const { as: Element = 'div', size, class: className, ...rest } = Astro.props
+const { as: Element = 'div', size, class: className, ...rest }: Props = Astro.props
 ---
 
 <Element class:list={['card', size && `card-${size}`, className]} {...rest}>

--- a/shared/ui/CardHeader.astro
+++ b/shared/ui/CardHeader.astro
@@ -10,10 +10,10 @@ interface Props {
   class?: string
 }
 
-const { title, as: TitleTag = 'h3', light, class: className } = Astro.props
+const { title, as: TitleTag = 'h3', light, class: className }: Props = Astro.props
 ---
 
 <div class:list={['card-header', light && 'card-header-light', className]}>
-  {title && <TitleTag class="card-title">{title}</TitleTag>}
+  {title && <TitleTag class:list={['card-title']}>{title}</TitleTag>}
   <slot />
 </div>

--- a/shared/ui/CardSubtitle.astro
+++ b/shared/ui/CardSubtitle.astro
@@ -7,7 +7,7 @@ interface Props {
   class?: string
 }
 
-const { as: Tag = 'p', class: className } = Astro.props
+const { as: Tag = 'p', class: className }: Props = Astro.props
 ---
 
 <Tag class:list={['card-subtitle', className]}>

--- a/shared/ui/CardTitle.astro
+++ b/shared/ui/CardTitle.astro
@@ -8,9 +8,9 @@ interface Props {
   id?: string
 }
 
-const { as: Tag = 'h3', class: className, id } = Astro.props
+const { as: Tag = 'h3', class: className, id }: Props = Astro.props
 ---
 
-<Tag class:list={['card-title', className]} id={id}>
+<Tag class:list={['card-title', className]} {...(id ? { id } : {})}>
   <slot />
 </Tag>

--- a/shared/ui/CardTitle.astro
+++ b/shared/ui/CardTitle.astro
@@ -11,6 +11,6 @@ interface Props {
 const { as: Tag = 'h3', class: className, id }: Props = Astro.props
 ---
 
-<Tag class:list={['card-title', className]} {...(id ? { id } : {})}>
+<Tag class:list={['card-title', className]} {...id ? { id } : {}}>
   <slot />
 </Tag>

--- a/shared/ui/ChartSparkline.astro
+++ b/shared/ui/ChartSparkline.astro
@@ -2,9 +2,9 @@
 import CaptureScript from '../components/CaptureScript.astro';
 
 interface Props {
-	id?: string;
+	id?: string | undefined;
 	type?: string;
-	color?: string;
+	color?: string | undefined;
 	height?: number;
 	small?: boolean;
 	wide?: boolean;

--- a/shared/ui/Chat.astro
+++ b/shared/ui/Chat.astro
@@ -2,6 +2,7 @@
 import Avatar from './Avatar.astro'
 import chats from '@data/chats.json'
 import people from '@data/people.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Person {
   full_name?: string
@@ -31,7 +32,7 @@ const peopleList = people as Person[]
   <div class="chat-bubbles">
     {
       messages.map((message) => {
-        const person = peopleList[message['person-id']]
+        const person = requireIndex(peopleList, message['person-id'])
         const me = message['person-id'] === 0
         const messageColClass = message.loading ? 'col-auto' : `col${wide ? ' col-lg-6' : ''}`
 

--- a/shared/ui/Empty.astro
+++ b/shared/ui/Empty.astro
@@ -9,11 +9,11 @@ interface Props {
   bordered?: boolean
   class?: string
   /** illustration file name, e.g. "computer-fix.svg" */
-  illustration?: string
+  illustration?: string | undefined
   /** icon-text param — big text rendered instead of an icon/illustration */
-  iconText?: string
+  iconText?: string | undefined
   title?: string
-  subtitle?: string
+  subtitle?: string | undefined
   buttonText?: string
   buttonIcon?: string
 }

--- a/shared/ui/Flag.astro
+++ b/shared/ui/Flag.astro
@@ -1,6 +1,6 @@
 ---
 interface Props {
-  flag?: string
+  flag?: string | undefined
   size?: string
   class?: string
   label?: string | undefined

--- a/shared/ui/FormHint.astro
+++ b/shared/ui/FormHint.astro
@@ -6,12 +6,12 @@ interface Props {
   as?: string
   class?: string
   /** id so a control can reference the hint via aria-describedby */
-  id?: string
+  id?: string | undefined
 }
 
-const { as: Tag = 'div', class: className, id } = Astro.props
+const { as: Tag = 'div', class: className, id }: Props = Astro.props
 ---
 
-<Tag class:list={['form-hint', className]} id={id}>
+<Tag class:list={['form-hint', className]} {...(id ? { id } : {})}>
   <slot />
 </Tag>

--- a/shared/ui/FormHint.astro
+++ b/shared/ui/FormHint.astro
@@ -12,6 +12,6 @@ interface Props {
 const { as: Tag = 'div', class: className, id }: Props = Astro.props
 ---
 
-<Tag class:list={['form-hint', className]} {...(id ? { id } : {})}>
+<Tag class:list={['form-hint', className]} {...id ? { id } : {}}>
   <slot />
 </Tag>

--- a/shared/ui/Icon.astro
+++ b/shared/ui/Icon.astro
@@ -4,8 +4,8 @@ import icons from '@data/icons.json'
 interface Props {
   name: string
   type?: 'outline' | 'filled'
-  class?: string
-  color?: string
+  class?: string | undefined
+  color?: string | undefined
   size?: string
   inline?: boolean
 }

--- a/shared/ui/ListGroup.astro
+++ b/shared/ui/ListGroup.astro
@@ -12,7 +12,7 @@ interface Props {
   [key: string]: unknown
 }
 
-const { as: Element = 'div', flush, hoverable, transparent, class: className, ...rest } = Astro.props
+const { as: Element = 'div', flush, hoverable, transparent, class: className, ...rest }: Props = Astro.props
 ---
 
 <Element class:list={['list-group', flush && 'list-group-flush', hoverable && 'list-group-hoverable', transparent && 'list-group-transparent', className]} {...rest}>

--- a/shared/ui/ListGroupItem.astro
+++ b/shared/ui/ListGroupItem.astro
@@ -13,7 +13,7 @@ interface Props {
   [key: string]: unknown
 }
 
-const { as: Element = 'div', action, active, disabled, class: className, ...rest } = Astro.props
+const { as: Element = 'div', action, active, disabled, class: className, ...rest }: Props = Astro.props
 ---
 
 <Element class:list={['list-group-item', action && 'list-group-item-action', active && 'active', disabled && 'disabled', className]} {...rest}>

--- a/shared/ui/Photo.astro
+++ b/shared/ui/Photo.astro
@@ -19,4 +19,4 @@ const { photo, background, ratio, class: className } = Astro.props
 const src = `./static/photos/${photo.file}`
 ---
 
-<!-- Photo -->{background ? <div class:list={className} style={`background-image: url(${src})`} /> : ratio ? <div class:list={['img-responsive', `img-responsive-${ratio}`, className]} style={`background-image: url(${src})`} /> : <img src={src} class:list={className} alt={photo.title} />}
+<!-- Photo -->{background ? <div class:list={[className]} style={`background-image: url(${src})`} /> : ratio ? <div class:list={['img-responsive', `img-responsive-${ratio}`, className]} style={`background-image: url(${src})`} /> : <img src={src} class:list={[className]} alt={photo.title} />}

--- a/shared/ui/Progress.astro
+++ b/shared/ui/Progress.astro
@@ -1,10 +1,10 @@
 ---
 interface Props {
-  value?: number | string
+  value?: number | string | undefined
   values?: (string | number)[]
-  color?: string
+  color?: string | undefined
   colors?: string[]
-  size?: string
+  size?: string | undefined
   class?: string
   width?: string
   id?: string

--- a/shared/ui/ProgressDescription.astro
+++ b/shared/ui/ProgressDescription.astro
@@ -14,7 +14,7 @@ interface Props {
 const { label = 'Label', description, value, color = 'blue', size, class: className } = Astro.props
 ---
 
-<div class:list={className}>
+<div class:list={[className]}>
   <div class="d-flex mb-1 align-items-center lh-1">
     <div class="fs-5 fw-semibold m-0">{label}</div>
     {description && <div class="fs-6 text-secondary ms-2">{description}</div>}

--- a/shared/ui/Select.astro
+++ b/shared/ui/Select.astro
@@ -52,7 +52,7 @@ interface Person {
 }
 
 // Build the option list.
-type Opt = { value: string; text: string; custom?: string; selected?: boolean };
+type Opt = { value: string; text: string; custom?: string | undefined; selected?: boolean };
 type Group = { label: string; options: Opt[] };
 let options: Opt[] = [];
 let optgroups: Group[] = [];

--- a/shared/ui/Subheader.astro
+++ b/shared/ui/Subheader.astro
@@ -9,7 +9,7 @@ interface Props {
   [key: string]: unknown
 }
 
-const { as: Tag = 'div', class: className, ...rest } = Astro.props
+const { as: Tag = 'div', class: className, ...rest }: Props = Astro.props
 ---
 
 <Tag class:list={['subheader', className]} {...rest}>

--- a/shared/ui/Timeline.astro
+++ b/shared/ui/Timeline.astro
@@ -4,6 +4,7 @@ import Icon from './Icon.astro'
 import Avatar from './Avatar.astro'
 import people from '@data/people.json'
 import photos from '@data/photos.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Props {
   simple?: boolean
@@ -13,6 +14,7 @@ const { simple } = Astro.props
 
 const avatarPeople = (people as { full_name?: string; photo?: string }[]).slice(0, 3)
 const timelinePhotos = photos as { file: string; title: string }[]
+const timelinePhoto = (i: number) => requireIndex(timelinePhotos, i)
 ---
 
 <ul class:list={['timeline', simple && 'timeline-simple']}>
@@ -78,15 +80,15 @@ const timelinePhotos = photos as { file: string; title: string }[]
           <div class="row g-2">
             <div class="col-4">
               <!-- Photo -->
-              <img src={`./static/photos/${timelinePhotos[6].file}`} class="rounded" alt={timelinePhotos[6].title} />
+              <img src={`./static/photos/${timelinePhoto(6).file}`} class="rounded" alt={timelinePhoto(6).title} />
             </div>
             <div class="col-4">
               <!-- Photo -->
-              <img src={`./static/photos/${timelinePhotos[7].file}`} class="rounded" alt={timelinePhotos[7].title} />
+              <img src={`./static/photos/${timelinePhoto(7).file}`} class="rounded" alt={timelinePhoto(7).title} />
             </div>
             <div class="col-4">
               <!-- Photo -->
-              <img src={`./static/photos/${timelinePhotos[8].file}`} class="rounded" alt={timelinePhotos[8].title} />
+              <img src={`./static/photos/${timelinePhoto(8).file}`} class="rounded" alt={timelinePhoto(8).title} />
             </div>
           </div>
         </div>

--- a/shared/ui/Toast.astro
+++ b/shared/ui/Toast.astro
@@ -1,6 +1,7 @@
 ---
 import Avatar from './Avatar.astro'
 import people from '@data/people.json'
+import { requireIndex } from '@shared/lib/array'
 
 interface Props {
   toastId?: string
@@ -21,7 +22,7 @@ interface Person {
   [key: string]: unknown
 }
 
-const person = (people as Person[])[personId]
+const person = requireIndex(people as Person[], personId)
 ---
 
 <div class:list={['toast', show && 'show']} id={`toast-${toastId}`} role="alert" aria-live="assertive" aria-atomic="true" data-bs-autohide="false">

--- a/shared/ui/Trending.astro
+++ b/shared/ui/Trending.astro
@@ -3,7 +3,7 @@ import Icon from './Icon.astro'
 
 interface Props {
   value?: number
-  unit?: string
+  unit?: string | undefined
   class?: string
 }
 


### PR DESCRIPTION
## Summary

- Switch `shared/tsconfig.json` from `astro/tsconfigs/strict` to `astro/tsconfigs/strictest` and fix the 131 resulting type errors across the shared component library used by both `preview` and `docs`.
- Use `requireIndex()` (added in the `preview` PR) at ~20 more call sites that index static seed data (`people.json`, `photos.json`, `tracks.json`, `projects.json`) by a fixed or prop-derived position, and in the `randomItem()` helper.
- Widen optional props that legitimately receive `undefined` from already-optional data (`Icon`, `Button`, `Avatar`, `Flag`, `Progress`, `ChartSparkline`, `AvatarList`, `Empty`, `SectionDivider`, `Navbar`/`Sidebar`, `PageHeader`/layout front-matter pass-throughs, `Select`'s `Opt.custom`) to `?: T | undefined`, as required by `exactOptionalPropertyTypes`.
- Fix a latent typing hole in `CardHeader`/`CardTitle`/`FormHint`: their `Props` interface was declared but never actually applied to `Astro.props` (TypeScript flagged it "declared but never used"), so the `as="..."` dynamic-tag prop had no real type checking. Explicitly annotating it surfaced that a generically-typed dynamic tag can't take plain `class`/`id` attributes in Astro's JSX — switched to `class:list` and a conditional spread for `id`. Rendered output is unchanged (verified byte-for-byte in the built HTML).
- Remove 2 unused imports and one real `any` (`AdvancedTable`'s table-properties/people casts, now properly typed).

## Notes / rollout

- Type-checking only, no rendered output changes. `astro check` passes with 0 errors, `astro build` for both `preview` (127 pages) and `docs` (128 pages) still succeeds, and `vitest` (38 tests) passes.
- Companion PRs: `preview` (#2834), `docs` (#2835, merged).