### PR TITLE
Format `<Example>` markup where MDX renders it unchanged

### DIFF
--- a/.build/reformat-mdx.ts
+++ b/.build/reformat-mdx.ts
@@ -10,11 +10,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const docs: string[] = sync(join(__dirname, '..', 'docs', 'pages', '**', '*.mdx'))
 
-async function formatHTML(htmlString: string): Promise<string> {
+async function formatHTML(htmlString: string, options: prettier.Options = {}): Promise<string> {
   try {
     const formattedHtml = await prettier.format(htmlString, {
       parser: 'html',
       printWidth: 100,
+      ...options,
     })
     return formattedHtml
   } catch (error) {
@@ -27,14 +28,60 @@ async function formatHTML(htmlString: string): Promise<string> {
 async function replaceAsync(str: string, regex: RegExp, asyncFn: (...args: string[]) => Promise<string>): Promise<string> {
   const matches = [...str.matchAll(regex)]
 
-  const replacements = await Promise.all(matches.map(async (match: RegExpMatchArray) => asyncFn(...match)))
+  const replacements = await Promise.all(matches.map(async (match: RegExpMatchArray) => asyncFn(...(match as unknown as string[]))))
 
-  let result = str
+  // Splice by match index. A string `.replace()` would hit the first occurrence
+  // every time, so two identical examples in one file would rewrite the same
+  // spot twice and leave the other untouched.
+  let result = ''
+  let last = 0
   matches.forEach((match: RegExpMatchArray, i: number) => {
-    result = result.replace(match[0], replacements[i])
+    const start = match.index ?? 0
+    result += str.slice(last, start) + replacements[i]
+    last = start + match[0].length
   })
 
-  return result
+  return result + str.slice(last)
+}
+
+/**
+ * `<Example>` slots hold the demo markup, so they get the same treatment as an
+ * ```html fence.
+ *
+ * Slots containing `{` are skipped. In MDX every unescaped brace is a JSX
+ * expression — a component prop (`title={…}`), or the template literal that
+ * `<script>` and `<style>` demos are wrapped in so their JS/CSS braces survive.
+ * The html parser either throws on those ("Opening tag not terminated") or
+ * reformats the embedded code and breaks the expression. Embedded formatting is
+ * off as a second guard.
+ *
+ * Empty lines are stripped: a blank line inside the slot would make MDX start a
+ * new paragraph and wrap the demo markup in a stray `<p>`.
+ */
+async function formatExamples(source: string): Promise<string> {
+  return replaceAsync(source, /(<Example\b[^>]*>\n)([\s\S]*?)(\n<\/Example>)/g, async (_m: string, open: string, inner: string, close: string) => {
+    // A space between two tags on one line is rendered, but JSX drops whitespace
+    // that contains a newline. Reflowing such an example would silently delete the
+    // gaps between, say, a row of buttons, so it is left alone.
+    if (inner.includes('{') || />[ \t]+</.test(inner)) return _m
+
+    // A line that does not start with a tag is markdown flow content: MDX renders
+    // it as its own <p>. Reflowing would fold it into a tag line and drop the
+    // paragraph, so those examples are left alone too.
+    const lines = inner.split('\n').filter((line) => line.trim())
+    if (!lines.every((line) => line.trim().startsWith('<'))) return _m
+
+    const formatted = (await formatHTML(inner, { embeddedLanguageFormatting: 'off' })).replace(/^\s*[\r\n]/gm, '').trim()
+
+    // Only take the result when every line starts with a tag. MDX parses the slot
+    // as markdown flow content, so a line starting with anything else changes what
+    // is rendered: text becomes a stray <p>, and prettier's inline-close artifact
+    // (`</a` then a lone `>`) is not valid JSX at all. Where prettier cannot format
+    // without breaking inline content, the example is left exactly as it was.
+    const isSafe = formatted.split('\n').every((line) => line.trim().startsWith('<'))
+
+    return formatted && isSafe ? open + formatted + close : _m
+  })
 }
 
 async function processFiles(): Promise<void> {
@@ -42,7 +89,7 @@ async function processFiles(): Promise<void> {
     const oldContent = readFileSync(file, 'utf8')
 
     // get codeblocks from markdown
-    const content = await replaceAsync(oldContent, /(```([a-z0-9]+).*?\n)(.*?)(```)/gs, async (m: string, m1: string, m2: string, m3: string, m4: string) => {
+    let content = await replaceAsync(oldContent, /(```([a-z0-9]+).*?\n)(.*?)(```)/gs, async (m: string, m1: string, m2: string, m3: string, m4: string) => {
       if (m2 === 'html') {
         let formattedHtml = await formatHTML(m3)
 
@@ -53,6 +100,8 @@ async function processFiles(): Promise<void> {
       }
       return m.trim()
     })
+
+    content = await formatExamples(content)
 
     if (content !== oldContent) {
       writeFileSync(file, content, 'utf8')

--- a/docs/pages/ui/components/card-gradient.mdx
+++ b/docs/pages/ui/components/card-gradient.mdx
@@ -20,7 +20,6 @@ Use the `.card-gradient` class on a `.card` element to apply the default gradien
 The example below shows the base gradient card style.
 
 <Example>
-
 <div class="card card-gradient">
   <div class="card-body">
     <h3 class="card-title">Total Revenue</h3>
@@ -34,7 +33,6 @@ The example below shows the base gradient card style.
 You can change the color of card gradient by adding a color class like `.card-gradient-primary` or `.card-gradient-success` to the `.card-gradient` element. You can choose any color from [full list of available colors](/ui/base/colors).
 
 <Example>
-
 <div class="card card-gradient card-gradient-primary">
   <div class="card-body">
     <h3 class="card-title">Primary</h3>
@@ -90,19 +88,16 @@ Use direction modifiers to control where the gradient flow starts.
 ```
 
 <Example>
-
 <div class="card card-gradient card-gradient-start card-gradient-purple">
   <div class="card-body">
     <h3 class="card-title">Start</h3>
   </div>
 </div>
-
 <div class="card card-gradient card-gradient-end card-gradient-purple">
   <div class="card-body">
     <h3 class="card-title">End</h3>
   </div>
 </div>
-
 <div class="card card-gradient card-gradient-bottom card-gradient-purple">
   <div class="card-body">
     <h3 class="card-title">Bottom</h3>
@@ -115,14 +110,12 @@ Use direction modifiers to control where the gradient flow starts.
 Add `.card-gradient-animated` to animate gradient direction over time.
 
 <Example>
-
 <div class="card card-gradient card-gradient-rainbow card-gradient-animated">
   <div class="card-body">
     <h3 class="card-title">Animated gradient</h3>
     <p class="text-secondary mb-0">Use this variant for visual emphasis on highlight cards.</p>
   </div>
 </div>
-
 <div class="card card-gradient card-gradient-sun card-gradient-animated">
   <div class="card-body">
     <h3 class="card-title">Animated gradient</h3>

--- a/docs/pages/ui/components/lightbox.mdx
+++ b/docs/pages/ui/components/lightbox.mdx
@@ -101,11 +101,7 @@ Use these attributes to control the media:
 Use `data-href` when the link should point somewhere else than the lightbox slide. The lightbox uses `data-href`, and `href` stays the normal link target.
 
 ```html
-<a
-  data-fslightbox="gallery"
-  data-href="/static/photos/large/photo.jpg"
-  href="/photos/12"
->
+<a data-fslightbox="gallery" data-href="/static/photos/large/photo.jpg" href="/photos/12">
   <img src="/static/photos/thumbs/photo.jpg" class="rounded" alt="Photo" />
 </a>
 ```
@@ -116,7 +112,6 @@ Set `href` to the id of an element on the page. The lightbox clones that element
 
 ```html
 <a data-fslightbox="custom" href="#vimeo-player">Open Vimeo video</a>
-
 <iframe
   id="vimeo-player"
   src="https://player.vimeo.com/video/22439234"

--- a/docs/pages/ui/components/vector-map.mdx
+++ b/docs/pages/ui/components/vector-map.mdx
@@ -27,7 +27,7 @@ To use vector maps in your project, you need to include the jsVectorMap library 
 Integrating the vector map into your website is straightforward. Below is a sample implementation for a world map:
 
 <Example codeOnly>
-  <MapVector mapId="empty" />
+<MapVector mapId="empty" />
 </Example>
 
 ## Sample demo
@@ -35,7 +35,7 @@ Integrating the vector map into your website is straightforward. Below is a samp
 Look at the example below to see how the vector map works with a world map.
 
 <Example>
-  <MapVector mapId="world" />
+<MapVector mapId="world" />
 </Example>
 
 ## Markers
@@ -43,7 +43,7 @@ Look at the example below to see how the vector map works with a world map.
 You can add markers to the map to highlight specific locations. Below is a sample implementation for a world map with markers:
 
 <Example>
-  <MapVector mapId="world-markers" />
+<MapVector mapId="world-markers" />
 </Example>
 
 ## Lines
@@ -51,5 +51,5 @@ You can add markers to the map to highlight specific locations. Below is a sampl
 You can also draw lines on the map to represent routes or connections between different locations. Below is a sample implementation for a world map with lines:
 
 <Example>
-  <MapVector mapId="world-lines" />
+<MapVector mapId="world-lines" />
 </Example>

--- a/docs/pages/ui/components/wysiwyg.mdx
+++ b/docs/pages/ui/components/wysiwyg.mdx
@@ -17,5 +17,5 @@ import Wysiwyg from '@ui/Wysiwyg.astro'
 Initialize HugeRTE on any element (or elements) on the web page by passing an object containing a selector value to `hugerte.init()`. The selector value can be any valid CSS selector.
 
 <Example>
-  <Wysiwyg />
+<Wysiwyg />
 </Example>

--- a/docs/pages/ui/forms/form-color-check.mdx
+++ b/docs/pages/ui/forms/form-color-check.mdx
@@ -21,7 +21,7 @@ Your input controls can come in a variety of colors, depending on your preferenc
 There is also an example of a color input:
 
 <Example>
-  <InputColor type="checkbox" />
+<InputColor type="checkbox" />
 </Example>
 
 If you need to select only one color, you can use the radio input type:

--- a/docs/pages/ui/plugins/flags.mdx
+++ b/docs/pages/ui/plugins/flags.mdx
@@ -23,7 +23,7 @@ You can also include the plugin via CDN:
 To create a flag, add the `flag` class to a component and choose the country whose flag you want to use.
 
 <Example>
-  <span class="flag flag-country-us"></span>
+<span class="flag flag-country-us"></span>
 </Example>
 
 ## Country flags
@@ -31,9 +31,9 @@ To create a flag, add the `flag` class to a component and choose the country who
 To use the flag of a particular country, add the `flag-country-(country name)` class. For example, to create a flag of Andorra, you should use the following class: `.flag-country-ad`. The full list of countries can be found at the end of this page.
 
 <Example>
-  <span class="flag flag-country-tg"></span>
-  <span class="flag flag-country-br"></span>
-  <span class="flag flag-country-pt"></span>
+<span class="flag flag-country-tg"></span>
+<span class="flag flag-country-br"></span>
+<span class="flag flag-country-pt"></span>
 </Example>
 
 ## Flag sizes
@@ -41,11 +41,11 @@ To use the flag of a particular country, add the `flag-country-(country name)` c
 Using Bootstrap’s typical naming structure, you can create a standard flag, or scale it up or down to different sizes based on what’s needed.
 
 <Example>
-  <span class="flag flag-xl flag-country-us"></span>
-  <span class="flag flag-lg flag-country-us"></span>
-  <span class="flag flag-md flag-country-us"></span>
-  <span class="flag flag-sm flag-country-us"></span>
-  <span class="flag flag-xs flag-country-us"></span>
+<span class="flag flag-xl flag-country-us"></span>
+<span class="flag flag-lg flag-country-us"></span>
+<span class="flag flag-md flag-country-us"></span>
+<span class="flag flag-sm flag-country-us"></span>
+<span class="flag flag-xs flag-country-us"></span>
 </Example>
 
 ## Flags list

--- a/docs/pages/ui/plugins/payments.mdx
+++ b/docs/pages/ui/plugins/payments.mdx
@@ -23,9 +23,9 @@ You can also include the plugin via CDN:
 To create a payment provider icon, add the `payment` class to a component and specify the payment provider with the `payment-provider-*` class. The full list of payment providers can be found at the end of this page.
 
 <Example>
-  <span class="payment payment-provider-shopify"></span>
-  <span class="payment payment-provider-visa"></span>
-  <span class="payment payment-provider-paypal"></span>
+<span class="payment payment-provider-shopify"></span>
+<span class="payment payment-provider-visa"></span>
+<span class="payment payment-provider-paypal"></span>
 </Example>
 
 ## Payment sizes
@@ -33,11 +33,11 @@ To create a payment provider icon, add the `payment` class to a component and sp
 Using Bootstrap’s typical naming structure, you can create a standard payment, or scale it up or down to different sizes based on what’s needed.
 
 <Example>
-  <span class="payment payment-xl payment-provider-shopify"></span>
-  <span class="payment payment-lg payment-provider-visa"></span>
-  <span class="payment payment-md payment-provider-paypal"></span>
-  <span class="payment payment-sm payment-provider-amazon"></span>
-  <span class="payment payment-xs payment-provider-blik"></span>
+<span class="payment payment-xl payment-provider-shopify"></span>
+<span class="payment payment-lg payment-provider-visa"></span>
+<span class="payment payment-md payment-provider-paypal"></span>
+<span class="payment payment-sm payment-provider-amazon"></span>
+<span class="payment payment-xs payment-provider-blik"></span>
 </Example>
 
 ## List of available payment providers

--- a/docs/pages/ui/plugins/social-icons.mdx
+++ b/docs/pages/ui/plugins/social-icons.mdx
@@ -23,7 +23,6 @@ You can also include the plugin via CDN:
 To create a social icon, add the `social` class to a component and provide the class `social-app-*` with the social app whose icon you want to use.
 
 <Example>
-
 <span class="social social-app-facebook"></span>
 <span class="social social-app-x"></span>
 <span class="social social-app-instagram"></span>

--- a/docs/pages/ui/utilities/background-patterns.mdx
+++ b/docs/pages/ui/utilities/background-patterns.mdx
@@ -82,9 +82,7 @@ Use `.bg-pattern-transparent` when you need a checkerboard-style transparent bac
   <Illustration image="boy-with-key.svg" class="d-block mx-auto mw-100" height={200} />
 </Example>
 <Example codeOnly>
-  <div class="bg-pattern-transparent p-4">
-
-  </div>
+<div class="bg-pattern-transparent p-4"></div>
 </Example>
 
 ## Pattern sizes
@@ -99,7 +97,6 @@ Use size utilities to control pattern density:
 Look at the following examples to see how the pattern sizes work:
 
 <Example hideCode>
-
 <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-3">
   <div class="col">
     <div class="bg-pattern-circles bg-pattern-sm rounded mb-2" style="height: 6rem;"></div>

--- a/docs/pages/ui/utilities/gradients.mdx
+++ b/docs/pages/ui/utilities/gradients.mdx
@@ -116,15 +116,15 @@ You can use any project color token with `from`, `via`, and `to` utilities. See 
 Use gradient utilities on card sections to highlight key content areas.
 
 <Example>
-  <div class="card">
-    <div class="card-body bg-gradient bg-gradient-from-indigo bg-gradient-to-transparent rounded-top">
-      <h3 class="card-title mb-1">Performance</h3>
-      <p class="text-secondary mb-0">Weekly trend overview</p>
-    </div>
-    <div class="card-body">
-      <p class="mb-0">Card content</p>
-    </div>
+<div class="card">
+  <div class="card-body bg-gradient bg-gradient-from-indigo bg-gradient-to-transparent rounded-top">
+    <h3 class="card-title mb-1">Performance</h3>
+    <p class="text-secondary mb-0">Weekly trend overview</p>
   </div>
+  <div class="card-body">
+    <p class="mb-0">Card content</p>
+  </div>
+</div>
 </Example>
 
 ### Badge-like highlight
@@ -132,7 +132,6 @@ Use gradient utilities on card sections to highlight key content areas.
 Use short gradients on compact UI elements for subtle emphasis.
 
 <Example>
-
 <div class="d-flex gap-2 flex-wrap">
   <span class="badge bg-gradient bg-gradient-from-green bg-gradient-to-teal">Success trend</span>
   <span class="badge bg-gradient bg-gradient-from-orange bg-gradient-to-red">Warning trend</span>


### PR DESCRIPTION
## Summary

- `reformat-mdx` now formats the markup inside `<Example>` slots, not only ```html fences.
- It only takes prettier's result where MDX is guaranteed to render the same thing. Slots with a JSX brace, with a rendered space between two tags, or with a text line are left exactly as they were. That is 57 of 435 examples today; 10 files change.
- Fixes `replaceAsync`, which spliced with `String.replace(match[0], …)` and so hit the first occurrence for every match. Two identical blocks in one file meant one was rewritten twice and the other never. This is what changes `lightbox.mdx` below — a fence that had never actually been formatted.

**Why the coverage is small.** MDX parses an `<Example>` slot as JSX, and JSX drops whitespace that contains a newline — HTML renders it as a space. Breaking `</a> <a` across two lines therefore deletes the gap between them. I verified this directly: breaking one line of the button example changed the built html from `</a> <a` to `</a><a`. 321 of the 435 examples are single lines of tags separated by spaces, so reflowing them would silently close up rows of buttons, badges and avatars. Covering those means replacing the spaces with a spacing utility (`gap-*` on the wrapper) — a content change, not a formatter change, and worth its own PR.

## Preview

- **URL:** [/ui/components/lightbox](https://tabler-docs-git-format-example-markup-tabler-io.vercel.app/ui/components/lightbox)
- **How to test:** This should be invisible. I built the docs before and after and compared all 134 rendered pages; exactly one differs, [/ui/components/lightbox](https://tabler-docs-git-format-example-markup-tabler-io.vercel.app/ui/components/lightbox), where the "Custom href" code sample now has its attributes on one line and a stray blank line removed — the `replaceAsync` fix, not the new formatting. Spot-check a reformatted page such as [/ui/plugins/flags](https://tabler-docs-git-format-example-markup-tabler-io.vercel.app/ui/plugins/flags) or [/ui/utilities/gradients](https://tabler-docs-git-format-example-markup-tabler-io.vercel.app/ui/utilities/gradients) against production: the demos and the code panels should be identical.

## Notes / rollout

- Re-running `pnpm run format` is idempotent — a second pass changes nothing.
- The guards are deliberately conservative. If a future example is skipped that looks like it should not be, the reason is one of the three listed above, and loosening any of them changes rendered output.
