### PR TITLE
Mark only 1.5 pages with the `New` badge in the menu

### DIFF
--- a/.changeset/menu-new-badges.md
+++ b/.changeset/menu-new-badges.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": patch
+---
+
+Updated `New` badges in `menu.json` to mark only pages added since 1.4, and dropped them from older pages.

--- a/shared/data/menu.json
+++ b/shared/data/menu.json
@@ -26,12 +26,12 @@
     "children": {
       "all-elements": {
         "title": "All Elements",
-        "url": "all-elements.html"
+        "url": "all-elements.html",
+        "badge": "New"
       },
       "accordion": {
         "title": "Accordion",
-        "url": "accordion.html",
-        "badge": "New"
+        "url": "accordion.html"
       },
       "alerts": {
         "title": "Alerts",
@@ -84,8 +84,7 @@
       },
       "avatars": {
         "url": "avatars.html",
-        "title": "Avatars",
-        "badge": "New"
+        "title": "Avatars"
       },
       "badges": {
         "url": "badges.html",
@@ -108,8 +107,7 @@
           },
           "actions": {
             "url": "card-actions.html",
-            "title": "Card actions",
-            "badge": "New"
+            "title": "Card actions"
           },
           "gradients": {
             "url": "card-gradients.html",
@@ -190,18 +188,15 @@
       },
       "progress": {
         "url": "progress.html",
-        "title": "Progress",
-        "badge": "New"
+        "title": "Progress"
       },
       "segmented-control": {
         "title": "Segmented control",
-        "url": "segmented-control.html",
-        "badge": "New"
+        "url": "segmented-control.html"
       },
       "scroll-spy": {
         "title": "Scroll spy",
-        "url": "scroll-spy.html",
-        "badge": "New"
+        "url": "scroll-spy.html"
       },
       "social": {
         "title": "Social icons",
@@ -251,8 +246,7 @@
       },
       "layout": {
         "url": "form-layout.html",
-        "title": "Form layouts",
-        "badge": "New"
+        "title": "Form layouts"
       }
     }
   },
@@ -296,7 +290,8 @@
       },
       "pay": {
         "title": "Pay",
-        "url": "pay.html"
+        "url": "pay.html",
+        "badge": "New"
       },
       "job-listing": {
         "title": "Job listing",
@@ -344,8 +339,7 @@
       },
       "signatures": {
         "title": "Signatures",
-        "url": "signatures.html",
-        "badge": "New"
+        "url": "signatures.html"
       },
       "tasks": {
         "title": "Tasks",
@@ -362,8 +356,7 @@
       },
       "text-features": {
         "title": "Text features",
-        "url": "text-features.html",
-        "badge": "New"
+        "url": "text-features.html"
       },
       "trial-ended": {
         "title": "Trial ended",
@@ -468,7 +461,8 @@
       },
       "sortable": {
         "title": "Sortable",
-        "url": "sortable.html"
+        "url": "sortable.html",
+        "badge": "New"
       },
       "fullcalendar": {
         "url": "fullcalendar.html",
@@ -496,7 +490,8 @@
       },
       "tour": {
         "url": "tour.html",
-        "title": "Tour"
+        "title": "Tour",
+        "badge": "New"
       },
       "wysiwyg": {
         "url": "wysiwyg.html",


### PR DESCRIPTION
## Summary

- The `New` badge in `menu.json` had drifted: it still sat on pages from 2019–2022 (Avatars, Progress, Accordion, Card actions) while four pages added since 1.4 had no badge at all.
- Set the badge only on pages first added after the 1.4.0 release (commit `2c73788c`, 2025-07-13): All Elements, Sortable, Pay, Tour, Email inbox, Crypto, Card gradients, Patterns, CRM.
- Removed it from nine older pages: Accordion, Avatars, Progress, Card actions, Segmented control, Scroll spy, Text features, Signatures, Form layouts.
- Prose looks new because `prose.md` was added in 2026, but it is the 2019 `markdown` page renamed, so it does not get a badge.

## Preview

- **URL:** [All Elements](https://tabler-git-update-menu-new-badges-tabler-io.vercel.app/all-elements.html)
- **How to test:** Open any preview page and look at the sidebar and the top navbar menus. Nine items should show the `New` badge: All Elements, Sortable, Pay, Tour, Email inbox, Crypto, Card gradients, Patterns and CRM. No other item should have one.