### PR TITLE
Fix wrong logical properties in `rounded-start` and `rounded-end` utilities

### DIFF
--- a/core/scss/_utilities.scss
+++ b/core/scss/_utilities.scss
@@ -839,7 +839,7 @@ $utilities: map.merge(
       ),
     ),
     'rounded-end': (
-      property: border-end-end-radius border-end-start-radius,
+      property: border-end-end-radius border-start-end-radius,
       class: rounded-end,
       values: (
         null: var(--border-radius),
@@ -869,7 +869,7 @@ $utilities: map.merge(
       ),
     ),
     'rounded-start': (
-      property: border-start-start-radius border-start-end-radius,
+      property: border-start-start-radius border-end-start-radius,
       class: rounded-start,
       values: (
         null: var(--border-radius),


### PR DESCRIPTION
## Summary

- `rounded-start` and `rounded-end` used the wrong CSS logical properties, so they rounded the wrong pair of corners in LTR layouts.
- `rounded-end` now sets `border-end-end-radius` and `border-start-end-radius` (both corners on the end/right side).
- `rounded-start` now sets `border-start-start-radius` and `border-end-start-radius` (both corners on the start/left side).

## Preview

- **URL:** [preview link](https://tabler-git-fix-rounded-utilities-properties-tabler-io.vercel.app/ui/utilities/borders/) (available once the branch is pushed)
- **How to test:** Add `.border.rounded-start`, `.rounded-end`, `.rounded-top`, and `.rounded-bottom` to a box and check that each class rounds the correct pair of corners (start = left side, end = right side, in LTR). Verified locally: compiled CSS and a rendered test showed all four classes rounding the correct corners after the fix.

## Notes / rollout

- Closes #2823