### PR TITLE
Fix dropstart caret side, link-opacity color, and breakpoint lookup bugs

### DIFF
--- a/core/scss/mixins/_functions.scss
+++ b/core/scss/mixins/_functions.scss
@@ -19,7 +19,7 @@
 // "Bootstrap functions" section below.
 
 @mixin media-breakpoint-down-than($name, $breakpoints: $grid-breakpoints) {
-  $prev: breakpoint-prev($name);
+  $prev: breakpoint-prev($name, $breakpoints);
 
   @if $prev == null {
     @content;

--- a/core/scss/mixins/bootstrap/_caret.scss
+++ b/core/scss/mixins/bootstrap/_caret.scss
@@ -33,7 +33,7 @@
 @mixin caret($direction: down, $width: $caret-width, $spacing: $caret-spacing, $vertical-align: $caret-vertical-align) {
   $selector: 'after';
 
-  @if $direction == 'left' {
+  @if $direction == 'start' {
     $selector: 'before';
   }
 
@@ -47,7 +47,7 @@
     border-inline-start: 1px var(--border-style);
     margin-inline-end: 0.1em;
 
-    @if $direction != 'left' {
+    @if $direction != 'start' {
       margin-inline-start: $caret-spacing;
     } @else {
       margin-inline-end: $caret-spacing;
@@ -64,7 +64,7 @@
     }
   }
 
-  @if $direction == 'left' {
+  @if $direction == 'start' {
     &::after {
       content: none;
     }

--- a/core/scss/tests/_caret.test.scss
+++ b/core/scss/tests/_caret.test.scss
@@ -1,7 +1,7 @@
 // Output tests for the caret mixins in scss/mixins/bootstrap/_caret.scss.
 // The `caret-{down,up,end,start}` helpers draw a triangle out of borders; the
 // main `caret()` builds a pseudo-element and branches on `$direction` for the
-// rotation and (for `left`) the ::before/::after structure.
+// rotation and (for `start`) the ::before/::after structure.
 
 @use '../mixins/bootstrap/caret' as *;
 
@@ -86,11 +86,11 @@
     }
   }
 
-  @include it('uses ::before and clears ::after for the left direction') {
+  @include it('uses ::before and clears ::after for the start direction') {
     @include assert() {
       @include output() {
         .t {
-          @include caret(left);
+          @include caret(start);
         }
       }
       @include expect() {

--- a/core/scss/tests/_media-breakpoint.test.scss
+++ b/core/scss/tests/_media-breakpoint.test.scss
@@ -174,4 +174,29 @@ $g: (
       }
     }
   }
+
+  // Names that don't exist in the global $grid-breakpoints at all: this only
+  // resolves if $breakpoints actually reaches the breakpoint-prev() lookup,
+  // not just the breakpoint-max() one.
+  $custom: (
+    tablet: 0,
+    desktop: 900px,
+  );
+
+  @include it('resolves the previous breakpoint from a custom $breakpoints map') {
+    @include assert() {
+      @include output() {
+        @include media-breakpoint-down-than(desktop, $custom) {
+          .t {
+            color: red;
+          }
+        }
+      }
+      @include expect() {
+        .t {
+          color: red;
+        }
+      }
+    }
+  }
 }

--- a/core/scss/ui/_type.scss
+++ b/core/scss/ui/_type.scss
@@ -9,10 +9,10 @@
 
 a {
   text-decoration-skip-ink: auto;
-  color: color-mix(in sRGB, transparent, var(--link-color) var(--link-opacity, 100%));
+  color: color-mix(in sRGB, transparent, var(--link-color) calc(var(--link-opacity, 1) * 100%));
 
   &:hover {
-    color: color-mix(in sRGB, transparent, var(--link-hover-color) var(--link-opacity, 100%));
+    color: color-mix(in sRGB, transparent, var(--link-hover-color) calc(var(--link-opacity, 1) * 100%));
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix the `caret()` mixin: it checked for direction `'left'`, but `.dropstart` calls it with `'start'`. This mismatch made the dropstart caret use the wrong pseudo-element, wrong margin, and wrong side.
- Fix link color: `a` and `a:hover` used `--link-opacity` as a CSS percentage in `color-mix()`, but every `.link-opacity-*` class sets it as a plain number (0–1). This made `color-mix()` invalid, so browsers dropped the color and links turned black instead of using their real color.
- Fix `media-breakpoint-down-than()`: it did not forward the custom `$breakpoints` map to `breakpoint-prev()`, only to `breakpoint-max()`. A caller using a custom breakpoints map would get the wrong "previous breakpoint" lookup.
- Add a test that uses a custom breakpoints map, so this bug cannot come back unnoticed.

## Preview

- **URL:** [preview link](https://tabler-git-fix-2822-tabler-io.vercel.app/dropdowns.html)
- **How to test:**
  - Open any page with links and add class `link-opacity-50` or `link-opacity-25` to a link. Before the fix it turns black; after the fix it shows a faded version of the link color.
  - The dropstart caret change is not shown on any public preview page yet. To check it locally, open `core/js/tests/visual/dropdown.html` in a browser (after `pnpm --filter @tabler/core run css-build`) and look at the "Dropstart" buttons — the caret (‹) should sit before the text, on the left.
  - Other dropdown directions (`dropup`, `dropend`, plain `dropdown`) on `/dropdowns.html` should look unchanged — this is a good regression check.

## Notes / rollout

- No breaking changes and no new dependencies.
- Closes #2822