### PR TITLE
Remove duplicate type-check step from lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,3 @@ jobs:
 
       - name: Lint
         run: pnpm run lint
-
-      - name: Type Check
-        run: pnpm run type-check


### PR DESCRIPTION
`pnpm run type-check` ran twice on every pull request: once as a step in the `Lint` job and once in the dedicated `Type Check` workflow.

Dropped the step from `lint.yml`. `type-check.yml` stays as the single source — it already runs on `pull_request` plus pushes to `main` and `dev`, and it caches `.turbo`, so coverage is unchanged and one redundant full type-check per PR goes away.