### PR TITLE
Remove the docs surface background, gradient, and edit-page link

### DIFF
--- a/.changeset/docs-readability-pass.md
+++ b/.changeset/docs-readability-pass.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Updated docs readability: white example panels joined with their code, larger headings, and a narrower text measure.

--- a/.changeset/remove-docs-edit-page-link.md
+++ b/.changeset/remove-docs-edit-page-link.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Removed the "Edit this page on GitHub" link and the `editPath` prop from the docs layout.

--- a/.changeset/remove-docs-surface-background.md
+++ b/.changeset/remove-docs-surface-background.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Removed the `<body>` background and the `.bg-docs-gradient` utility from the docs layout.

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -1570,6 +1570,48 @@ svg.DocSearch-Hit-Select-Icon {
   width: 15rem;
 }
 
+/* Running text keeps a comfortable measure of about 70 characters; demos, code
+   and tables stay full width. Direct children only, so markup inside demos is
+   left alone. Geist's `0` is much wider than its average glyph, so 61ch reads
+   as roughly 70 characters, not 61. */
+.prose > p,
+.prose > ul,
+.prose > ol,
+.prose > dl,
+.prose > blockquote,
+.prose > h2,
+.prose > h3,
+.prose > h4 {
+  max-width: 61ch;
+}
+
+/* Docs pages need more heading contrast than the dashboard scale gives: there,
+   h3 matches the body size and only differs in weight. */
+.docs-page-header h1 {
+  font-size: 1.875rem;
+  line-height: 1.2;
+}
+
+.prose > h2 {
+  font-size: 1.375rem;
+  line-height: 1.3;
+}
+
+.prose > h3 {
+  font-size: 1.125rem;
+}
+
+/* The code panel is flush with the demo above it. It carries the lower half of
+   the shared outline: in dark mode the code background matches the page, so
+   without a border the card would have no bottom edge. */
+.example-code .shiki {
+  margin-bottom: 0;
+  border: 1px solid var(--tblr-border-color);
+  border-block-start: 0;
+  border-start-start-radius: 0;
+  border-start-end-radius: 0;
+}
+
 .DocSearch-Button {
   width: 100%;
   box-shadow: 0 0 0 1px var(--tblr-border-color);

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -1570,12 +1570,6 @@ svg.DocSearch-Hit-Select-Icon {
   width: 15rem;
 }
 
-@media (min-width: 992px) {
-  .bg-docs-gradient {
-    background: radial-gradient(circle at 0 0, color-mix(in srgb, var(--tblr-primary) 4%, transparent), transparent 80%) no-repeat 0 0/800px 800px !important;
-  }
-}
-
 .DocSearch-Button {
   width: 100%;
   box-shadow: 0 0 0 1px var(--tblr-border-color);

--- a/docs/components/Example.astro
+++ b/docs/components/Example.astro
@@ -5,11 +5,11 @@ import { beautifyHtml, highlightCode, removeHref } from '@shared/lib/code-exampl
 
 /**
  * Demo area background:
- * - surface-secondary — muted solid surface (default)
+ * - surface — theme-aware white, one step above the page background (default)
+ * - surface-secondary — muted solid surface, same tone as the page background
  * - transparent — checkerboard pattern, for components with their own background
- * - primary — theme-aware white (bg-surface)
  */
-type ExampleBackground = 'surface-secondary' | 'transparent' | 'primary'
+type ExampleBackground = 'surface' | 'surface-secondary' | 'transparent'
 
 interface Props {
   /** raw HTML of the example; when absent — the slot is rendered */
@@ -29,12 +29,12 @@ interface Props {
   codeOnly?: boolean
 }
 
-const { html: htmlProp, code, raw, overflow = 'auto', background = 'surface-secondary', class: className, height, column, centered, vertical, columnFullWidth, hideCode, codeOnly } = Astro.props
+const { html: htmlProp, code, raw, overflow = 'auto', background = 'surface', class: className, height, column, centered, vertical, columnFullWidth, hideCode, codeOnly } = Astro.props
 
 const backgroundClasses: Record<ExampleBackground, string> = {
+  'surface': 'bg-surface',
   'surface-secondary': 'bg-surface-secondary',
   'transparent': 'bg-pattern-rectangles',
-  'primary': 'bg-surface',
 }
 
 // Strip empty lines from the example HTML.
@@ -45,7 +45,11 @@ let html = (htmlProp ?? (await Astro.slots.render('default'))).replace(/^\s*[\r\
 // code in the panel looks like hand-written HTML.
 html = html.replace(/<(path|circle|line|polyline|polygon|rect|ellipse)([^>]*?)\s*><\/\1>/g, '<$1$2 />').replace(/&#39;/g, "'")
 
-const exampleClasses = ['example fs-base border rounded my-5', !raw && 'd-flex flex-wrap justify-content-center', `overflow-${overflow}`, 'position-relative', backgroundClasses[background], className]
+// The demo and its code panel sit flush against each other so they read as one
+// card; a demo without code keeps all four corners and its own bottom margin.
+const joined = !hideCode && !codeOnly
+
+const exampleClasses = ['example fs-base border mt-5', joined ? 'rounded-top border-bottom-0 mb-0' : 'rounded mb-5', !raw && 'd-flex flex-wrap justify-content-center', `overflow-${overflow}`, 'position-relative', backgroundClasses[background], className]
 
 const innerClasses = ['p-6 w-full', column && 'd-flex gap-3 flex-column', !column && centered && `d-flex flex-fill flex-wrap gap-2 justify-content-center${vertical ? ' align-items-center flex-column' : ' justify-content-center'}`, columnFullWidth && 'd-flex flex-fill flex-column gap-2']
 
@@ -68,7 +72,7 @@ const highlighted = hideCode ? '' : await highlightCode(beautifyHtml(code ?? htm
 
 {
   !hideCode && (
-    <div class="position-relative">
+    <div class:list={['position-relative', joined && 'example-code mb-5']}>
       <a class="btn btn-icon btn-dark position-absolute m-2 top-0 end-0 z-3" data-clipboard-text={code ?? html}>
         <Icon name="clipboard" />
         <Icon name="check" class="d-none" />

--- a/docs/layouts/DocsLayout.astro
+++ b/docs/layouts/DocsLayout.astro
@@ -291,7 +291,7 @@ const relatedPages = await Promise.all(
 		<!-- END DOCS STYLES -->
 	</head>
 
-	<body class="d-flex flex-column" style="background: var(--tblr-bg-surface)">
+	<body class="d-flex flex-column">
 		<a href="#content" class="visually-hidden-focusable skip-link">Skip to main content</a>
 		<!-- BEGIN GLOBAL THEME SCRIPT -->
 		<script is:inline src="/dist/js/tabler-theme.js"></script>
@@ -328,7 +328,7 @@ const relatedPages = await Promise.all(
 						</div>
 					</div>
 					<!-- END DOCS MENU -->
-					<div class="col bg-docs-gradient">
+					<div class="col">
 						<div class="py-lg-5 ps-lg-5">
 							<div class="py-6 ps-lg-6 p-xxl-6">
 								{breadcrumbs && (

--- a/docs/layouts/DocsLayout.astro
+++ b/docs/layouts/DocsLayout.astro
@@ -34,8 +34,7 @@ interface Props {
 	/**
 	 * Page URL in the docs namespace, e.g. "/ui/components/alert".
 	 * By default derived from Astro.url.pathname by stripping the /docs prefix.
-	 * Drives the active menu entry, pagination, the "Edit this page" link, and
-	 * the relative favicon path.
+	 * Drives the active menu entry, pagination, and the relative favicon path.
 	 */
 	url?: string | undefined;
 	/** Extra libraries from libs.json (css+js) */
@@ -46,8 +45,6 @@ interface Props {
 	related?: string[];
 	/** hides child and previous/next page navigation */
 	hidePagination?: boolean | undefined;
-	/** repo-relative source path for the "Edit this page" link, e.g. "docs/content/ui/components/alert.mdx" */
-	editPath?: string | undefined;
 	/** url of this page's markdown mirror (see pages/[...slug].md.ts); omitted for pages outside the docs collection */
 	markdownUrl?: string | undefined;
 }
@@ -64,7 +61,6 @@ const {
 	cssPlugins = [],
 	related = [],
 	hidePagination = false,
-	editPath,
 	markdownUrl,
 } = Astro.props;
 
@@ -109,11 +105,6 @@ const ogImageUrl = new URL('/static/og.png', Astro.site ?? site.docsUrl).href;
 // Relative asset base: for /ui/components/alert/ -> "../../.."
 const depth = docsUrl.split('/').filter(Boolean).length;
 const relative = depth === 0 ? '.' : '../'.repeat(depth).slice(0, -1);
-
-// Source path for the "Edit this page" link. Prefer the real path passed by the
-// route (from the collection entry); fall back to the flat-page convention.
-const editFilePath =
-	editPath ?? (docsUrl === '/' ? 'docs/content/index.mdx' : `docs/content${docsUrl.replace(/\/$/, '')}.mdx`);
 
 // docs-libs + clipboard (always included). In dev, file names stay unchanged
 // (e.g. dist/clipboard.min.js keeps .min).
@@ -389,15 +380,7 @@ const relatedPages = await Promise.all(
 									{!hidePagination && <DocsPagination url={docsUrl} />}
 
 									<div class="mt-7">
-										<div>
-											<a
-												href={`${site.githubUrl}/edit/dev/${editFilePath}`}
-												class="link-primary"
-												target="_blank" rel="noopener noreferrer"><Icon name="edit" class="icon-inline" /> Edit this page on GitHub</a
-											>
-										</div>
-
-										<nav class="mt-5" aria-label="Documentation sections">
+										<nav aria-label="Documentation sections">
 											<ul class="list-inline list-inline-dots mb-0 text-secondary">
 												{[
 													{ title: 'Getting started', url: '/ui/getting-started' },

--- a/docs/layouts/DocsLayout.astro
+++ b/docs/layouts/DocsLayout.astro
@@ -347,7 +347,7 @@ const relatedPages = await Promise.all(
 									data-bs-smooth-scroll="true"
 									tabindex="0"
 								>
-									<div class="d-flex">
+									<div class="d-flex docs-page-header">
 										<h1>
 											{title}
 										</h1>
@@ -361,7 +361,7 @@ const relatedPages = await Promise.all(
 										}
 									</div>
 
-									<p class="text-secondary fs-3 lh-3">{summary}</p>
+									<p class="text-secondary fs-2 lh-3">{summary}</p>
 
 									{/* Page must supply headings with ids (MDX does this by default). */}
 									<slot />

--- a/docs/pages/404.astro
+++ b/docs/pages/404.astro
@@ -14,7 +14,7 @@ const sections = [
 ]
 ---
 
-<DocsLayout title="Page not found" summary="The page you are looking for does not exist or has been moved." description="The page you are looking for does not exist. Browse the Tabler documentation sections or use the search." hidePagination url="/404" editPath="docs/pages/404.astro">
+<DocsLayout title="Page not found" summary="The page you are looking for does not exist or has been moved." description="The page you are looking for does not exist. Browse the Tabler documentation sections or use the search." hidePagination url="/404">
   <p>Check the address for typos, use the search at the top of the page, or start from one of the sections below.</p>
 
   <div class="mt-6">

--- a/docs/pages/[...slug].astro
+++ b/docs/pages/[...slug].astro
@@ -39,7 +39,6 @@ const toc = headings.filter((heading) => heading.depth === 2 || heading.depth ==
   toc={toc}
   url={docsUrlFromId(entry.id)}
   markdownUrl={`/${entry.id}.md`}
-  editPath={entry.filePath ? `docs/${entry.filePath}` : undefined}
 >
   <Content />
 </DocsLayout>


### PR DESCRIPTION
## Summary

- The docs `<body>` no longer carries an inline `background: var(--tblr-bg-surface)`, so pages use the theme's default body background.
- Removed the `.bg-docs-gradient` utility from `docs.css` and dropped the class from the content column, so the radial gradient behind docs content is gone.
- Removed the "Edit this page on GitHub" link and the machinery behind it: the `editPath` prop, the `editFilePath` fallback in `DocsLayout.astro`, and the `editPath` values passed from `[...slug].astro` and `404.astro`.

## Preview

- **URL:** [docs preview](https://tabler-docs-git-remove-docs-surface-background-tabler-io.vercel.app/ui/components/alert)
- **How to test:** Open any docs page. The page background should match the theme's default body color, with no tinted radial gradient in the top-left of the content column. Scroll to the bottom: the "Edit this page on GitHub" link is gone and the section links sit directly under the previous/next pagination. Check [the license page](https://tabler-docs-git-remove-docs-surface-background-tabler-io.vercel.app/ui/getting-started/license) and the 404 page too, since both used to pass a custom edit path. Toggle dark mode to confirm the background still follows the theme.
