### PR TITLE
Fix duplicate `!default` SCSS vars so avatar font-size and body emphasis color apply

### DIFF
--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -373,8 +373,6 @@ $body-secondary-bg: $gray-200 !default;
 $body-tertiary-color: rgba($body-color, 0.5) !default;
 $body-tertiary-bg: $gray-100 !default;
 
-$body-emphasis-color: $black !default;
-
 // Typography
 $font-google: null !default;
 $font-google-monospaced: null !default;
@@ -795,7 +793,6 @@ $nested-kbd-font-weight: null !default; // Deprecated in v5.2.0, removing in v6
 // scss-docs-start avatar-variables
 $avatar-size: 2.5rem !default;
 $avatar-status-size: 0.75rem !default;
-$avatar-font-size: 1rem !default;
 $avatar-icon-size: 1.5rem !default;
 $avatar-brand-size: 1.25rem !default;
 $avatar-upload-icon-size: 1.5rem !default;


### PR DESCRIPTION
## Summary

- Removed two duplicate SCSS variable declarations in `core/scss/_variables.scss`. Because Sass `!default` only sets a variable if it's still unset, the second (intended) value was silently ignored in both cases.
- `$avatar-font-size` was set twice (`1rem`, then `$h4-font-size`). The first value always won, so the default `.avatar` (no size modifier) had a different font size than `.avatar-md`, even though they're meant to match.
- `$body-emphasis-color` was set twice (`$black`, then `$gray-700`). The first value always won, so `--tblr-emphasis-color` shipped as pure black/white instead of gray. This affects `--table-hover-bg`, `--nav-underline-link-active-color`, `.text-body-emphasis`, and other consumers.
- Fixes #2818.

## Preview

- **URL:** [preview link](https://tabler-git-fix-2818-tabler-io.vercel.app/avatars.html)
- **How to test:** Open `/avatars.html` and check that the default `.avatar` (no size class) now has the same font size as `.avatar-md`. Also check any page using `.text-body-emphasis` or table hover states — the color should now be gray, not pure black/white.

## Notes / rollout

- Closes #2818