### PR TITLE
Fix broken CSS custom property references in SCSS

### DIFF
--- a/core/scss/_props.scss
+++ b/core/scss/_props.scss
@@ -26,6 +26,7 @@
   --gray-950: #{$gray-950};
 
   --white: #{$white};
+  --white-lt: color-mix(in oklab, var(--white) 10%, transparent);
   --black: #{$black};
   --dark: #{$dark};
   --light: #{$light};

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -727,8 +727,8 @@ $backdrop-opacity: 0.32 !default;
 $backdrop-blur: 4px !default;
 $backdrop-bg: light-dark(var(--gray-800), var(--black)) !default;
 $backdrops: (
-  dark: color-mix(in sRGB, var(--color-dark), transparent var(--backdrop-opacity)),
-  light: color-mix(in sRGB, var(--color-light), transparent var(--backdrop-opacity)),
+  dark: color-mix(in sRGB, var(--dark), transparent var(--backdrop-opacity)),
+  light: color-mix(in sRGB, var(--light), transparent var(--backdrop-opacity)),
 ) !default;
 
 // Gradient
@@ -786,7 +786,7 @@ $kbd-padding-y: 0.25rem !default;
 $kbd-font-weight: var(--font-weight-medium) !default;
 $kbd-font-size: var(--font-size-h5) !default;
 $kbd-border: var(--border-width) var(--border-style) var(--border-color) !default;
-$kbd-color: var(--text-secondary-dark) !default;
+$kbd-color: var(--secondary-color) !default;
 $kbd-bg: var(--code-bg) !default;
 $kbd-border-radius: var(--border-radius) !default;
 $nested-kbd-font-weight: null !default; // Deprecated in v5.2.0, removing in v6
@@ -1312,6 +1312,7 @@ $accordion-button-active-color: inherit !default;
 $accordion-btn-gap: 0.75rem !default;
 $accordion-header-gap: 1rem !default;
 $accordion-tabs-gap: 0.75rem !default;
+$accordion-btn-focus-box-shadow: $focus-ring-box-shadow !default;
 // scss-docs-end accordion-variables
 
 // Carousel

--- a/core/scss/ui/_accordion.scss
+++ b/core/scss/ui/_accordion.scss
@@ -18,6 +18,7 @@
   --accordion-body-padding-y: #{$accordion-body-padding-y};
   --accordion-btn-gap: #{$accordion-btn-gap};
   --accordion-header-gap: #{$accordion-header-gap};
+  --accordion-btn-focus-box-shadow: #{$accordion-btn-focus-box-shadow};
 
   display: flex;
   flex-direction: column;

--- a/core/scss/vendor/_stars-rating.scss
+++ b/core/scss/vendor/_stars-rating.scss
@@ -8,8 +8,8 @@
 
 [data-star-rating] {
   svg {
-    width: var(--icon-size, --gl-star-size);
-    height: var(--icon-size, --gl-star-size);
+    width: var(--icon-size, var(--gl-star-size));
+    height: var(--icon-size, var(--gl-star-size));
   }
 
   :not(.gl-active) > .gl-star-full {


### PR DESCRIPTION
## Summary

- Several SCSS rules pointed to CSS custom properties that are never generated, so the declarations silently fell back to invalid or wrong values instead of the intended color.
- `kbd` text now uses `--secondary-color` (was `--text-secondary-dark`, which does not exist), so it has its own color instead of just inheriting the parent's.
- Backdrop colors now use the real tokens `--dark` / `--light` (was `--color-dark` / `--color-light`), fixing an invalid `color-mix()`.
- Keyboard focus on the accordion header is now visible: added the missing `--accordion-btn-focus-box-shadow` variable, following the same pattern as `--pagination-focus-box-shadow`.
- `.bg-white-lt` now works: added the missing `--white-lt` custom property.
- Fixed an invalid CSS fallback in the star rating icon size (`var(--icon-size, --gl-star-size)` → `var(--icon-size, var(--gl-star-size))`).

## Preview

- **URL:** [preview link](https://tabler-git-fix-2819-tabler-io.vercel.app/)
- **How to test:**
  - [Typography](https://tabler-git-fix-2819-tabler-io.vercel.app/typography.html) — check `<kbd>` elements have their own text color, not inherited.
  - [Colors](https://tabler-git-fix-2819-tabler-io.vercel.app/colors.html) — check `.bg-white-lt` renders a light tint instead of being empty/invalid.
  - [Accordion](https://tabler-git-fix-2819-tabler-io.vercel.app/accordion.html) — tab to an accordion header and confirm a focus ring appears.
  - [Stars rating](https://tabler-git-fix-2819-tabler-io.vercel.app/stars-rating.html) — confirm star icons render at the correct size.
  - Any offcanvas/modal backdrop — confirm the backdrop tint still renders correctly in light and dark mode.

## Notes / rollout

- No breaking changes; all fixes restore intended values, no public API changed.
- Closes #2819