### PR TITLE
Fix double border on `.dropdown-menu`

### DIFF
--- a/core/scss/bootstrap/_dropdown.scss
+++ b/core/scss/bootstrap/_dropdown.scss
@@ -62,7 +62,6 @@
   list-style: none;
   background-color: var(--dropdown-bg);
   background-clip: padding-box;
-  border: var(--dropdown-border-width) solid var(--dropdown-border-color);
   @include border-radius(var(--dropdown-border-radius));
   @include box-shadow(var(--dropdown-box-shadow));
 


### PR DESCRIPTION
## Summary

- Remove the redundant `border` on `.dropdown-menu`. The box-shadow already draws a 1px ring around it, so having both a real border and the shadow ring made the edge look doubled.

## Preview

- **URL:** [preview link](https://tabler-git-fix-dropdown-double-border-tabler-io.vercel.app/)
- **How to test:** Open any page. Click the user avatar (top right) or the notifications bell to open a dropdown menu. Look at the outer edge — it should be one clean line, not two. Check both light and dark mode.