### PR TITLE
Serve the docs as markdown for LLMs (llms.txt)

### DIFF
--- a/.build/check-docs-links.ts
+++ b/.build/check-docs-links.ts
@@ -39,6 +39,12 @@ for (const file of sync(join(contentDir, '**', '*.mdx'))) addRoute(contentDir, f
 for (const file of sync(join(pagesDir, '**', '*.astro'))) {
   if (!file.includes('[')) addRoute(pagesDir, file)
 }
+// Endpoints keep their extension in the route: robots.txt.ts → /robots.txt,
+// sitemap.xml.ts → /sitemap.xml, llms.txt.ts → /llms.txt.
+for (const file of sync(join(pagesDir, '**', '*.ts'))) {
+  if (file.includes('[')) continue
+  routeFiles.set(`/${relative(pagesDir, file).replace(/\.ts$/, '')}`, file)
+}
 
 // Redirect sources are valid link targets; their destinations must exist.
 const astroConfig = readFileSync(join(repoRoot, 'docs', 'astro.config.mjs'), 'utf8')
@@ -136,8 +142,9 @@ const checkTarget = (sourceLabel: string, link: string, sourceFile?: string) => 
   }
 
   // Root-level files (favicon.ico, apple-touch-icon.png, …) live in docs/assets
-  // or docs/public and are copied to the site root at build time.
-  if (/^\/[^/]+\.[a-z0-9]+$/i.test(cleanPath)) {
+  // or docs/public and are copied to the site root at build time. Endpoint routes
+  // look the same (/llms.txt) but are generated, so they are matched as routes below.
+  if (!routeFiles.has(cleanPath) && /^\/[^/]+\.[a-z0-9]+$/i.test(cleanPath)) {
     const file = cleanPath.slice(1)
     if (![join(repoRoot, 'docs', 'assets', file), join(repoRoot, 'docs', 'public', file)].some((p) => existsSync(p))) {
       errors.push(`${sourceLabel}: dead asset link "${link}"`)

--- a/docs/layouts/DocsLayout.astro
+++ b/docs/layouts/DocsLayout.astro
@@ -48,6 +48,8 @@ interface Props {
 	hidePagination?: boolean | undefined;
 	/** repo-relative source path for the "Edit this page" link, e.g. "docs/content/ui/components/alert.mdx" */
 	editPath?: string | undefined;
+	/** url of this page's markdown mirror (see pages/[...slug].md.ts); omitted for pages outside the docs collection */
+	markdownUrl?: string | undefined;
 }
 
 const {
@@ -63,6 +65,7 @@ const {
 	related = [],
 	hidePagination = false,
 	editPath,
+	markdownUrl,
 } = Astro.props;
 
 // Always-on plugin styles. Heavy demo-only sheets (flags, payments, socials)
@@ -218,6 +221,10 @@ const relatedPages = await Promise.all(
 
 		<title>{metaTitle} | {siteName}</title>
 		{isVercelPreview && <meta name="robots" content="noindex" />}
+
+		<!-- Markdown for LLMs: the docs index and this page's own .md mirror. -->
+		<link rel="alternate" type="text/plain" href="/llms.txt" title="llms.txt" />
+		{markdownUrl && <link rel="alternate" type="text/markdown" href={markdownUrl} title={`${title} (markdown)`} />}
 		{
 			environment === 'production' && (
 				<Fragment>

--- a/docs/lib/llms.ts
+++ b/docs/lib/llms.ts
@@ -1,0 +1,163 @@
+// Source-level MDX → plain markdown, for the /llms.txt endpoints.
+//
+// The docs are MDX: prose is already markdown, but the parts that carry the most
+// value for a reader (the actual Tabler markup) sit inside <Example> slots and
+// component props. Stripping components wholesale — the usual llms.txt recipe —
+// would delete exactly that. So the components that hold content are unwrapped
+// into fenced code blocks instead, and only the decorative ones are dropped.
+import type { CollectionEntry } from 'astro:content'
+import { extractMarkedSnippet } from '@shared/lib/code-example'
+import { site } from '@shared/lib/site'
+import packageManagers from '@data/package-managers.json'
+
+// Lazy raw imports, same as CodeDocs.astro — node:fs paths break once this is
+// bundled into dist/.prerender.
+const scssSources = import.meta.glob('../../core/scss/**/*.scss', { query: '?raw', import: 'default' })
+const jsSources = import.meta.glob('../../core/js/**/*.{js,ts}', { query: '?raw', import: 'default' })
+
+const fence = (code: string, lang = 'html') => `\`\`\`${lang}\n${code.trim()}\n\`\`\``
+
+/** Strip the common leading indentation from a block and trim blank edges. */
+const dedent = (text: string) => {
+  const lines = text.replace(/^\n+|\s+$/g, '').split('\n')
+  const indents = lines.filter((line) => line.trim()).map((line) => (line.match(/^[ \t]*/)?.[0] ?? '').length)
+  const min = indents.length ? Math.min(...indents) : 0
+  return lines.map((line) => line.slice(min)).join('\n')
+}
+
+/** Replace every match of `pattern`, awaiting an async replacer for each one. */
+async function replaceAsync(input: string, pattern: RegExp, replacer: (match: RegExpExecArray) => Promise<string>) {
+  const matches = [...input.matchAll(pattern)]
+  if (!matches.length) return input
+
+  const replacements = await Promise.all(matches.map((match) => replacer(match as RegExpExecArray)))
+
+  let result = ''
+  let last = 0
+  matches.forEach((match, index) => {
+    result += input.slice(last, match.index) + replacements[index]
+    last = (match.index ?? 0) + match[0].length
+  })
+  return result + input.slice(last)
+}
+
+const attr = (tag: string, name: string) => tag.match(new RegExp(`${name}=["']([^"']*)["']`))?.[1] ?? null
+
+/** `<CodeDocs name file />` → the marked snippet from the real source file. */
+async function resolveCodeDocs(tag: string): Promise<string> {
+  const file = attr(tag, 'file')
+  const name = attr(tag, 'name')
+  if (!file || !name) return ''
+
+  const extension = file.split('.').pop()
+  const kind = extension === 'scss' ? { sources: scssSources, marker: 'scss-docs', lang: 'scss' } : extension === 'ts' || extension === 'js' ? { sources: jsSources, marker: 'js-docs', lang: extension } : null
+  if (!kind) return ''
+
+  const load = kind.sources[`../../${file}`]
+  if (!load) return ''
+
+  let source = (await load()) as string
+  if (kind.lang === 'scss') source = source.replaceAll(' !default', '')
+
+  const snippet = extractMarkedSnippet(source, kind.marker, name)
+  return snippet ? `${fence(snippet, kind.lang)}\n\n_Source: \`${file}\`_` : ''
+}
+
+// Placeholder sentinel for code that must survive the component stripping below.
+// A private-use code point cannot appear in the docs source, so a placeholder can
+// never collide with prose.
+const SENTINEL = String.fromCharCode(0xe000)
+const placeholder = (index: number) => `${SENTINEL}${index}${SENTINEL}`
+const placeholderPattern = new RegExp(`${SENTINEL}(\\d+)${SENTINEL}`, 'g')
+
+/**
+ * Swap fenced blocks and inline code for placeholders, so the component stripping
+ * never reaches inside them. Without this, an `<Alert />` shown as example markup
+ * and an `import App from './App.vue'` line in a framework guide would both be
+ * deleted as if they were real MDX.
+ */
+function protectCode(text: string, store: string[]) {
+  return text.replace(/```[\s\S]*?```|`[^`\n]*`/g, (match) => {
+    store.push(match)
+    return placeholder(store.length - 1)
+  })
+}
+
+/** Placeholders can nest (a rewritten block may contain protected code), so repeat until stable. */
+function restoreCode(text: string, store: string[]) {
+  let result = text
+  while (result.includes(SENTINEL)) {
+    const next = result.replace(placeholderPattern, (_match, index: string) => store[Number(index)] ?? '')
+    // a sentinel that resolves to nothing would otherwise loop forever
+    if (next === result) break
+    result = next
+  }
+  return result
+}
+
+/** Turn one page's MDX body into plain markdown. */
+export async function mdxToMarkdown(body: string): Promise<string> {
+  // `<Code lang code={`…`} />` first: its template literal contains backticks, which
+  // would otherwise be mistaken for markdown code spans by protectCode() below.
+  let text = body.replace(/<Code\b[^>]*?code=\{`([\s\S]*?)`\}[\s\S]*?\/>/g, (match, snippet: string) => {
+    const lang = attr(match, 'lang') ?? 'html'
+    return `\n${fence(snippet.replaceAll('${site.cdnUrl}', site.cdnUrl), lang)}\n`
+  })
+
+  const code: string[] = []
+  // code the page already had, before anything is rewritten
+  text = protectCode(text, code)
+
+  // top-level imports are wiring, not content
+  text = text.replace(/^import\s+.+?from\s+['"][^'"]+['"];?[ \t]*$/gm, '')
+
+  // <Example> slots hold the markup the page is actually documenting
+  text = text.replace(/<Example\b[^>]*>([\s\S]*?)<\/Example>/g, (_match, inner: string) => {
+    const snippet = dedent(inner)
+    return snippet ? `\n${fence(snippet)}\n` : ''
+  })
+
+  text = await replaceAsync(text, /<CodeDocs\b[^>]*\/>/g, (match) => resolveCodeDocs(match[0]))
+
+  // install instructions rendered as tabs in the browser
+  text = text.replace(/<TabsPackage\b[^>]*\/>/g, (match: string) => {
+    const name = attr(match, 'name')
+    if (!name) return ''
+    const commands = packageManagers.map((manager) => `${manager.command} ${manager.install} ${name}`)
+    return `\n${fence(commands.join('\n'), 'shell')}\n`
+  })
+
+  text = text.replace(/<CdnImportPackage\b[^>]*\/>/g, () => `\n${fence(`<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler.min.css" />\n<script src="${site.cdnUrl}/dist/js/tabler.min.js"></script>`)}\n`)
+
+  text = text.replace(/<CdnImportPlugin\b[^>]*\/>/g, (match: string) => {
+    const plugins = [...match.matchAll(/'([^']+)'/g)].map((plugin) => plugin[1])
+    if (!plugins.length) return ''
+    const links = plugins.map((plugin) => `<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler-${plugin}.min.css" />`)
+    return `\n${fence(links.join('\n'))}\n`
+  })
+
+  // the blocks just produced must be protected too, for the same reason
+  text = protectCode(text, code)
+
+  // decorative self-closing components (icons, illustrations, charts, …)
+  text = text.replace(/<[A-Z][A-Za-z]*\b[^>]*\/>/g, '')
+  // anything else that wraps content: drop the tags, keep what is inside
+  text = text.replace(/<\/?[A-Z][A-Za-z]*\b[^>]*>/g, '')
+  // MDX comments and leftover JSX expressions
+  text = text.replace(/\{\/\*[\s\S]*?\*\/\}/g, '')
+
+  return restoreCode(text, code)
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+/** A single docs page as a standalone markdown document. */
+export async function pageMarkdown(entry: CollectionEntry<'docs'>, url: string): Promise<string> {
+  const { title, summary, description } = entry.data
+  const header = [`# ${title}`, '', `> ${summary}`, '', description, '', `Source: ${url}`, '', '---', ''].join('\n')
+
+  return `${header}\n${await mdxToMarkdown(entry.body ?? '')}\n`
+}
+
+/** Absolute in production, root-relative in dev — same rule as sitemap.xml.ts. */
+export const baseUrl = () => (process.env.NODE_ENV === 'development' ? '' : site.docsUrl)

--- a/docs/pages/[...slug].astro
+++ b/docs/pages/[...slug].astro
@@ -38,6 +38,7 @@ const toc = headings.filter((heading) => heading.depth === 2 || heading.depth ==
   hidePagination={data.hidePagination}
   toc={toc}
   url={docsUrlFromId(entry.id)}
+  markdownUrl={`/${entry.id}.md`}
   editPath={entry.filePath ? `docs/${entry.filePath}` : undefined}
 >
   <Content />

--- a/docs/pages/[...slug].md.ts
+++ b/docs/pages/[...slug].md.ts
@@ -1,0 +1,30 @@
+// Markdown mirror of every docs page: append `.md` to any docs url.
+// `/ui/components/button` → `/ui/components/button.md`. The home page is
+// `/index.md`, since `/.md` is not a usable route.
+import type { APIRoute, GetStaticPaths } from 'astro'
+import { getCollection } from 'astro:content'
+import { docsUrlFromId } from '@lib/docs-pages'
+import { baseUrl, pageMarkdown } from '@lib/llms'
+
+export const prerender = true
+
+export const getStaticPaths = (async () => {
+  const entries = await getCollection('docs')
+
+  return entries.map((entry) => ({
+    // ids already mirror the page url, and `index` keeps the home page addressable
+    params: { slug: entry.id },
+    props: { entry },
+  }))
+}) satisfies GetStaticPaths
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as { entry: Awaited<ReturnType<typeof getCollection<'docs'>>>[number] }
+  const body = await pageMarkdown(entry, `${baseUrl()}${docsUrlFromId(entry.id)}`)
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+    },
+  })
+}

--- a/docs/pages/llms.txt.ts
+++ b/docs/pages/llms.txt.ts
@@ -1,0 +1,73 @@
+// https://llmstxt.org — index of the docs, pointing at the .md mirror of each
+// page (see [...slug].md.ts). Order and grouping follow the sidebar tree in
+// docs.json; any page missing from that tree still lands in "Other", so the
+// index can never silently omit a page.
+import type { APIRoute } from 'astro'
+import { getCollection } from 'astro:content'
+import docs from '@data/docs.json'
+import { site } from '@shared/lib/site'
+import { docsUrlFromId } from '@lib/docs-pages'
+import { baseUrl } from '@lib/llms'
+
+export const prerender = true
+
+type MenuNode = { title?: string; url?: string; children?: MenuNode[] }
+
+const normalizeUrl = (url: string) => {
+  const parts = url.split('/').filter(Boolean)
+  return parts.length ? `/${parts.join('/')}` : '/'
+}
+
+export const GET: APIRoute = async () => {
+  const entries = await getCollection('docs')
+  const byUrl = new Map(entries.map((entry) => [docsUrlFromId(entry.id), entry]))
+  const base = baseUrl()
+  const listed = new Set<string>()
+
+  const item = (url: string) => {
+    const entry = byUrl.get(url)
+    if (!entry || listed.has(url)) return null
+    listed.add(url)
+    // `/` has no `.md` sibling — its mirror is `/index.md`
+    return `- [${entry.data.title}](${base}${url === '/' ? '/index' : url}.md): ${entry.data.description}`
+  }
+
+  const sections: string[] = []
+  for (const group of docs.menu as MenuNode[]) {
+    for (const section of group.children ?? []) {
+      const urls = [section.url, ...(section.children ?? []).map((child) => child.url)].filter((url): url is string => typeof url === 'string' && url.startsWith('/'))
+      const lines = urls.map((url) => item(normalizeUrl(url))).filter(Boolean)
+      if (lines.length) {
+        sections.push(`## ${group.title} — ${section.title}\n\n${lines.join('\n')}`)
+      }
+    }
+  }
+
+  const remaining = [...byUrl.keys()]
+    .filter((url) => !listed.has(url))
+    .sort((a, b) => (a === '/' ? -1 : b === '/' ? 1 : a.localeCompare(b)))
+    .map((url) => item(url))
+    .filter(Boolean)
+  if (remaining.length) {
+    sections.push(`## Other\n\n${remaining.join('\n')}`)
+  }
+
+  const body = `# Tabler
+
+> ${site.description}
+
+Tabler is a free and open source dashboard UI kit built on Bootstrap. This file indexes the documentation at ${site.docsUrl}.
+
+Every page is available as markdown by appending \`.md\` to its url, for example \`${site.docsUrl}/ui/components/button.md\`. Those files contain the same prose as the html page plus the markup of every example, as fenced code blocks.
+
+The markup is taken from the documentation source. A small number of examples are written with Tabler's own documentation components, and those appear as component tags (for example \`<Alert type="success" />\`) instead of the final html; open the page itself for those.
+
+${sections.join('\n\n')}
+`
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- Adds `/llms.txt` ([llmstxt.org](https://llmstxt.org)), an index of all 133 docs pages grouped by the sidebar tree. It is built from the content collection, so a page missing from `docs.json` still shows up under "Other" and can never be silently left out.
- Mirrors every page as markdown at `<url>.md` — `/ui/components/button` → `/ui/components/button.md`. Appending `.md` is guessable without reading the index first. The home page is `/index.md`, since `/.md` is not a usable route.
- The markdown keeps what makes these docs worth reading: `<Example>` slots become fenced html blocks, `<CodeDocs>` resolves to the real SCSS/JS snippet, and the install and CDN components become shell and html blocks. The usual llms.txt recipe deletes components wholesale, which here would have removed the Tabler markup itself.
- Both files are linked from the docs `<head>` with `rel="alternate"`.

Stacked on `migrate-docs-to-content-collections` — `entry.body` from the collection is what makes this tractable. Merge that one first.

## Preview

- **URL:** [/llms.txt](https://tabler-docs-git-add-llms-txt-tabler-io.vercel.app/llms.txt)
- **How to test:** Open [/llms.txt](https://tabler-docs-git-add-llms-txt-tabler-io.vercel.app/llms.txt) and check the sections match the sidebar. Then open a page-heavy example, [/ui/components/button.md](https://tabler-docs-git-add-llms-txt-tabler-io.vercel.app/ui/components/button.md), and confirm each example is a fenced html block with real Tabler markup. [/ui/forms/form-input-mask.md](https://tabler-docs-git-add-llms-txt-tabler-io.vercel.app/ui/forms/form-input-mask.md) shows the install commands, and [/ui/forms/form-validation.md](https://tabler-docs-git-add-llms-txt-tabler-io.vercel.app/ui/forms/form-validation.md) shows a resolved `<CodeDocs>` snippet. View source on any docs page to see the two `rel="alternate"` links.

## Notes / rollout

- **Known limitation:** 56 of 731 code blocks (7.7%, across 27 pages) come from examples written with Tabler's own doc components, so they show `<Alert type="success" />` instead of the final html. The remaining 675 blocks are fine (586 plain html, 89 html containing an icon component). This is stated in the `llms.txt` header so consumers know. Rendering those properly means running pages through the Astro Container API at build time, which roughly doubles build cost — worth a separate discussion.
- The links **inside** the preview's `llms.txt` point at `docs.tabler.io`, not at the preview, because the urls are absolute in production builds — the same rule `sitemap.xml` already follows. They will 404 until this merges. Use the preview links above to read the files themselves.
- `llms-full.txt` is deliberately not included. All pages concatenated is about 600 KB, and the per-page files plus the index cover the same ground on demand.
- The link checker now knows about endpoint routes (`llms.txt.ts` → `/llms.txt`). Before this, linking `/robots.txt` or `/sitemap.xml` from a page would have been reported as a dead link too.