### PR TITLE
Fix icon–text gap in Tom Select dropdown options

### DIFF
--- a/core/scss/ui/_dropdowns.scss
+++ b/core/scss/ui/_dropdowns.scss
@@ -30,7 +30,7 @@
 
 .dropdown-item {
   display: flex;
-  gap: var(--dropdown-item-gap);
+  gap: var(--dropdown-item-gap, #{$dropdown-item-gap});
   align-items: center;
   min-width: $dropdown-min-width;
   margin: 0;

--- a/shared/components/forms/FormElements1.astro
+++ b/shared/components/forms/FormElements1.astro
@@ -161,7 +161,7 @@ const states = (selects as { states: { options: Record<string, { name: string; s
 
       const renderOption = (data, escape) => {
         if (data.customProperties) {
-          return `<div><span class="dropdown-item-indicator">${data.customProperties}</span>${escape(data.text)}</div>`
+          return `<div class="dropdown-item"><span class="dropdown-item-indicator">${data.customProperties}</span>${escape(data.text)}</div>`
         }
         return `<div>${escape(data.text)}</div>`
       }

--- a/shared/ui/Select.astro
+++ b/shared/ui/Select.astro
@@ -126,7 +126,7 @@ const selectId = id ? `select-${id}` : undefined;
 
 					const renderOption = (data, escape) => {
 						if (data.customProperties) {
-							return `<div><span class="dropdown-item-indicator">${data.customProperties}</span>${escape(data.text)}</div>`;
+							return `<div class="dropdown-item"><span class="dropdown-item-indicator">${data.customProperties}</span>${escape(data.text)}</div>`;
 						}
 						return `<div>${escape(data.text)}</div>`;
 					};


### PR DESCRIPTION
## Summary

- Give Tom Select custom options the `dropdown-item` class so icon + label use the same flex gap as other dropdown items.
- Add a Sass fallback on `.dropdown-item` gap (`var(--dropdown-item-gap, #{$dropdown-item-gap})`) so spacing still works when the custom property is missing.

## Preview

- **URL:** [Form elements](https://tabler-git-fix-gap-in-select-tabler-io.vercel.app/form-elements.html)
- **How to test:** Open Form elements and use selects that show icons in options (e.g. countries / custom property items). The icon and label should have a clear gap, matching normal dropdown items.