### PR TITLE
Fix `.dropstart` caret rendering after logical-properties migration

### DIFF
--- a/core/scss/mixins/bootstrap/_caret.scss
+++ b/core/scss/mixins/bootstrap/_caret.scss
@@ -33,7 +33,7 @@
 @mixin caret($direction: down, $width: $caret-width, $spacing: $caret-spacing, $vertical-align: $caret-vertical-align) {
   $selector: 'after';
 
-  @if $direction == 'left' {
+  @if $direction == 'start' {
     $selector: 'before';
   }
 
@@ -47,7 +47,7 @@
     border-inline-start: 1px var(--border-style);
     margin-inline-end: 0.1em;
 
-    @if $direction != 'left' {
+    @if $direction != 'start' {
       margin-inline-start: $caret-spacing;
     } @else {
       margin-inline-end: $caret-spacing;
@@ -64,7 +64,7 @@
     }
   }
 
-  @if $direction == 'left' {
+  @if $direction == 'start' {
     &::after {
       content: none;
     }

--- a/core/scss/tests/_caret.test.scss
+++ b/core/scss/tests/_caret.test.scss
@@ -1,7 +1,7 @@
 // Output tests for the caret mixins in scss/mixins/bootstrap/_caret.scss.
 // The `caret-{down,up,end,start}` helpers draw a triangle out of borders; the
 // main `caret()` builds a pseudo-element and branches on `$direction` for the
-// rotation and (for `left`) the ::before/::after structure.
+// rotation and (for `start`) the ::before/::after structure.
 
 @use '../mixins/bootstrap/caret' as *;
 
@@ -86,11 +86,11 @@
     }
   }
 
-  @include it('uses ::before and clears ::after for the left direction') {
+  @include it('uses ::before and clears ::after for the start direction') {
     @include assert() {
       @include output() {
         .t {
-          @include caret(left);
+          @include caret(start);
         }
       }
       @include expect() {


### PR DESCRIPTION
## Summary

- The `caret()` Sass mixin still checked for the old `'left'` keyword to move the arrow onto `::before`. After the physical-to-logical property migration, every real caller now passes `'start'` instead, so that check never matched.
- Result: `.dropstart` dropdown toggles (menu opens toward the start edge) rendered their arrow on `::after` — after the label — instead of before it, in both LTR and RTL.
- Fix: change the three `'left'` comparisons in `core/scss/mixins/bootstrap/_caret.scss` to `'start'`. No other files touched.

## Preview

- **URL:** [preview link](https://tabler-git-fix-2821-tabler-io.vercel.app/dropdowns.html)
- **How to test:** The public dropdowns demo page does not include a `.dropstart` example, so the fix won't be visible there. To check it directly: build the core CSS (`pnpm --filter @tabler/core run css-build`) and open `core/js/tests/visual/dropdown.html` in a browser. On the "Dropstart" and "Dropstart split" buttons, the small arrow should sit before the label (left of it in LTR, right of it with an RTL build), not after.

## Notes / rollout

- Fixes #2821.
- CSS-only change, no JS or markup changes.