### PR TITLE
Remove box-shadow from alerts

### DIFF
--- a/core/scss/ui/_alerts.scss
+++ b/core/scss/ui/_alerts.scss
@@ -26,7 +26,6 @@
   color: var(--alert-color);
   background-color: color-mix(in sRGB, var(--alert-bg), var(--bg-surface));
   border: var(--border-width) var(--border-style) var(--alert-border-color);
-  box-shadow: var(--box-shadow);
   @include border-radius(var(--alert-border-radius));
 }
 


### PR DESCRIPTION
## Summary

- Drop `box-shadow` from `.alert` so alerts sit flat without a drop shadow.

## Preview

- **URL:** [Alerts](https://tabler-git-remove-alerts-shadow-tabler-io.vercel.app/alerts.html)
- **How to test:** Open the Alerts page and check default, important, and important-with-icon alerts. They should have no drop shadow. Spot-check light and dark theme.