### PR TITLE
Move demo page titles, actions and docs links into the layout header

### DIFF
--- a/.changeset/card-title-heading-level.md
+++ b/.changeset/card-title-heading-level.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": patch
+---
+
+Fixed heading order by making `CardTitle` and `CardHeader` render `h2`, so cards no longer skip a level under the page `h1`.

--- a/.changeset/demo-page-titles-in-header.md
+++ b/.changeset/demo-page-titles-in-header.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": minor
+---
+
+Updated the demo pages to show their title and description in the page header, with `pageHeader` falling back to `title`.

--- a/.changeset/docs-link-component.md
+++ b/.changeset/docs-link-component.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": minor
+---
+
+Added a `DocsLink` component for the documentation link in the demo page headers.

--- a/.changeset/docs-link-component.md
+++ b/.changeset/docs-link-component.md
@@ -1,5 +1,0 @@
----
-"@tabler/preview": minor
----
-
-Added a `DocsLink` component for the documentation link in the demo page headers.

--- a/.changeset/drop-page-header-actions-presets.md
+++ b/.changeset/drop-page-header-actions-presets.md
@@ -1,5 +1,0 @@
----
-"@tabler/preview": minor
----
-
-Removed the `actions` preset prop from `DefaultLayout` — pages now pass header actions through the slot.

--- a/.changeset/drop-page-header-actions-presets.md
+++ b/.changeset/drop-page-header-actions-presets.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": minor
+---
+
+Removed the `actions` preset prop from `DefaultLayout` — pages now pass header actions through the slot.

--- a/.changeset/page-header-actions-slot.md
+++ b/.changeset/page-header-actions-slot.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": minor
+---
+
+Added a `page-header-actions` slot to `DefaultLayout` and moved the Interface demo page titles into the page header.

--- a/.changeset/page-header-actions-slot.md
+++ b/.changeset/page-header-actions-slot.md
@@ -2,4 +2,4 @@
 "@tabler/preview": minor
 ---
 
-Added a `page-header-actions` slot to `DefaultLayout` and moved the Interface demo page titles into the page header.
+Removed the `actions` preset prop from `DefaultLayout`; pages now fill a `page-header-actions` slot instead.

--- a/.changeset/page-header-defaults-to-title.md
+++ b/.changeset/page-header-defaults-to-title.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": minor
+---
+
+Updated `DefaultLayout` so `pageHeader` falls back to `title`; pass `pageHeader={false}` for a page with no header.

--- a/.changeset/page-header-defaults-to-title.md
+++ b/.changeset/page-header-defaults-to-title.md
@@ -1,5 +1,0 @@
----
-"@tabler/preview": minor
----
-
-Updated `DefaultLayout` so `pageHeader` falls back to `title`; pass `pageHeader={false}` for a page with no header.

--- a/.changeset/preview-meta-description.md
+++ b/.changeset/preview-meta-description.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": patch
+---
+
+Added a `meta` description tag, filled from the page `description` prop.

--- a/preview/pages/2-step-verification-code.astro
+++ b/preview/pages/2-step-verification-code.astro
@@ -4,12 +4,13 @@ import SingleLayout from '@shared/layouts/SingleLayout.astro'
 import Button from '@ui/Button.astro'
 import ButtonList from '@ui/ButtonList.astro'
 import CaptureScript from '@shared/components/CaptureScript.astro'
+import CardTitle from '@ui/CardTitle.astro'
 ---
 
 <SingleLayout title="2-Step Verification">
   <form class="card card-md" action="./" method="get" novalidate>
     <div class="card-body">
-      <h2 class="card-title card-title-lg text-center mb-4">Authenticate Your Account</h2>
+      <CardTitle class="card-title-lg text-center mb-4">Authenticate Your Account</CardTitle>
 
       <p class="my-4 text-center">
         Please confirm your account by entering the authorization code sent to <strong>+1 856-672-8552</strong>.

--- a/preview/pages/2-step-verification.astro
+++ b/preview/pages/2-step-verification.astro
@@ -6,12 +6,13 @@ import SingleLayout from '@shared/layouts/SingleLayout.astro'
 import Button from '@ui/Button.astro'
 import FormGroup from '@ui/FormGroup.astro'
 import flags from '@data/flags.json'
+import CardTitle from '@ui/CardTitle.astro'
 ---
 
 <SingleLayout title="2-Step Verification">
   <form class="card card-md" action="./2-step-verification-code.html" method="get" novalidate>
     <div class="card-body">
-      <h2 class="card-title text-center mb-4">2-Step Verification</h2>
+      <CardTitle class="text-center mb-4">2-Step Verification</CardTitle>
 
       <FormGroup label="Country" for="verify-country">
         <select class="form-select" id="verify-country" autocomplete="country-name">

--- a/preview/pages/accordion.astro
+++ b/preview/pages/accordion.astro
@@ -5,16 +5,11 @@ import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
-import Icon from '@ui/Icon.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const accordionDocsUrl = getDocsUrl('/ui/components/accordion')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Accordion" pageHeader="Accordion" pageMenu="base.accordion" description="Accordions show and hide sections of content, one panel at a time, inside a card.">
-  <a slot="page-header-actions" href={accordionDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Accordion" pageMenu="base.accordion" description="Accordions show and hide sections of content, one panel at a time, inside a card.">
+  <DocsLink slot="page-header-actions" path="/ui/components/accordion" />
 
   <div class="row row-cards">
     <div class="col-md-6">

--- a/preview/pages/accordion.astro
+++ b/preview/pages/accordion.astro
@@ -7,18 +7,14 @@ import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
 import Icon from '@ui/Icon.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const accordionDocsUrl = getDocsUrl('/ui/components/accordion')
 ---
 
-<DefaultLayout title="Accordion" pageMenu="base.accordion" description="Accordions show and hide sections of content, one panel at a time, inside a card.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Accordion</PageTitle>
-    <a href={accordionDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Accordion" pageHeader="Accordion" pageMenu="base.accordion" description="Accordions show and hide sections of content, one panel at a time, inside a card.">
+  <a slot="page-header-actions" href={accordionDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     <div class="col-md-6">

--- a/preview/pages/activity.astro
+++ b/preview/pages/activity.astro
@@ -5,7 +5,7 @@ import CardBody from '@ui/CardBody.astro'
 import ActivityPart from '@ui/ActivityPart.astro'
 ---
 
-<DefaultLayout title="Activity" pageHeader="Activity" pageMenu="extra.activity">
+<DefaultLayout title="Activity" pageMenu="extra.activity">
   <div class="row">
     <div class="col-8">
       <Card>

--- a/preview/pages/alerts.astro
+++ b/preview/pages/alerts.astro
@@ -7,18 +7,14 @@ import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
 import Icon from '@ui/Icon.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const alertDocsUrl = getDocsUrl('/ui/components/alert')
 ---
 
-<DefaultLayout title="Alerts" pageMenu="base.alerts" description="Alert messages inform users about the status of an action, in success, info, warning, or danger states.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Alerts</PageTitle>
-    <a href={alertDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Alerts" pageHeader="Alerts" pageMenu="base.alerts" description="Alert messages inform users about the status of an action, in success, info, warning, or danger states.">
+  <a slot="page-header-actions" href={alertDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     <div class="col-12">

--- a/preview/pages/alerts.astro
+++ b/preview/pages/alerts.astro
@@ -5,22 +5,17 @@ import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
-import Icon from '@ui/Icon.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const alertDocsUrl = getDocsUrl('/ui/components/alert')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Alerts" pageHeader="Alerts" pageMenu="base.alerts" description="Alert messages inform users about the status of an action, in success, info, warning, or danger states.">
-  <a slot="page-header-actions" href={alertDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Alerts" pageMenu="base.alerts" description="Alert messages inform users about the status of an action, in success, info, warning, or danger states.">
+  <DocsLink slot="page-header-actions" path="/ui/components/alert" />
 
   <div class="row row-cards">
     <div class="col-12">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Basic</CardTitle>
+          <CardTitle>Basic</CardTitle>
           <CardSubtitle>A title and a color are enough to show the status of an action.</CardSubtitle>
           <Alert type="danger" title="An error occurred!" />
           <Alert type="warning" title="Some information is missing!" />
@@ -32,7 +27,7 @@ const alertDocsUrl = getDocsUrl('/ui/components/alert')
     <div class="col-12">
       <Card>
         <CardBody>
-          <CardTitle as="h2">With action</CardTitle>
+          <CardTitle>With action</CardTitle>
           <CardSubtitle>Add a link with the <code>action</code> prop to give users something to do next.</CardSubtitle>
           <Alert showClose action="Link" type="danger" title="An error occurred!" />
           <Alert showClose action="Link" type="warning" title="Some information is missing!" />
@@ -44,7 +39,7 @@ const alertDocsUrl = getDocsUrl('/ui/components/alert')
     <div class="col-12">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Dismissible</CardTitle>
+          <CardTitle>Dismissible</CardTitle>
           <CardSubtitle>Add <code>showClose</code> to let users close the alert.</CardSubtitle>
           <Alert showClose type="danger" title="An error occurred!" />
           <Alert showClose type="warning" title="Some information is missing!" />
@@ -56,7 +51,7 @@ const alertDocsUrl = getDocsUrl('/ui/components/alert')
     <div class="col-12">
       <Card>
         <CardBody>
-          <CardTitle as="h2">With a description</CardTitle>
+          <CardTitle>With a description</CardTitle>
           <CardSubtitle>Add a <code>description</code> or a <code>list</code> when the title alone isn't enough context.</CardSubtitle>
           <Alert showClose type="danger" title="Password does not meet requirements:" list={['Minimum 8 characters', 'Include a special character']} />
           <Alert showClose type="warning" title="Some information is missing!" description="This is a custom alert box with a description." />
@@ -68,7 +63,7 @@ const alertDocsUrl = getDocsUrl('/ui/components/alert')
     <div class="col-12">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Important</CardTitle>
+          <CardTitle>Important</CardTitle>
           <CardSubtitle>Add <code>important</code> for a bolder style that stands out from the rest of the page.</CardSubtitle>
           <Alert showClose important type="danger" title="Password does not meet requirements:" list={['Minimum 8 characters', 'Include a special character']} />
           <Alert showClose important type="success" description="This is a custom alert box with a description." />
@@ -80,7 +75,7 @@ const alertDocsUrl = getDocsUrl('/ui/components/alert')
     <div class="col-12">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Minor</CardTitle>
+          <CardTitle>Minor</CardTitle>
           <CardSubtitle>Add <code>minor</code> for a quieter style that fits inline with other content.</CardSubtitle>
           <Alert showClose minor type="danger" title="Password does not meet requirements:" list={['Minimum 8 characters', 'Include a special character']} />
           <Alert showClose minor type="success" description="This is a custom alert box with a description." />

--- a/preview/pages/avatars.astro
+++ b/preview/pages/avatars.astro
@@ -11,7 +11,6 @@ import Icon from '@ui/Icon.astro'
 import people from '@data/people.json'
 import { site } from '@shared/lib/site'
 import { firstLetters, getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const iconIcons = ['user', 'settings', 'car', 'balloon', 'users', 'users-group', 'apps', 'ghost']
 
@@ -29,13 +28,10 @@ const brands = ['netflix', 'amazon', 'messenger', 'figma', 'twitch']
 const avatarDocsUrl = getDocsUrl('/ui/components/avatar')
 ---
 
-<DefaultLayout title="Avatars" pageMenu="base.avatars" description="Avatars display a photo, icon, or initials to represent a person, brand, or status.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Avatars</PageTitle>
-    <a href={avatarDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Avatars" pageHeader="Avatars" pageMenu="base.avatars" description="Avatars display a photo, icon, or initials to represent a person, brand, or status.">
+  <a slot="page-header-actions" href={avatarDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     <div class="col-sm-6 col-lg-4">

--- a/preview/pages/avatars.astro
+++ b/preview/pages/avatars.astro
@@ -7,10 +7,10 @@ import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
-import Icon from '@ui/Icon.astro'
 import people from '@data/people.json'
 import { site } from '@shared/lib/site'
-import { firstLetters, getDocsUrl } from '@shared/lib/string-format'
+import { firstLetters } from '@shared/lib/string-format'
+import DocsLink from '@ui/DocsLink.astro'
 
 const iconIcons = ['user', 'settings', 'car', 'balloon', 'users', 'users-group', 'apps', 'ghost']
 
@@ -24,20 +24,16 @@ const listSizes = ['xxs', 'xs', 'sm', 'md', 'lg'] as const
 const uploadSizes = ['xxs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const
 const statusColors = ['red', 'green', 'blue', 'yellow', 'secondary']
 const brands = ['netflix', 'amazon', 'messenger', 'figma', 'twitch']
-
-const avatarDocsUrl = getDocsUrl('/ui/components/avatar')
 ---
 
-<DefaultLayout title="Avatars" pageHeader="Avatars" pageMenu="base.avatars" description="Avatars display a photo, icon, or initials to represent a person, brand, or status.">
-  <a slot="page-header-actions" href={avatarDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Avatars" pageMenu="base.avatars" description="Avatars display a photo, icon, or initials to represent a person, brand, or status.">
+  <DocsLink slot="page-header-actions" path="/ui/components/avatar" />
 
   <div class="row row-cards">
     <div class="col-sm-6 col-lg-4">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Default avatar</CardTitle>
+          <CardTitle>Default avatar</CardTitle>
           <CardSubtitle>The base <code>.avatar</code> element — a placeholder box for a photo, icon, or initials.</CardSubtitle>
           <Avatar />
         </CardBody>
@@ -46,7 +42,7 @@ const avatarDocsUrl = getDocsUrl('/ui/components/avatar')
     <div class="col-sm-6 col-lg-4">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Avatar with icon</CardTitle>
+          <CardTitle>Avatar with icon</CardTitle>
           <CardSubtitle>Use an icon instead of a photo with the <code>icon</code> prop.</CardSubtitle>
           <div class="avatar-list">
             {iconIcons.map((icon) => <Avatar icon={icon} />)}
@@ -57,7 +53,7 @@ const avatarDocsUrl = getDocsUrl('/ui/components/avatar')
     <div class="col-sm-6 col-lg-4">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Avatar icon colors</CardTitle>
+          <CardTitle>Avatar icon colors</CardTitle>
           <CardSubtitle>Combine an icon avatar with any theme color.</CardSubtitle>
           <div class="avatar-list">
             {colors.map((color) => <Avatar icon="user" color={color} />)}
@@ -68,7 +64,7 @@ const avatarDocsUrl = getDocsUrl('/ui/components/avatar')
     <div class="col-sm-6 col-lg-4">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Simple avatar</CardTitle>
+          <CardTitle>Simple avatar</CardTitle>
           <CardSubtitle>Pass a <code>person</code> object to render their photo.</CardSubtitle>
           <div class="avatar-list">
             {people8.map((person) => <Avatar person={person} />)}
@@ -79,7 +75,7 @@ const avatarDocsUrl = getDocsUrl('/ui/components/avatar')
     <div class="col-sm-6 col-lg-4">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Avatar placeholder</CardTitle>
+          <CardTitle>Avatar placeholder</CardTitle>
           <CardSubtitle>Fall back to initials with the <code>placeholder</code> prop when there's no photo.</CardSubtitle>
           <div class="avatar-list">
             {people8.map((person) => <Avatar placeholder={firstLetters(person.full_name)} />)}
@@ -90,7 +86,7 @@ const avatarDocsUrl = getDocsUrl('/ui/components/avatar')
     <div class="col-sm-6 col-lg-4">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Avatar shapes</CardTitle>
+          <CardTitle>Avatar shapes</CardTitle>
           <CardSubtitle>Square by default — add <code>.rounded-circle</code> or <code>.rounded-0</code> to change the shape.</CardSubtitle>
           <div class="avatar-list">
             <Avatar />
@@ -103,7 +99,7 @@ const avatarDocsUrl = getDocsUrl('/ui/components/avatar')
     <div class="col-12 col-lg-6">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Avatar sizes</CardTitle>
+          <CardTitle>Avatar sizes</CardTitle>
           <CardSubtitle>Six sizes from <code>xxs</code> to <code>xl</code>, for both photos and placeholders.</CardSubtitle>
           <div class="row">
             <div class="col-6">
@@ -123,7 +119,7 @@ const avatarDocsUrl = getDocsUrl('/ui/components/avatar')
     <div class="col-12 col-lg-6">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Avatar lists</CardTitle>
+          <CardTitle>Avatar lists</CardTitle>
           <CardSubtitle>Stack avatars with <code>&lt;AvatarList&gt;</code> to show a group at a glance.</CardSubtitle>
           <div class="row g-3">
             {
@@ -155,7 +151,7 @@ const avatarDocsUrl = getDocsUrl('/ui/components/avatar')
     <div class="col-sm-6 col-lg-4">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Avatar upload</CardTitle>
+          <CardTitle>Avatar upload</CardTitle>
           <CardSubtitle>An upload control styled as an avatar, for profile photo pickers.</CardSubtitle>
           {uploadSizes.map((size) => <AvatarUpload size={size} />)}
         </CardBody>
@@ -164,7 +160,7 @@ const avatarDocsUrl = getDocsUrl('/ui/components/avatar')
     <div class="col-sm-6 col-lg-4">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Avatar statuses</CardTitle>
+          <CardTitle>Avatar statuses</CardTitle>
           <CardSubtitle>Add a <code>status</code> dot to show online, away, or busy state.</CardSubtitle>
           {statusColors.map((color, i) => <Avatar personId={i + 1} class="rounded-circle" status={color} />)}
         </CardBody>
@@ -173,7 +169,7 @@ const avatarDocsUrl = getDocsUrl('/ui/components/avatar')
     <div class="col-sm-6 col-lg-4">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Avatar brands</CardTitle>
+          <CardTitle>Avatar brands</CardTitle>
           <CardSubtitle>Show a recognizable brand icon instead of a person.</CardSubtitle>
           {brands.map((brand, i) => <Avatar personId={i + 1} brand={brand} />)}
         </CardBody>

--- a/preview/pages/badges.astro
+++ b/preview/pages/badges.astro
@@ -12,7 +12,6 @@ import CardSubtitle from '@ui/CardSubtitle.astro'
 import DropdownMenu from '@ui/DropdownMenu.astro'
 import site from '@data/site.json'
 import { ucFirst, getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const colors = ['default', ...Object.keys(site.colors), 'dark', 'light']
 const sizes = ['sm', 'md', 'lg']
@@ -20,13 +19,10 @@ const sizes = ['sm', 'md', 'lg']
 const badgeDocsUrl = getDocsUrl('/ui/components/badge')
 ---
 
-<DefaultLayout title="Badges" pageMenu="base.badges" description="Badges highlight a count, status, or short label attached to text, buttons, or menu items.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Badges</PageTitle>
-    <a href={badgeDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Badges" pageHeader="Badges" pageMenu="base.badges" description="Badges highlight a count, status, or short label attached to text, buttons, or menu items.">
+  <a slot="page-header-actions" href={badgeDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards mb-5">
     <div class="col-md-6 col-lg-4">

--- a/preview/pages/badges.astro
+++ b/preview/pages/badges.astro
@@ -11,18 +11,15 @@ import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
 import DropdownMenu from '@ui/DropdownMenu.astro'
 import site from '@data/site.json'
-import { ucFirst, getDocsUrl } from '@shared/lib/string-format'
+import { ucFirst } from '@shared/lib/string-format'
+import DocsLink from '@ui/DocsLink.astro'
 
 const colors = ['default', ...Object.keys(site.colors), 'dark', 'light']
 const sizes = ['sm', 'md', 'lg']
-
-const badgeDocsUrl = getDocsUrl('/ui/components/badge')
 ---
 
-<DefaultLayout title="Badges" pageHeader="Badges" pageMenu="base.badges" description="Badges highlight a count, status, or short label attached to text, buttons, or menu items.">
-  <a slot="page-header-actions" href={badgeDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Badges" pageMenu="base.badges" description="Badges highlight a count, status, or short label attached to text, buttons, or menu items.">
+  <DocsLink slot="page-header-actions" path="/ui/components/badge" />
 
   <div class="row row-cards mb-5">
     <div class="col-md-6 col-lg-4">

--- a/preview/pages/blank.astro
+++ b/preview/pages/blank.astro
@@ -4,7 +4,7 @@ import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Empty from '@ui/Empty.astro'
 ---
 
-<DefaultLayout title="Blank page" pageMenu="base.blank" containerCentered>
+<DefaultLayout title="Blank page" pageHeader={false} pageMenu="base.blank" containerCentered>
   <h1 class="visually-hidden">Blank page</h1>
   <Empty buttonText="Add your first client" buttonIcon="plus" illustration="computer-fix.svg" />
 </DefaultLayout>

--- a/preview/pages/buttons.astro
+++ b/preview/pages/buttons.astro
@@ -9,7 +9,6 @@ import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
 import site from '@data/site.json'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 type ColorEntry = [string, { title: string; icon?: string }]
 
@@ -25,13 +24,10 @@ const sizes = ['sm', 'md', 'lg', 'xl'] as const
 const buttonDocsUrl = getDocsUrl('/ui/components/button')
 ---
 
-<DefaultLayout title="Buttons" pageMenu="base.buttons" description="Buttons are used to trigger actions in a user interface.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Buttons</PageTitle>
-    <a href={buttonDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Buttons" pageHeader="Buttons" pageMenu="base.buttons" description="Buttons are used to trigger actions in a user interface.">
+  <a slot="page-header-actions" href={buttonDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards mb-5">
     <div class="col-md-6 col-lg-4">

--- a/preview/pages/buttons.astro
+++ b/preview/pages/buttons.astro
@@ -8,7 +8,7 @@ import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
 import site from '@data/site.json'
-import { getDocsUrl } from '@shared/lib/string-format'
+import DocsLink from '@ui/DocsLink.astro'
 
 type ColorEntry = [string, { title: string; icon?: string }]
 
@@ -20,14 +20,10 @@ const socialColors = Object.entries(site.socialColors) as ColorEntry[]
 
 const actions = ['edit', 'copy', 'settings', 'clipboard', 'x']
 const sizes = ['sm', 'md', 'lg', 'xl'] as const
-
-const buttonDocsUrl = getDocsUrl('/ui/components/button')
 ---
 
-<DefaultLayout title="Buttons" pageHeader="Buttons" pageMenu="base.buttons" description="Buttons are used to trigger actions in a user interface.">
-  <a slot="page-header-actions" href={buttonDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Buttons" pageMenu="base.buttons" description="Buttons are used to trigger actions in a user interface.">
+  <DocsLink slot="page-header-actions" path="/ui/components/button" />
 
   <div class="row row-cards mb-5">
     <div class="col-md-6 col-lg-4">

--- a/preview/pages/card-actions.astro
+++ b/preview/pages/card-actions.astro
@@ -16,7 +16,7 @@ const person0 = requireIndex(people, 0)
 const person3 = requireIndex(people, 3)
 ---
 
-<DefaultLayout title="Card actions" pageHeader="Card actions" pageMenu="base.cards.actions">
+<DefaultLayout title="Card actions" pageMenu="base.cards.actions">
   <div class="row row-cards">
     <div class="col-md-6">
       <Card>
@@ -57,7 +57,7 @@ const person3 = requireIndex(people, 3)
                 <Avatar person={person0} />
               </div>
               <div class="col">
-                <h3 class="card-title">{person0.full_name}</h3>
+                <CardTitle>{person0.full_name}</CardTitle>
                 <CardSubtitle as="div">{person0.job_title}</CardSubtitle>
               </div>
             </div>
@@ -107,7 +107,7 @@ const person3 = requireIndex(people, 3)
                 <Avatar person={person3} />
               </div>
               <div class="col">
-                <h3 class="card-title">{person3.full_name}</h3>
+                <CardTitle>{person3.full_name}</CardTitle>
                 <CardSubtitle as="div">{person3.job_title}</CardSubtitle>
               </div>
             </div>

--- a/preview/pages/card-gradients.astro
+++ b/preview/pages/card-gradients.astro
@@ -14,7 +14,7 @@ import people from '@data/people.json'
 import { requireIndex } from '@shared/lib/array'
 ---
 
-<DefaultLayout title="Card Gradients" pageHeader="Card Gradients" pageMenu="base.cards.gradients" pageLibs={['apexcharts']}>
+<DefaultLayout title="Card Gradients" pageMenu="base.cards.gradients" pageLibs={['apexcharts']}>
   <div class="row row-cards">
     <div class="col-md-6">
       <div class="row row-cards">

--- a/preview/pages/cards-masonry.astro
+++ b/preview/pages/cards-masonry.astro
@@ -9,7 +9,7 @@ import BodyPlaceholder from '@shared/components/cards/BodyPlaceholder.astro'
 const heights = [200, 150, 400, 300, 350, 600, 700, 200, 150, 250, 50, 400, 300, 200]
 ---
 
-<DefaultLayout title="Cards Masonry" pageHeader="Cards Masonry" pageMenu="base.cards.masonry" pageLibs={['masonry']}>
+<DefaultLayout title="Cards Masonry" pageMenu="base.cards.masonry" pageLibs={['masonry']}>
   <div class="row row-cards" data-masonry={'{"percentPosition": true }'}>
     {
       heights.map((height) => (

--- a/preview/pages/cards.astro
+++ b/preview/pages/cards.astro
@@ -17,7 +17,7 @@ const cardsStack = ['First', 'Second', 'Third']
 const cardsStackColors = ['red', 'green', 'blue']
 ---
 
-<DefaultLayout title="Cards" pageHeader="Cards" pageMenu="base.cards.base">
+<DefaultLayout title="Cards" pageMenu="base.cards.base">
   <div class="row row-cards">
     <div class="col-md-6 col-lg-3">
       <div class="card">

--- a/preview/pages/carousel.astro
+++ b/preview/pages/carousel.astro
@@ -1,16 +1,11 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import CarouselCard from '@shared/components/cards/CarouselCard.astro'
-import Icon from '@ui/Icon.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const carouselDocsUrl = getDocsUrl('/ui/components/carousel')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Carousel" pageHeader="Carousel" pageMenu="base.carousel" description="A carousel cycles through a set of slides, with optional indicators and controls.">
-  <a slot="page-header-actions" href={carouselDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Carousel" pageMenu="base.carousel" description="A carousel cycles through a set of slides, with optional indicators and controls.">
+  <DocsLink slot="page-header-actions" path="/ui/components/carousel" />
 
   <div class="row row-cards">
     <div class="col-md-6">

--- a/preview/pages/carousel.astro
+++ b/preview/pages/carousel.astro
@@ -3,18 +3,14 @@ import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import CarouselCard from '@shared/components/cards/CarouselCard.astro'
 import Icon from '@ui/Icon.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const carouselDocsUrl = getDocsUrl('/ui/components/carousel')
 ---
 
-<DefaultLayout title="Carousel" pageMenu="base.carousel" description="A carousel cycles through a set of slides, with optional indicators and controls.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Carousel</PageTitle>
-    <a href={carouselDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Carousel" pageHeader="Carousel" pageMenu="base.carousel" description="A carousel cycles through a set of slides, with optional indicators and controls.">
+  <a slot="page-header-actions" href={carouselDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     <div class="col-md-6">

--- a/preview/pages/changelog.astro
+++ b/preview/pages/changelog.astro
@@ -6,6 +6,6 @@ import changelog from '../../core/CHANGELOG.md?raw'
 const changelogHtml = renderMarkdown(changelog)
 ---
 
-<ProseLayout title="Changelog" pageHeader="Changelog" pageMenu="changelog">
+<ProseLayout title="Changelog" pageMenu="changelog">
   <Fragment set:html={changelogHtml} />
 </ProseLayout>

--- a/preview/pages/charts.astro
+++ b/preview/pages/charts.astro
@@ -12,7 +12,7 @@ import { capitalize } from '@shared/lib/string-format'
 const demoCharts = Object.entries(chartsData as Record<string, { demo?: boolean; name?: string }>).filter(([, chart]) => chart && chart.demo)
 ---
 
-<DefaultLayout title="Charts" pageHeader="Charts" pageMenu="plugins.charts" pageLibs={['apexcharts']}>
+<DefaultLayout title="Charts" pageMenu="plugins.charts" pageLibs={['apexcharts']}>
   <div class="row row-cards">
     <div class="col-lg-12">
       <Activity />

--- a/preview/pages/chat.astro
+++ b/preview/pages/chat.astro
@@ -22,7 +22,7 @@ const sidebarPeople = (people as Person[]).slice(0, 10)
 const messages = chats as Message[]
 ---
 
-<DefaultLayout title="Chat" pageHeader="Chat" pageMenu="extra.chat" containerClass="flex-fill d-flex flex-column">
+<DefaultLayout title="Chat" pageMenu="extra.chat" containerClass="flex-fill d-flex flex-column">
   <div class="card flex-fill">
     <div class="row g-0 flex-fill">
       <div class="col-12 col-lg-5 col-xl-3 border-end d-flex flex-column">

--- a/preview/pages/colorpicker.astro
+++ b/preview/pages/colorpicker.astro
@@ -9,7 +9,7 @@ import site from '@data/site.json'
 const colors = Object.values(site.colors) as { hex: string; title: string }[]
 ---
 
-<DefaultLayout title="Color picker" pageHeader="Color picker" pageMenu="plugins.colorpicker" pageLibs={['coloris.js']}>
+<DefaultLayout title="Color picker" pageMenu="plugins.colorpicker" pageLibs={['coloris.js']}>
   <Card>
     <CardBody>
       <CardTitle>Basic</CardTitle>

--- a/preview/pages/colors.astro
+++ b/preview/pages/colors.astro
@@ -10,7 +10,6 @@ import CardSubtitle from '@ui/CardSubtitle.astro'
 import Icon from '@ui/Icon.astro'
 import site from '@data/site.json'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 type ColorEntry = [string, { title: string; hex: string; abbr?: string; icon?: string }]
 
@@ -24,13 +23,10 @@ const gradientColors = [...Object.keys(site.colors), 'inverted', 'white', 'trans
 const colorsDocsUrl = getDocsUrl('/ui/base/colors')
 ---
 
-<DefaultLayout title="Colors" pageMenu="base.colors" description="The full color palette, with hex values, and a gradient builder.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Colors</PageTitle>
-    <a href={colorsDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Colors" pageHeader="Colors" pageMenu="base.colors" description="The full color palette, with hex values, and a gradient builder.">
+  <a slot="page-header-actions" href={colorsDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     <div class="col-6 col-lg-3">

--- a/preview/pages/colors.astro
+++ b/preview/pages/colors.astro
@@ -7,9 +7,8 @@ import CardBody from '@ui/CardBody.astro'
 import Avatar from '@ui/Avatar.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
-import Icon from '@ui/Icon.astro'
 import site from '@data/site.json'
-import { getDocsUrl } from '@shared/lib/string-format'
+import DocsLink from '@ui/DocsLink.astro'
 
 type ColorEntry = [string, { title: string; hex: string; abbr?: string; icon?: string }]
 
@@ -19,14 +18,10 @@ const grayColors = Object.entries(site.grayColors) as ColorEntry[]
 const socialColors = Object.entries(site.socialColors) as ColorEntry[]
 
 const gradientColors = [...Object.keys(site.colors), 'inverted', 'white', 'transparent']
-
-const colorsDocsUrl = getDocsUrl('/ui/base/colors')
 ---
 
-<DefaultLayout title="Colors" pageHeader="Colors" pageMenu="base.colors" description="The full color palette, with hex values, and a gradient builder.">
-  <a slot="page-header-actions" href={colorsDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Colors" pageMenu="base.colors" description="The full color palette, with hex values, and a gradient builder.">
+  <DocsLink slot="page-header-actions" path="/ui/base/colors" />
 
   <div class="row row-cards">
     <div class="col-6 col-lg-3">

--- a/preview/pages/cookie-banner.astro
+++ b/preview/pages/cookie-banner.astro
@@ -4,7 +4,7 @@ import Offcanvas from '@ui/Offcanvas.astro'
 import OffcanvasBody from '@ui/OffcanvasBody.astro'
 ---
 
-<DefaultLayout title="Cookie banner" pageHeader="Cookie banner" pageMenu="extra.cookie-banner">
+<DefaultLayout title="Cookie banner" pageMenu="extra.cookie-banner">
   <Offcanvas direction="bottom" show class="h-auto" tabindex="-1" id="offcanvasBottom" aria-modal="true" role="dialog">
     <OffcanvasBody>
       <div class="container">

--- a/preview/pages/dashboard-crm.astro
+++ b/preview/pages/dashboard-crm.astro
@@ -10,7 +10,7 @@ import TeamLeaderboard from '@shared/components/cards/TeamLeaderboard.astro'
 import ChurnRisk from '@shared/components/cards/ChurnRisk.astro'
 ---
 
-<DefaultLayout title="CRM Dashboard" pageHeader="CRM Dashboard" description="Welcome back — here's your CRM overview for today." pageMenu="dashboards.crm" pageLibs={['apexcharts']}>
+<DefaultLayout title="CRM Dashboard" description="Welcome back — here's your CRM overview for today." pageMenu="dashboards.crm" pageLibs={['apexcharts']}>
   <div>
     <div class="col-12">
       <div class="row row-cards">

--- a/preview/pages/dashboard-crypto.astro
+++ b/preview/pages/dashboard-crypto.astro
@@ -14,6 +14,7 @@ import cryptoCurrencies from '@data/crypto-currencies.json'
 import cryptoMarkets from '@data/crypto-markets.json'
 import cryptoOrders from '@data/crypto-orders.json'
 import { parseCurrency, roundTo } from '@shared/lib/string-format'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Currency {
   'symbol': string
@@ -43,7 +44,7 @@ const orders = cryptoOrders as { sell_orders: { price: string; btc: string; sum:
 const operationCurrencies = currencies.slice(0, 20)
 ---
 
-<DefaultLayout title="Crypto Dashboard" pageHeader="Crypto Dashboard" pageMenu="dashboards.crypto" pageLibs={['apexcharts']}>
+<DefaultLayout title="Crypto Dashboard" pageMenu="dashboards.crypto" pageLibs={['apexcharts']}>
   <div class="row row-cards">
     <div class="col-12">
       <div class="row row-cards">
@@ -52,7 +53,7 @@ const operationCurrencies = currencies.slice(0, 20)
             <CardBody>
               <div class="row">
                 <div class="col mt-0">
-                  <h5 class="card-title">Total balance</h5>
+                  <CardTitle>Total balance</CardTitle>
                 </div>
                 <div class="col-auto">
                   <Avatar icon="currency-dollar" />
@@ -75,7 +76,7 @@ const operationCurrencies = currencies.slice(0, 20)
             <CardBody>
               <div class="row">
                 <div class="col mt-0">
-                  <h5 class="card-title">USD/BTC</h5>
+                  <CardTitle>USD/BTC</CardTitle>
                 </div>
                 <div class="col-auto">
                   <Avatar icon="currency-bitcoin" />
@@ -97,7 +98,7 @@ const operationCurrencies = currencies.slice(0, 20)
             <CardBody>
               <div class="row">
                 <div class="col mt-0">
-                  <h5 class="card-title">LTC/BTC</h5>
+                  <CardTitle>LTC/BTC</CardTitle>
                 </div>
                 <div class="col-auto">
                   <Avatar icon="currency-litecoin" />
@@ -119,7 +120,7 @@ const operationCurrencies = currencies.slice(0, 20)
             <CardBody>
               <div class="row">
                 <div class="col mt-0">
-                  <h5 class="card-title">ETH/BTC</h5>
+                  <CardTitle>ETH/BTC</CardTitle>
                 </div>
                 <div class="col-auto">
                   <Avatar icon="currency-ethereum" />
@@ -141,7 +142,7 @@ const operationCurrencies = currencies.slice(0, 20)
             <CardBody>
               <div class="row">
                 <div class="col mt-0">
-                  <h5 class="card-title">XMR/BTC</h5>
+                  <CardTitle>XMR/BTC</CardTitle>
                 </div>
                 <div class="col-auto">
                   <Avatar icon="currency-monero" />
@@ -164,7 +165,7 @@ const operationCurrencies = currencies.slice(0, 20)
         <div class="col-12 col-lg-5">
           <Card>
             <CardHeader>
-              <h5 class="card-title mb-0">Markets</h5>
+              <CardTitle class="mb-0">Markets</CardTitle>
               <CardActions>
                 <CardDropdown />
               </CardActions>
@@ -205,7 +206,7 @@ const operationCurrencies = currencies.slice(0, 20)
         <div class="col-12 col-lg-7">
           <Card>
             <CardHeader>
-              <h5 class="card-title mb-0">LTC/BTC</h5>
+              <CardTitle class="mb-0">LTC/BTC</CardTitle>
               <CardActions>
                 <NavSegmented items={['1m', '5m', '30m', '1h', '1d']} name="timeframe" size="sm" default={2} />
               </CardActions>
@@ -222,7 +223,7 @@ const operationCurrencies = currencies.slice(0, 20)
         <div class="col-12 col-lg-12 col-xxl-3">
           <Card>
             <CardHeader>
-              <h5 class="card-title mb-0">Operations</h5>
+              <CardTitle class="mb-0">Operations</CardTitle>
               <CardActions>
                 <NavSegmented items={['Buy', 'Sell', 'Send']} name="operations" size="sm" />
               </CardActions>
@@ -269,7 +270,7 @@ const operationCurrencies = currencies.slice(0, 20)
         <div class="col-12 col-lg-6 col-xxl">
           <Card>
             <CardHeader>
-              <h5 class="card-title mb-0">Sell Orders</h5>
+              <CardTitle class="mb-0">Sell Orders</CardTitle>
               <CardActions>
                 <button class="btn btn-sm">View all</button>
               </CardActions>
@@ -300,7 +301,7 @@ const operationCurrencies = currencies.slice(0, 20)
         <div class="col-12 col-lg-6 col-xxl">
           <Card>
             <CardHeader>
-              <h5 class="card-title mb-0">Buy Orders</h5>
+              <CardTitle class="mb-0">Buy Orders</CardTitle>
               <CardActions>
                 <button class="btn btn-sm">View all</button>
               </CardActions>

--- a/preview/pages/datagrid.astro
+++ b/preview/pages/datagrid.astro
@@ -6,18 +6,14 @@ import CardBody from '@ui/CardBody.astro'
 import Icon from '@ui/Icon.astro'
 import Datagrid from '@shared/components/parts/Datagrid.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const datagridDocsUrl = getDocsUrl('/ui/components/datagrid')
 ---
 
-<DefaultLayout title="Data grid" pageMenu="base.datagrid" description="A data grid lays out label/value pairs in a compact, aligned grid.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Data grid</PageTitle>
-    <a href={datagridDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Data grid" pageHeader="Data grid" pageMenu="base.datagrid" description="A data grid lays out label/value pairs in a compact, aligned grid.">
+  <a slot="page-header-actions" href={datagridDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <Card>
     <CardHeader title="Base info" />

--- a/preview/pages/datagrid.astro
+++ b/preview/pages/datagrid.astro
@@ -3,17 +3,12 @@ import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Card from '@ui/Card.astro'
 import CardHeader from '@ui/CardHeader.astro'
 import CardBody from '@ui/CardBody.astro'
-import Icon from '@ui/Icon.astro'
 import Datagrid from '@shared/components/parts/Datagrid.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const datagridDocsUrl = getDocsUrl('/ui/components/datagrid')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Data grid" pageHeader="Data grid" pageMenu="base.datagrid" description="A data grid lays out label/value pairs in a compact, aligned grid.">
-  <a slot="page-header-actions" href={datagridDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Data grid" pageMenu="base.datagrid" description="A data grid lays out label/value pairs in a compact, aligned grid.">
+  <DocsLink slot="page-header-actions" path="/ui/components/datagrid" />
 
   <Card>
     <CardHeader title="Base info" />

--- a/preview/pages/datatables.astro
+++ b/preview/pages/datatables.astro
@@ -33,7 +33,7 @@ const rows = (rollercoasters as Rollercoaster[]).map((rc, i) => {
 const valueNames = ['sort-name', 'sort-type', 'sort-city', 'sort-score', { attr: 'data-date', name: 'sort-date' }, { attr: 'data-progress', name: 'sort-progress' }, 'sort-quantity']
 ---
 
-<DefaultLayout title="Datatables" pageHeader="Datatables" pageMenu="plugins.datatables" pageLibs={['lists']}>
+<DefaultLayout title="Datatables" pageMenu="plugins.datatables" pageLibs={['lists']}>
   <Card>
     <CardBody class="p-0">
       <div id={`table-${id}`} class="table-responsive">

--- a/preview/pages/dropdowns.astro
+++ b/preview/pages/dropdowns.astro
@@ -4,18 +4,14 @@ import DropdownMenu from '@ui/DropdownMenu.astro'
 import DropdownMenuAll from '@ui/DropdownMenuAll.astro'
 import Icon from '@ui/Icon.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const dropdownDocsUrl = getDocsUrl('/ui/components/dropdown')
 ---
 
-<DefaultLayout title="Dropdowns" pageMenu="base.dropdowns" description="Dropdown menus for actions, filters, and selections, always shown open here for reference.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Dropdowns</PageTitle>
-    <a href={dropdownDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Dropdowns" pageHeader="Dropdowns" pageMenu="base.dropdowns" description="Dropdown menus for actions, filters, and selections, always shown open here for reference.">
+  <a slot="page-header-actions" href={dropdownDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row">
     <div class="col-sm-6 col-lg-3">

--- a/preview/pages/dropdowns.astro
+++ b/preview/pages/dropdowns.astro
@@ -2,16 +2,11 @@
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import DropdownMenu from '@ui/DropdownMenu.astro'
 import DropdownMenuAll from '@ui/DropdownMenuAll.astro'
-import Icon from '@ui/Icon.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const dropdownDocsUrl = getDocsUrl('/ui/components/dropdown')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Dropdowns" pageHeader="Dropdowns" pageMenu="base.dropdowns" description="Dropdown menus for actions, filters, and selections, always shown open here for reference.">
-  <a slot="page-header-actions" href={dropdownDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Dropdowns" pageMenu="base.dropdowns" description="Dropdown menus for actions, filters, and selections, always shown open here for reference.">
+  <DocsLink slot="page-header-actions" path="/ui/components/dropdown" />
 
   <div class="row">
     <div class="col-sm-6 col-lg-3">

--- a/preview/pages/dropzone.astro
+++ b/preview/pages/dropzone.astro
@@ -6,7 +6,7 @@ import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 ---
 
-<DefaultLayout title="Dropzone" pageHeader="Dropzone" pageMenu="plugins.dropzone" pageLibs={['dropzone']}>
+<DefaultLayout title="Dropzone" pageMenu="plugins.dropzone" pageLibs={['dropzone']}>
   <div class="row row-cards">
     <div class="col-md-6">
       <Card>

--- a/preview/pages/empty.astro
+++ b/preview/pages/empty.astro
@@ -2,6 +2,6 @@
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 ---
 
-<DefaultLayout title="Empty page" pageHeader="Empty page" pageMenu="extra.empty">
+<DefaultLayout title="Empty page" pageMenu="extra.empty">
   <!-- Content here -->
 </DefaultLayout>

--- a/preview/pages/faq.astro
+++ b/preview/pages/faq.astro
@@ -2,11 +2,13 @@
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Icon from '@ui/Icon.astro'
 import faq from '@data/faq.json'
+import HeaderActionsBreadcrumb from '@shared/components/layout/HeaderActionsBreadcrumb.astro'
 
 const categories = faq as { name: string; questions: { question: string }[] }[]
 ---
 
-<DefaultLayout title="Frequently Asked Questions" pageHeader="Frequently Asked Questions" actions="breadcrumb" pageMenu="extra.faq">
+<DefaultLayout title="Frequently Asked Questions" pageHeader="Frequently Asked Questions" pageMenu="extra.faq">
+  <HeaderActionsBreadcrumb slot="page-header-actions" />
   <div class="card card-lg">
     <div class="card-body">
       <div class="space-y-4">

--- a/preview/pages/faq.astro
+++ b/preview/pages/faq.astro
@@ -7,7 +7,7 @@ import HeaderActionsBreadcrumb from '@shared/components/layout/HeaderActionsBrea
 const categories = faq as { name: string; questions: { question: string }[] }[]
 ---
 
-<DefaultLayout title="Frequently Asked Questions" pageHeader="Frequently Asked Questions" pageMenu="extra.faq">
+<DefaultLayout title="Frequently Asked Questions" pageMenu="extra.faq">
   <HeaderActionsBreadcrumb slot="page-header-actions" />
   <div class="card card-lg">
     <div class="card-body">

--- a/preview/pages/flags.astro
+++ b/preview/pages/flags.astro
@@ -4,15 +4,16 @@ import Card from '@ui/Card.astro'
 import CardHeader from '@ui/CardHeader.astro'
 import CardBody from '@ui/CardBody.astro'
 import flags from '@data/flags.json'
+import CardTitle from '@ui/CardTitle.astro'
 
 // 21 filler divs for flexbox layout.
 const fillers = Array.from({ length: 21 })
 ---
 
-<DefaultLayout title="Flags" pageHeader="Flags" pageMenu="addons.flags">
+<DefaultLayout title="Flags" pageMenu="addons.flags">
   <Card>
     <CardHeader>
-      <h3 class="card-title">List of all flags</h3>
+      <CardTitle>List of all flags</CardTitle>
     </CardHeader>
     <CardBody class="p-0">
       <div class="demo-icons-list-wrap">

--- a/preview/pages/form-elements.astro
+++ b/preview/pages/form-elements.astro
@@ -50,12 +50,12 @@ const rows = [
 ]
 ---
 
-<DefaultLayout title="Form elements" pageHeader="Form elements" pageMenu="form.elements" pageLibs={['nouislider', 'autosize', 'tabler-flags', 'tabler-payments', 'litepicker', 'tom-select', 'imask']}>
+<DefaultLayout title="Form elements" pageMenu="form.elements" pageLibs={['nouislider', 'autosize', 'tabler-flags', 'tabler-payments', 'litepicker', 'tom-select', 'imask']}>
   <div class="row row-cards">
     <div class="col-12">
       <Card as="form" action="https://httpbin.org/post" method="post">
         <CardHeader>
-          <h4 class="card-title">Form elements</h4>
+          <CardTitle>Form elements</CardTitle>
         </CardHeader>
         <CardBody>
           <div class="row g-5">

--- a/preview/pages/fullcalendar.astro
+++ b/preview/pages/fullcalendar.astro
@@ -5,7 +5,7 @@ import CardBody from '@ui/CardBody.astro'
 import Fullcalendar from '@ui/Fullcalendar.astro'
 ---
 
-<DefaultLayout title="Fullcalendar" pageHeader="Fullcalendar" pageMenu="plugins.fullcalendar" pageLibs={['fullcalendar']}>
+<DefaultLayout title="Fullcalendar" pageMenu="plugins.fullcalendar" pageLibs={['fullcalendar']}>
   <Card>
     <CardBody>
       <Fullcalendar sampleEvents />

--- a/preview/pages/gallery.astro
+++ b/preview/pages/gallery.astro
@@ -11,7 +11,7 @@ import HeaderActionsPhotos from '@shared/components/layout/HeaderActionsPhotos.a
 const galleryPhotos = photos.filter((photo) => photo.horizontal).slice(0, 15)
 ---
 
-<DefaultLayout title="Gallery" pageHeader="Gallery" description="1-15 of 241 photos" pageMenu="extra.gallery">
+<DefaultLayout title="Gallery" description="1-15 of 241 photos" pageMenu="extra.gallery">
   <HeaderActionsPhotos slot="page-header-actions" />
   <div class="row row-cards">
     {

--- a/preview/pages/gallery.astro
+++ b/preview/pages/gallery.astro
@@ -5,12 +5,14 @@ import Pagination from '@ui/Pagination.astro'
 import photos from '@data/photos.json'
 import people from '@data/people.json'
 import { requireIndex } from '@shared/lib/array'
+import HeaderActionsPhotos from '@shared/components/layout/HeaderActionsPhotos.astro'
 
 // Horizontal photos, limit 15; person = people[loop index].
 const galleryPhotos = photos.filter((photo) => photo.horizontal).slice(0, 15)
 ---
 
-<DefaultLayout title="Gallery" pageHeader="Gallery" description="1-15 of 241 photos" actions="photos" pageMenu="extra.gallery">
+<DefaultLayout title="Gallery" pageHeader="Gallery" description="1-15 of 241 photos" pageMenu="extra.gallery">
+  <HeaderActionsPhotos slot="page-header-actions" />
   <div class="row row-cards">
     {
       galleryPhotos.map((photo, index) => (

--- a/preview/pages/icons.astro
+++ b/preview/pages/icons.astro
@@ -4,7 +4,7 @@ import IconsBanner from '@shared/components/cards/IconsBanner.astro'
 import Icons from '@shared/components/cards/Icons.astro'
 ---
 
-<DefaultLayout title="Icons" pageHeader="Icons" pageMenu="addons.icons">
+<DefaultLayout title="Icons" pageMenu="addons.icons">
   <div class="row row-cards">
     <div class="col-lg-4">
       <IconsBanner />

--- a/preview/pages/illustrations.astro
+++ b/preview/pages/illustrations.astro
@@ -33,7 +33,7 @@ const moreCount = illustrationsList.length - 4
 const illustrationsData = Object.fromEntries(autodarkEntries.map(([key, svg]) => [key, { svg: withClass(svg) }]))
 ---
 
-<DefaultLayout title="SVG Illustrations" pageHeader="SVG Illustrations" pageMenu="addons.illustrations">
+<DefaultLayout title="SVG Illustrations" pageMenu="addons.illustrations">
   <div class="mb-7" style={`--tblr-illustrations-primary: var(--tblr-color-primary); --tblr-illustrations-skin: ${skinFirst.hex};`} id="current-illustration-style">
     <div class="row row-cards">
       <div class="col-12">

--- a/preview/pages/index.astro
+++ b/preview/pages/index.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Dashboard" pretitle="Overview" actions="buttons" pageMenu="dashboards.default" pageLibs={['apexcharts', 'jsvectormap']}>
+<DefaultLayout title="Dashboard" pageHeader="Dashboard" pretitle="Overview" pageMenu="dashboards.default" pageLibs={['apexcharts', 'jsvectormap']}>
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/index.astro
+++ b/preview/pages/index.astro
@@ -4,7 +4,7 @@ import HomepageContent from '@shared/components/HomepageContent.astro'
 import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Dashboard" pretitle="Overview" pageMenu="dashboards.default" pageLibs={['apexcharts', 'jsvectormap']}>
+<DefaultLayout title="Dashboard" pretitle="Overview" pageMenu="dashboards.default" pageLibs={['apexcharts', 'jsvectormap']}>
   <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/inline-player.astro
+++ b/preview/pages/inline-player.astro
@@ -10,7 +10,7 @@ import players from '@data/inline-players.json'
 type Provider = { 'title': string; 'type': string; 'id': string; 'embed-id': string | number }
 ---
 
-<DefaultLayout title="Inline Player" pageHeader="Inline Player" pageMenu="plugins.plyr" pageLibs={['plyr']}>
+<DefaultLayout title="Inline Player" pageMenu="plugins.plyr" pageLibs={['plyr']}>
   <div class="row row-cards">
     {
       (players as Provider[]).map((provider) => (

--- a/preview/pages/invoice.astro
+++ b/preview/pages/invoice.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import InvoiceCard from '@shared/components/cards/InvoiceCard.astro'
+import HeaderActionsPrint from '@shared/components/layout/HeaderActionsPrint.astro'
 ---
 
-<DefaultLayout title="Invoice" pageHeader="Invoice" pageMenu="extra.invoice" actions="print">
+<DefaultLayout title="Invoice" pageHeader="Invoice" pageMenu="extra.invoice">
+  <HeaderActionsPrint slot="page-header-actions" />
   <InvoiceCard />
 </DefaultLayout>

--- a/preview/pages/invoice.astro
+++ b/preview/pages/invoice.astro
@@ -4,7 +4,7 @@ import InvoiceCard from '@shared/components/cards/InvoiceCard.astro'
 import HeaderActionsPrint from '@shared/components/layout/HeaderActionsPrint.astro'
 ---
 
-<DefaultLayout title="Invoice" pageHeader="Invoice" pageMenu="extra.invoice">
+<DefaultLayout title="Invoice" pageMenu="extra.invoice">
   <HeaderActionsPrint slot="page-header-actions" />
   <InvoiceCard />
 </DefaultLayout>

--- a/preview/pages/job-listing.astro
+++ b/preview/pages/job-listing.astro
@@ -6,6 +6,7 @@ import Avatar from '@ui/Avatar.astro'
 import BadgeList from '@ui/BadgeList.astro'
 import Check from '@ui/form/Check.astro'
 import jobsData from '@data/jobs.json'
+import HeaderActionsAddJob from '@shared/components/layout/HeaderActionsAddJob.astro'
 
 interface Job {
   company: string
@@ -23,7 +24,8 @@ const types = ['Programming', 'Design', 'Management / Finance', 'Customer Suppor
 const salaries = ['$20K - $50K', '$50K - $100K', '> $100K']
 ---
 
-<DefaultLayout title="Search for Jobs" pageHeader="Search for Jobs" actions="add-job" pageMenu="extra.job-listing">
+<DefaultLayout title="Search for Jobs" pageHeader="Search for Jobs" pageMenu="extra.job-listing">
+  <HeaderActionsAddJob slot="page-header-actions" />
   <div class="row g-4">
     <div class="col-md-3">
       <form action="./" method="get" autocomplete="off" novalidate class="sticky-top">

--- a/preview/pages/job-listing.astro
+++ b/preview/pages/job-listing.astro
@@ -24,7 +24,7 @@ const types = ['Programming', 'Design', 'Management / Finance', 'Customer Suppor
 const salaries = ['$20K - $50K', '$50K - $100K', '> $100K']
 ---
 
-<DefaultLayout title="Search for Jobs" pageHeader="Search for Jobs" pageMenu="extra.job-listing">
+<DefaultLayout title="Search for Jobs" pageMenu="extra.job-listing">
   <HeaderActionsAddJob slot="page-header-actions" />
   <div class="row g-4">
     <div class="col-md-3">

--- a/preview/pages/layout-boxed.astro
+++ b/preview/pages/layout-boxed.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Boxed layout" pretitle="Overview" actions="buttons" pageMenu="layout.boxed" pageLibs={['apexcharts', 'jsvectormap']} bodyClass="layout-boxed">
+<DefaultLayout title="Dashboard" pageHeader="Boxed layout" pretitle="Overview" pageMenu="layout.boxed" pageLibs={['apexcharts', 'jsvectormap']} bodyClass="layout-boxed">
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/layout-combo.astro
+++ b/preview/pages/layout-combo.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Combo layout" pretitle="Overview" actions="buttons" pageMenu="layout.combo" pageLibs={['apexcharts', 'jsvectormap']} sidebar sidebarDark navbarHideBrand navbarClass="d-none d-lg-flex" navbarCondensed>
+<DefaultLayout title="Dashboard" pageHeader="Combo layout" pretitle="Overview" pageMenu="layout.combo" pageLibs={['apexcharts', 'jsvectormap']} sidebar sidebarDark navbarHideBrand navbarClass="d-none d-lg-flex" navbarCondensed>
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/layout-condensed.astro
+++ b/preview/pages/layout-condensed.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Condensed layout" pretitle="Overview" actions="buttons" pageMenu="layout.condensed" pageLibs={['apexcharts', 'jsvectormap']} navbarCondensed>
+<DefaultLayout title="Dashboard" pageHeader="Condensed layout" pretitle="Overview" pageMenu="layout.condensed" pageLibs={['apexcharts', 'jsvectormap']} navbarCondensed>
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/layout-fluid-vertical.astro
+++ b/preview/pages/layout-fluid-vertical.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Fluid vertical layout" pretitle="Overview" actions="buttons" pageMenu="layout.fluid-vertical" pageLibs={['apexcharts', 'jsvectormap']} bodyClass="layout-fluid" sidebar sidebarDark hideTopbar>
+<DefaultLayout title="Dashboard" pageHeader="Fluid vertical layout" pretitle="Overview" pageMenu="layout.fluid-vertical" pageLibs={['apexcharts', 'jsvectormap']} bodyClass="layout-fluid" sidebar sidebarDark hideTopbar>
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/layout-fluid.astro
+++ b/preview/pages/layout-fluid.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Fluid layout" pretitle="Overview" actions="buttons" pageMenu="layout.fluid" pageLibs={['apexcharts', 'jsvectormap']} bodyClass="layout-fluid">
+<DefaultLayout title="Dashboard" pageHeader="Fluid layout" pretitle="Overview" pageMenu="layout.fluid" pageLibs={['apexcharts', 'jsvectormap']} bodyClass="layout-fluid">
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/layout-horizontal.astro
+++ b/preview/pages/layout-horizontal.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Horizontal layout" pretitle="Overview" actions="buttons" pageMenu="layout.horizontal" pageLibs={['apexcharts', 'jsvectormap']}>
+<DefaultLayout title="Dashboard" pageHeader="Horizontal layout" pretitle="Overview" pageMenu="layout.horizontal" pageLibs={['apexcharts', 'jsvectormap']}>
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/layout-navbar-dark.astro
+++ b/preview/pages/layout-navbar-dark.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Navbar dark" pretitle="Overview" actions="buttons" pageMenu="layout.navbar-dark" pageLibs={['apexcharts', 'jsvectormap']} navbarDark>
+<DefaultLayout title="Dashboard" pageHeader="Navbar dark" pretitle="Overview" pageMenu="layout.navbar-dark" pageLibs={['apexcharts', 'jsvectormap']} navbarDark>
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/layout-navbar-overlap.astro
+++ b/preview/pages/layout-navbar-overlap.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Navbar overlap layout" pretitle="Overview" actions="buttons" pageMenu="layout.navbar-overlap" pageLibs={['apexcharts', 'jsvectormap']} navbarOverlap navbarCondensed navbarDark>
+<DefaultLayout title="Dashboard" pageHeader="Navbar overlap layout" pretitle="Overview" pageMenu="layout.navbar-overlap" pageLibs={['apexcharts', 'jsvectormap']} navbarOverlap navbarCondensed navbarDark>
+  <HeaderActionsButtons slot="page-header-actions" dark />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/layout-navbar-sticky.astro
+++ b/preview/pages/layout-navbar-sticky.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Navbar sticky" pretitle="Overview" actions="buttons" pageMenu="layout.navbar-sticky" pageLibs={['apexcharts', 'jsvectormap']} navbarSticky>
+<DefaultLayout title="Dashboard" pageHeader="Navbar sticky" pretitle="Overview" pageMenu="layout.navbar-sticky" pageLibs={['apexcharts', 'jsvectormap']} navbarSticky>
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/layout-rtl.astro
+++ b/preview/pages/layout-rtl.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="RTL mode" pageHeader="RTL mode" pretitle="Overview" actions="buttons" pageMenu="home" pageLibs={['apexcharts', 'jsvectormap']} rtl>
+<DefaultLayout title="RTL mode" pageHeader="RTL mode" pretitle="Overview" pageMenu="home" pageLibs={['apexcharts', 'jsvectormap']} rtl>
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent rtl />
 </DefaultLayout>

--- a/preview/pages/layout-rtl.astro
+++ b/preview/pages/layout-rtl.astro
@@ -4,7 +4,7 @@ import HomepageContent from '@shared/components/HomepageContent.astro'
 import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="RTL mode" pageHeader="RTL mode" pretitle="Overview" pageMenu="home" pageLibs={['apexcharts', 'jsvectormap']} rtl>
+<DefaultLayout title="RTL mode" pretitle="Overview" pageMenu="home" pageLibs={['apexcharts', 'jsvectormap']} rtl>
   <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent rtl />
 </DefaultLayout>

--- a/preview/pages/layout-vertical-right.astro
+++ b/preview/pages/layout-vertical-right.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Right vertical layout" pretitle="Overview" actions="buttons" pageMenu="layout.vertical-end" pageLibs={['apexcharts', 'jsvectormap']} sidebar sidebarEnd hideTopbar>
+<DefaultLayout title="Dashboard" pageHeader="Right vertical layout" pretitle="Overview" pageMenu="layout.vertical-end" pageLibs={['apexcharts', 'jsvectormap']} sidebar sidebarEnd hideTopbar>
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/layout-vertical-transparent.astro
+++ b/preview/pages/layout-vertical-transparent.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Vertical transparent layout" pretitle="Overview" actions="buttons" pageMenu="layout.vertical-transparent" pageLibs={['apexcharts', 'jsvectormap']} sidebar navbarTransparent hideTopbar>
+<DefaultLayout title="Dashboard" pageHeader="Vertical transparent layout" pretitle="Overview" pageMenu="layout.vertical-transparent" pageLibs={['apexcharts', 'jsvectormap']} sidebar navbarTransparent hideTopbar>
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/layout-vertical.astro
+++ b/preview/pages/layout-vertical.astro
@@ -3,8 +3,10 @@
 // layout: homepage (page-header overridden by the page front matter)
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import HomepageContent from '@shared/components/HomepageContent.astro'
+import HeaderActionsButtons from '@shared/components/layout/HeaderActionsButtons.astro'
 ---
 
-<DefaultLayout title="Dashboard" pageHeader="Vertical layout" pretitle="Overview" actions="buttons" pageLibs={['apexcharts', 'jsvectormap']} pageMenu="layout.vertical" sidebar sidebarDark hideTopbar>
+<DefaultLayout title="Dashboard" pageHeader="Vertical layout" pretitle="Overview" pageLibs={['apexcharts', 'jsvectormap']} pageMenu="layout.vertical" sidebar sidebarDark hideTopbar>
+  <HeaderActionsButtons slot="page-header-actions" />
   <HomepageContent />
 </DefaultLayout>

--- a/preview/pages/lightbox.astro
+++ b/preview/pages/lightbox.astro
@@ -7,7 +7,7 @@ import photos from '@data/photos.json'
 const filteredPhotos = photos.filter((photo) => photo.horizontal)
 ---
 
-<DefaultLayout title="Lightbox" pageHeader="Lightbox" pageMenu="plugins.lightbox" pageLibs={['fslightbox']}>
+<DefaultLayout title="Lightbox" pageMenu="plugins.lightbox" pageLibs={['fslightbox']}>
   <div class="row row-cols-3 row-cols-md-4 row-cols-lg-6 g-3">
     {
       filteredPhotos.map((photo) => (

--- a/preview/pages/lists.astro
+++ b/preview/pages/lists.astro
@@ -2,21 +2,16 @@
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Card from '@ui/Card.astro'
 import CardHeader from '@ui/CardHeader.astro'
-import Icon from '@ui/Icon.astro'
 import UsersList from '@shared/components/cards/UsersList.astro'
 import UsersList2 from '@shared/components/cards/UsersList2.astro'
 import UsersListHeaders from '@shared/components/cards/UsersListHeaders.astro'
 import ListGroup from '@ui/ListGroup.astro'
 import ListGroupItem from '@ui/ListGroupItem.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const listGroupDocsUrl = getDocsUrl('/ui/components/list-group')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Lists" pageHeader="Lists" pageMenu="base.lists" description="Lists of users, contacts, and links — built from list-group items or a plain card body.">
-  <a slot="page-header-actions" href={listGroupDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Lists" pageMenu="base.lists" description="Lists of users, contacts, and links — built from list-group items or a plain card body.">
+  <DocsLink slot="page-header-actions" path="/ui/components/list-group" />
 
   <div class="row row-cards">
     <div class="col-md-6">

--- a/preview/pages/lists.astro
+++ b/preview/pages/lists.astro
@@ -9,18 +9,14 @@ import UsersListHeaders from '@shared/components/cards/UsersListHeaders.astro'
 import ListGroup from '@ui/ListGroup.astro'
 import ListGroupItem from '@ui/ListGroupItem.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const listGroupDocsUrl = getDocsUrl('/ui/components/list-group')
 ---
 
-<DefaultLayout title="Lists" pageMenu="base.lists" description="Lists of users, contacts, and links — built from list-group items or a plain card body.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Lists</PageTitle>
-    <a href={listGroupDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Lists" pageHeader="Lists" pageMenu="base.lists" description="Lists of users, contacts, and links — built from list-group items or a plain card body.">
+  <a slot="page-header-actions" href={listGroupDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     <div class="col-md-6">

--- a/preview/pages/logs.astro
+++ b/preview/pages/logs.astro
@@ -8,7 +8,7 @@ import CardFooter from '@ui/CardFooter.astro'
 import { site } from '@shared/lib/site'
 ---
 
-<DefaultLayout title="Logs" pageHeader="Logs" pageMenu="extra.logs">
+<DefaultLayout title="Logs" pageMenu="extra.logs">
   <div class="row">
     <div class="col-lg-6">
       <Card>

--- a/preview/pages/map-fullsize.astro
+++ b/preview/pages/map-fullsize.astro
@@ -3,7 +3,7 @@ import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import CaptureScript from '@shared/components/CaptureScript.astro'
 ---
 
-<DefaultLayout title="Full Size Map" pageMenu="plugins.map-fullsize" pageLibs={['google-maps']} sidebar hideTopbar wrapperFull>
+<DefaultLayout title="Full Size Map" pageHeader={false} pageMenu="plugins.map-fullsize" pageLibs={['google-maps']} sidebar hideTopbar wrapperFull>
   <h1 class="visually-hidden">Full Size Map</h1>
   <div class="map flex-fill" id="map-google"></div>
   <!--

--- a/preview/pages/maps-vector.astro
+++ b/preview/pages/maps-vector.astro
@@ -6,7 +6,7 @@ import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 ---
 
-<DefaultLayout title="Vector Maps" pageHeader="Vector Maps" pageMenu="plugins.maps-vector" pageLibs={['jsvectormap']}>
+<DefaultLayout title="Vector Maps" pageMenu="plugins.maps-vector" pageLibs={['jsvectormap']}>
   <div class="row row-cards">
     <div class="col-md-6">
       <Card>

--- a/preview/pages/maps.astro
+++ b/preview/pages/maps.astro
@@ -5,12 +5,13 @@ import Map from '@ui/Map.astro'
 import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import maps from '@data/maps.json'
+import CardTitle from '@ui/CardTitle.astro'
 
 type MapData = { title?: string; card?: boolean }
 const mapEntries = Object.entries(maps as Record<string, MapData>)
 ---
 
-<DefaultLayout title="Maps" pageHeader="Maps" pageMenu="plugins.maps" pageLibs={['mapbox']}>
+<DefaultLayout title="Maps" pageMenu="plugins.maps" pageLibs={['mapbox']}>
   <div class="row row-cards">
     {
       mapEntries.map(([mapId, data]) =>
@@ -24,7 +25,7 @@ const mapEntries = Object.entries(maps as Record<string, MapData>)
           <div class="col-lg-6">
             <Card>
               <CardBody>
-                <h3 class="card-title">{data.title}</h3>
+                <CardTitle>{data.title}</CardTitle>
                 <Map mapId={mapId} />
               </CardBody>
             </Card>

--- a/preview/pages/modals.astro
+++ b/preview/pages/modals.astro
@@ -24,20 +24,16 @@ import ConfirmDeleteModalContent from '@shared/components/modals/ConfirmDeleteMo
 import ChangePasswordModalContent from '@shared/components/modals/ChangePasswordModalContent.astro'
 import AddTaskModalContent from '@shared/components/modals/AddTaskModalContent.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const cardClass = 'position-relative rounded d-block bg-surface-backdrop py-6 w-auto h-auto z-0'
 
 const modalDocsUrl = getDocsUrl('/ui/components/modal')
 ---
 
-<DefaultLayout title="Modals" pageMenu="base.modals" pageLibs={['signature_pad', 'hugerte', 'litepicker', 'tom-select']} description="Modals interrupt the page to ask for input, confirmation, or a focused action.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Modals</PageTitle>
-    <a href={modalDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Modals" pageHeader="Modals" pageMenu="base.modals" pageLibs={['signature_pad', 'hugerte', 'litepicker', 'tom-select']} description="Modals interrupt the page to ask for input, confirmation, or a focused action.">
+  <a slot="page-header-actions" href={modalDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <Card>
     <CardBody>

--- a/preview/pages/modals.astro
+++ b/preview/pages/modals.astro
@@ -4,7 +4,6 @@
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
-import Icon from '@ui/Icon.astro'
 import ModalInline from '@shared/components/modals/ModalInline.astro'
 import SimpleModalContent from '@shared/components/modals/SimpleModalContent.astro'
 import LargeModalContent from '@shared/components/modals/LargeModalContent.astro'
@@ -23,17 +22,13 @@ import EditProfileModalContent from '@shared/components/modals/EditProfileModalC
 import ConfirmDeleteModalContent from '@shared/components/modals/ConfirmDeleteModalContent.astro'
 import ChangePasswordModalContent from '@shared/components/modals/ChangePasswordModalContent.astro'
 import AddTaskModalContent from '@shared/components/modals/AddTaskModalContent.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
+import DocsLink from '@ui/DocsLink.astro'
 
 const cardClass = 'position-relative rounded d-block bg-surface-backdrop py-6 w-auto h-auto z-0'
-
-const modalDocsUrl = getDocsUrl('/ui/components/modal')
 ---
 
-<DefaultLayout title="Modals" pageHeader="Modals" pageMenu="base.modals" pageLibs={['signature_pad', 'hugerte', 'litepicker', 'tom-select']} description="Modals interrupt the page to ask for input, confirmation, or a focused action.">
-  <a slot="page-header-actions" href={modalDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Modals" pageMenu="base.modals" pageLibs={['signature_pad', 'hugerte', 'litepicker', 'tom-select']} description="Modals interrupt the page to ask for input, confirmation, or a focused action.">
+  <DocsLink slot="page-header-actions" path="/ui/components/modal" />
 
   <Card>
     <CardBody>

--- a/preview/pages/music.astro
+++ b/preview/pages/music.astro
@@ -6,7 +6,7 @@ import TrackInfo from '@shared/components/cards/music/TrackInfo.astro'
 const topTrackIds = [8, 9, 10, 11, 12, 13]
 ---
 
-<DefaultLayout title="Music components" pageHeader="Music components" pageMenu="extra.music">
+<DefaultLayout title="Music components" pageMenu="extra.music">
   <div class="row">
     <div class="col-lg-8">
       <TracksList />

--- a/preview/pages/navigation.astro
+++ b/preview/pages/navigation.astro
@@ -4,16 +4,11 @@
 // fluid-search (variant 5) is a no-op — search block in condensed branch is dead code.
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Navbar from '@shared/components/navbar/Navbar.astro'
-import Icon from '@ui/Icon.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const navbarDocsUrl = getDocsUrl('/ui/layout/navbars')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Navigation" pageHeader="Navigation" pageMenu="base.navigation" description="Navbar variants — condensed, dark, colored, and with different logo and search layouts.">
-  <a slot="page-header-actions" href={navbarDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Navigation" pageMenu="base.navigation" description="Navbar variants — condensed, dark, colored, and with different logo and search layouts.">
+  <DocsLink slot="page-header-actions" path="/ui/layout/navbars" />
 
   <div class="box">
     <div class="mb-3">

--- a/preview/pages/navigation.astro
+++ b/preview/pages/navigation.astro
@@ -6,18 +6,14 @@ import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Navbar from '@shared/components/navbar/Navbar.astro'
 import Icon from '@ui/Icon.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const navbarDocsUrl = getDocsUrl('/ui/layout/navbars')
 ---
 
-<DefaultLayout title="Navigation" pageMenu="base.navigation" description="Navbar variants — condensed, dark, colored, and with different logo and search layouts.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Navigation</PageTitle>
-    <a href={navbarDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Navigation" pageHeader="Navigation" pageMenu="base.navigation" description="Navbar variants — condensed, dark, colored, and with different logo and search layouts.">
+  <a slot="page-header-actions" href={navbarDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="box">
     <div class="mb-3">

--- a/preview/pages/offcanvas.astro
+++ b/preview/pages/offcanvas.astro
@@ -1,23 +1,19 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
-import { ucFirst as capitalize, getDocsUrl } from '@shared/lib/string-format'
+import { ucFirst as capitalize } from '@shared/lib/string-format'
 import ButtonList from '@ui/ButtonList.astro'
 import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
-import Icon from '@ui/Icon.astro'
 import Offcanvas from '@ui/Offcanvas.astro'
 import OffcanvasHeader from '@ui/OffcanvasHeader.astro'
 import OffcanvasBody from '@ui/OffcanvasBody.astro'
+import DocsLink from '@ui/DocsLink.astro'
 
 const directions = ['start', 'end', 'top', 'bottom'] as const
-
-const offcanvasDocsUrl = getDocsUrl('/ui/components/offcanvas')
 ---
 
-<DefaultLayout title="Offcanvas" pageHeader="Offcanvas" pageMenu="base.offcanvas" description="An offcanvas panel slides in from an edge of the screen for navigation or supplementary content.">
-  <a slot="page-header-actions" href={offcanvasDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Offcanvas" pageMenu="base.offcanvas" description="An offcanvas panel slides in from an edge of the screen for navigation or supplementary content.">
+  <DocsLink slot="page-header-actions" path="/ui/components/offcanvas" />
 
   <Card>
     <CardBody>

--- a/preview/pages/offcanvas.astro
+++ b/preview/pages/offcanvas.astro
@@ -8,20 +8,16 @@ import Icon from '@ui/Icon.astro'
 import Offcanvas from '@ui/Offcanvas.astro'
 import OffcanvasHeader from '@ui/OffcanvasHeader.astro'
 import OffcanvasBody from '@ui/OffcanvasBody.astro'
-import PageTitle from '@ui/PageTitle.astro'
 
 const directions = ['start', 'end', 'top', 'bottom'] as const
 
 const offcanvasDocsUrl = getDocsUrl('/ui/components/offcanvas')
 ---
 
-<DefaultLayout title="Offcanvas" pageMenu="base.offcanvas" description="An offcanvas panel slides in from an edge of the screen for navigation or supplementary content.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Offcanvas</PageTitle>
-    <a href={offcanvasDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Offcanvas" pageHeader="Offcanvas" pageMenu="base.offcanvas" description="An offcanvas panel slides in from an edge of the screen for navigation or supplementary content.">
+  <a slot="page-header-actions" href={offcanvasDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <Card>
     <CardBody>

--- a/preview/pages/pagination.astro
+++ b/preview/pages/pagination.astro
@@ -5,16 +5,11 @@ import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
-import Icon from '@ui/Icon.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const paginationDocsUrl = getDocsUrl('/ui/components/pagination')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Pagination" pageHeader="Pagination" pageMenu="base.pagination" description="Pagination splits a long list of results into pages, with Prev/Next controls.">
-  <a slot="page-header-actions" href={paginationDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Pagination" pageMenu="base.pagination" description="Pagination splits a long list of results into pages, with Prev/Next controls.">
+  <DocsLink slot="page-header-actions" path="/ui/components/pagination" />
 
   <div class="row row-cards">
     <div class="col-12">

--- a/preview/pages/pagination.astro
+++ b/preview/pages/pagination.astro
@@ -7,18 +7,14 @@ import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
 import Icon from '@ui/Icon.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const paginationDocsUrl = getDocsUrl('/ui/components/pagination')
 ---
 
-<DefaultLayout title="Pagination" pageMenu="base.pagination" description="Pagination splits a long list of results into pages, with Prev/Next controls.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Pagination</PageTitle>
-    <a href={paginationDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Pagination" pageHeader="Pagination" pageMenu="base.pagination" description="Pagination splits a long list of results into pages, with Prev/Next controls.">
+  <a slot="page-header-actions" href={paginationDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     <div class="col-12">

--- a/preview/pages/patterns.astro
+++ b/preview/pages/patterns.astro
@@ -7,7 +7,6 @@ import Icon from '@ui/Icon.astro'
 import BackgroundPattern from '@ui/BackgroundPattern.astro'
 import site from '@data/site.json'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const patternColors = Object.keys(site.colors)
 const patternSizes = ['sm', 'md', 'lg', 'xl'] as const
@@ -17,13 +16,10 @@ const patterns = ['diagonal', 'diagonal-2', 'dots', 'rectangles', 'lines', 'line
 const patternsDocsUrl = getDocsUrl('/ui/utilities/background-patterns')
 ---
 
-<DefaultLayout title="Patterns" pageMenu="base.patterns" description="Background patterns you can apply to any element with a utility class.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Patterns</PageTitle>
-    <a href={patternsDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Patterns" pageHeader="Patterns" pageMenu="base.patterns" description="Background patterns you can apply to any element with a utility class.">
+  <a slot="page-header-actions" href={patternsDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     <div class="col-12">

--- a/preview/pages/patterns.astro
+++ b/preview/pages/patterns.astro
@@ -3,23 +3,18 @@ import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
-import Icon from '@ui/Icon.astro'
 import BackgroundPattern from '@ui/BackgroundPattern.astro'
 import site from '@data/site.json'
-import { getDocsUrl } from '@shared/lib/string-format'
+import DocsLink from '@ui/DocsLink.astro'
 
 const patternColors = Object.keys(site.colors)
 const patternSizes = ['sm', 'md', 'lg', 'xl'] as const
 
 const patterns = ['diagonal', 'diagonal-2', 'dots', 'rectangles', 'lines', 'lines-vertical', 'grid', 'grid-diagonal', 'blueprint', 'circles', 'diagonal-stripes', 'diagonal-stripes-2', 'zigzag', 'vertical-stripes', 'horizontal-stripes'] as const
-
-const patternsDocsUrl = getDocsUrl('/ui/utilities/background-patterns')
 ---
 
-<DefaultLayout title="Patterns" pageHeader="Patterns" pageMenu="base.patterns" description="Background patterns you can apply to any element with a utility class.">
-  <a slot="page-header-actions" href={patternsDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Patterns" pageMenu="base.patterns" description="Background patterns you can apply to any element with a utility class.">
+  <DocsLink slot="page-header-actions" path="/ui/utilities/background-patterns" />
 
   <div class="row row-cards">
     <div class="col-12">

--- a/preview/pages/payment-providers.astro
+++ b/preview/pages/payment-providers.astro
@@ -5,16 +5,17 @@ import Card from '@ui/Card.astro'
 import CardHeader from '@ui/CardHeader.astro'
 import CardBody from '@ui/CardBody.astro'
 import payments from '@data/payments.json'
+import CardTitle from '@ui/CardTitle.astro'
 
 const providers = payments as { name: string; logo: string }[]
 ---
 
-<DefaultLayout title="Payment Providers" pageHeader="Payment Providers" pageMenu="addons.payments">
+<DefaultLayout title="Payment Providers" pageMenu="addons.payments">
   <div class="row row-cards">
     <div class="col-12">
       <Card>
         <CardHeader>
-          <h3 class="card-title">Light version</h3>
+          <CardTitle>Light version</CardTitle>
         </CardHeader>
         <CardBody>
           <div class="row g-5 row-cols-5">
@@ -42,7 +43,7 @@ const providers = payments as { name: string; logo: string }[]
     <div class="col-12">
       <Card>
         <CardHeader>
-          <h3 class="card-title">Dark version</h3>
+          <CardTitle>Dark version</CardTitle>
         </CardHeader>
         <CardBody>
           <div class="row g-5 row-cols-5">

--- a/preview/pages/photogrid.astro
+++ b/preview/pages/photogrid.astro
@@ -8,7 +8,7 @@ import { requireIndex } from '@shared/lib/array'
 const photoAt = (i: number) => requireIndex(photosData, i)
 ---
 
-<DefaultLayout title="Photogrid" pageHeader="Photogrid" pageMenu="extra.photogrid" pageLibs={['fslightbox']}>
+<DefaultLayout title="Photogrid" pageMenu="extra.photogrid" pageLibs={['fslightbox']}>
   <div class="row g-2 g-md-3">
     <div class="col-lg-6">
       <div class="row g-2 g-md-3">

--- a/preview/pages/placeholder.astro
+++ b/preview/pages/placeholder.astro
@@ -1,23 +1,18 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
-import Icon from '@ui/Icon.astro'
 import PlaceholderCard1 from '@shared/components/cards/placeholder/Card1.astro'
 import PlaceholderCard2 from '@shared/components/cards/placeholder/Card2.astro'
 import PlaceholderCard3 from '@shared/components/cards/placeholder/Card3.astro'
 import PlaceholderCard4 from '@shared/components/cards/placeholder/Card4.astro'
 import PlaceholderCard5 from '@shared/components/cards/placeholder/Card5.astro'
 import PlaceholderCard6 from '@shared/components/cards/placeholder/Card6.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
+import DocsLink from '@ui/DocsLink.astro'
 
 const cols = [1, 2, 3, 4]
-
-const placeholderDocsUrl = getDocsUrl('/ui/components/placeholder')
 ---
 
-<DefaultLayout title="Placeholder" pageHeader="Placeholder" pageMenu="base.placeholder" description="Placeholders mimic the shape of content that hasn't loaded yet.">
-  <a slot="page-header-actions" href={placeholderDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Placeholder" pageMenu="base.placeholder" description="Placeholders mimic the shape of content that hasn't loaded yet.">
+  <DocsLink slot="page-header-actions" path="/ui/components/placeholder" />
 
   <div class="row row-cards">
     {

--- a/preview/pages/placeholder.astro
+++ b/preview/pages/placeholder.astro
@@ -8,20 +8,16 @@ import PlaceholderCard4 from '@shared/components/cards/placeholder/Card4.astro'
 import PlaceholderCard5 from '@shared/components/cards/placeholder/Card5.astro'
 import PlaceholderCard6 from '@shared/components/cards/placeholder/Card6.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const cols = [1, 2, 3, 4]
 
 const placeholderDocsUrl = getDocsUrl('/ui/components/placeholder')
 ---
 
-<DefaultLayout title="Placeholder" pageMenu="base.placeholder" description="Placeholders mimic the shape of content that hasn't loaded yet.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Placeholder</PageTitle>
-    <a href={placeholderDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Placeholder" pageHeader="Placeholder" pageMenu="base.placeholder" description="Placeholders mimic the shape of content that hasn't loaded yet.">
+  <a slot="page-header-actions" href={placeholderDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     {

--- a/preview/pages/playground-categories.astro
+++ b/preview/pages/playground-categories.astro
@@ -11,7 +11,7 @@ import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 ---
 
-<DefaultLayout title="Categories playground">
+<DefaultLayout title="Categories playground" pageHeader={false}>
   <!-- Header -->
   <div class="row align-items-center gy-3 mb-5">
     <div class="col">

--- a/preview/pages/playground-layout.astro
+++ b/preview/pages/playground-layout.astro
@@ -5,12 +5,12 @@ import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 ---
 
-<DefaultLayout title="Layout playground" pageHeader="Layout playground" pretitle="Playground" sidebar sidebarDark>
+<DefaultLayout title="Layout playground" pretitle="Playground" sidebar sidebarDark>
   <div class="row row-cards">
     <div class="col-12">
       <Card>
         <CardBody>
-          <CardTitle as="h2">Sandbox</CardTitle>
+          <CardTitle>Sandbox</CardTitle>
           <p class="text-secondary mb-0">Edit this page to try layout options, components, and styles.</p>
         </CardBody>
       </Card>

--- a/preview/pages/playground.astro
+++ b/preview/pages/playground.astro
@@ -9,6 +9,7 @@ import ProgressSteps from '@ui/ProgressSteps.astro'
 import Datepicker from '@ui/Datepicker.astro'
 import FormGroup from '@ui/FormGroup.astro'
 import Trending from '@ui/Trending.astro'
+import CardTitle from '@ui/CardTitle.astro'
 ---
 
 <DefaultLayout title="Playground" pageHeader="Project Settings" pageLibs={['litepicker']}>
@@ -157,7 +158,7 @@ import Trending from '@ui/Trending.astro'
     <div class="col-8">
       <Card>
         <CardBody>
-          <h3 class="card-title mb-4">Cohort Statistics</h3>
+          <CardTitle class="mb-4">Cohort Statistics</CardTitle>
           <dl class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
             <div class="col">
               <Subheader as="dt">Total Users</Subheader>

--- a/preview/pages/pricing-table.astro
+++ b/preview/pages/pricing-table.astro
@@ -5,7 +5,7 @@ import Card from '@ui/Card.astro'
 import Subheader from '@ui/Subheader.astro'
 ---
 
-<DefaultLayout title="Pricing table" pageHeader="Pricing table" pageMenu="extra.pricing-table">
+<DefaultLayout title="Pricing table" pageMenu="extra.pricing-table">
   <Card>
     <div class="table-responsive">
       <table class="table table-vcenter table-bordered table-nowrap card-table">

--- a/preview/pages/pricing.astro
+++ b/preview/pages/pricing.astro
@@ -4,7 +4,7 @@ import PricingCard from '@shared/components/cards/PricingCard.astro'
 import PricingCardEnterprise from '@shared/components/cards/PricingCardEnterprise.astro'
 ---
 
-<DefaultLayout title="Pricing cards" pageHeader="Pricing cards" pageMenu="extra.pricing">
+<DefaultLayout title="Pricing cards" pageMenu="extra.pricing">
   <div class="row row-cards">
     <div class="col-sm-6 col-lg-3">
       <PricingCard price="0" users={3} category="Free" />

--- a/preview/pages/profile.astro
+++ b/preview/pages/profile.astro
@@ -20,7 +20,7 @@ import UserInfo from '@shared/components/cards/UserInfo.astro'
         <div class="col-12">
           <Card>
             <CardBody>
-              <CardTitle as="h2">About Me</CardTitle>
+              <CardTitle>About Me</CardTitle>
               <div>
                 <p>
                   Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusantium aliquid beatae eaque eius esse fugit, hic id illo itaque modi molestias nemo perferendis quae rerum soluta. Blanditiis laborum minima molestiae molestias nemo nesciunt nisi pariatur quae sapiente ut. Aut consectetur doloremque,

--- a/preview/pages/progress.astro
+++ b/preview/pages/progress.astro
@@ -11,7 +11,7 @@ import ProgressBg from '@ui/ProgressBg.astro'
 import ProgressDescription from '@ui/ProgressDescription.astro'
 ---
 
-<DefaultLayout title="Progress" pageHeader="Progress" pageMenu="base.progress">
+<DefaultLayout title="Progress" pageMenu="base.progress">
   <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
     <div class="col">
       <Card>

--- a/preview/pages/prose.astro
+++ b/preview/pages/prose.astro
@@ -4,18 +4,14 @@ import Prose from '@ui/Prose.astro'
 import Icon from '@ui/Icon.astro'
 import Avatar from '@ui/Avatar.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const proseDocsUrl = getDocsUrl('/ui/base/prose')
 ---
 
-<DefaultLayout title="Prose" pageMenu="base.prose" description="Wrap long-form content in .prose to style headings, paragraphs, lists, and tables without adding classes to every element.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Prose</PageTitle>
-    <a href={proseDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Prose" pageHeader="Prose" pageMenu="base.prose" description="Wrap long-form content in .prose to style headings, paragraphs, lists, and tables without adding classes to every element.">
+  <a slot="page-header-actions" href={proseDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row justify-content-center">
     <div class="col-lg-9 col-xl-8">

--- a/preview/pages/prose.astro
+++ b/preview/pages/prose.astro
@@ -1,17 +1,12 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Prose from '@ui/Prose.astro'
-import Icon from '@ui/Icon.astro'
 import Avatar from '@ui/Avatar.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const proseDocsUrl = getDocsUrl('/ui/base/prose')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Prose" pageHeader="Prose" pageMenu="base.prose" description="Wrap long-form content in .prose to style headings, paragraphs, lists, and tables without adding classes to every element.">
-  <a slot="page-header-actions" href={proseDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Prose" pageMenu="base.prose" description="Wrap long-form content in .prose to style headings, paragraphs, lists, and tables without adding classes to every element.">
+  <DocsLink slot="page-header-actions" path="/ui/base/prose" />
 
   <div class="row justify-content-center">
     <div class="col-lg-9 col-xl-8">

--- a/preview/pages/scroll-spy.astro
+++ b/preview/pages/scroll-spy.astro
@@ -63,7 +63,7 @@ const articles: [string, string[]][] = [
 ]
 ---
 
-<DefaultLayout title="Scroll Spy" pageHeader="Scroll Spy" pageMenu="base.scroll-spy">
+<DefaultLayout title="Scroll Spy" pageMenu="base.scroll-spy">
   <div class="row g-5">
     <div class="col-sm-2">
       <div class="sticky-top">

--- a/preview/pages/search-results.astro
+++ b/preview/pages/search-results.astro
@@ -9,7 +9,7 @@ import { requireIndex } from '@shared/lib/array'
 const resultPhotos = photos.filter((photo) => photo.horizontal).slice(0, 18)
 ---
 
-<DefaultLayout title="Search results" pageHeader="Search results" description="About 2,410 result (0.19 seconds)" pageMenu="extra.search-results">
+<DefaultLayout title="Search results" description="About 2,410 result (0.19 seconds)" pageMenu="extra.search-results">
   <div class="row g-4">
     <div class="col-md-3">
       <NavAside />

--- a/preview/pages/segmented-control.astro
+++ b/preview/pages/segmented-control.astro
@@ -5,16 +5,11 @@ import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
-import Icon from '@ui/Icon.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const segmentedControlDocsUrl = getDocsUrl('/ui/components/segmented-control')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Segmented control" pageHeader="Segmented control" pageMenu="base.segmented-control" description="A segmented control lets users pick one option from a small, always-visible set.">
-  <a slot="page-header-actions" href={segmentedControlDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Segmented control" pageMenu="base.segmented-control" description="A segmented control lets users pick one option from a small, always-visible set.">
+  <DocsLink slot="page-header-actions" path="/ui/components/segmented-control" />
 
   <div class="row row-cards">
     <div class="col-md-6">

--- a/preview/pages/segmented-control.astro
+++ b/preview/pages/segmented-control.astro
@@ -7,18 +7,14 @@ import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
 import Icon from '@ui/Icon.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const segmentedControlDocsUrl = getDocsUrl('/ui/components/segmented-control')
 ---
 
-<DefaultLayout title="Segmented control" pageMenu="base.segmented-control" description="A segmented control lets users pick one option from a small, always-visible set.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Segmented control</PageTitle>
-    <a href={segmentedControlDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Segmented control" pageHeader="Segmented control" pageMenu="base.segmented-control" description="A segmented control lets users pick one option from a small, always-visible set.">
+  <a slot="page-header-actions" href={segmentedControlDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     <div class="col-md-6">

--- a/preview/pages/signatures.astro
+++ b/preview/pages/signatures.astro
@@ -57,7 +57,7 @@ document.querySelector("#signature-advanced-png").addEventListener("click", func
 });`
 ---
 
-<DefaultLayout title="Signatures" pageHeader="Signatures" pageMenu="extra.signatures" pageLibs={['signature_pad']}>
+<DefaultLayout title="Signatures" pageMenu="extra.signatures" pageLibs={['signature_pad']}>
   <div class="row row-cards">
     <div class="col-lg-6">
       <Card>

--- a/preview/pages/social-icons.astro
+++ b/preview/pages/social-icons.astro
@@ -7,10 +7,9 @@ import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
-import Icon from '@ui/Icon.astro'
 import socialTiles from '@data/social-tiles.json'
 import socials from '@data/socials.json'
-import { getDocsUrl } from '@shared/lib/string-format'
+import DocsLink from '@ui/DocsLink.astro'
 
 interface SocialTile {
   icon: string
@@ -27,14 +26,10 @@ interface Social {
 const tiles = socialTiles as SocialTile[]
 const socialList = socials as Social[]
 const fillers = Array.from({ length: 21 })
-
-const socialDocsUrl = getDocsUrl('/ui/plugins/social-icons')
 ---
 
-<DefaultLayout title="Social icons" pageHeader="Social icons" pageMenu="base.social" description="Branded icons and helpers for linking out to, or signing in with, social networks.">
-  <a slot="page-header-actions" href={socialDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Social icons" pageMenu="base.social" description="Branded icons and helpers for linking out to, or signing in with, social networks.">
+  <DocsLink slot="page-header-actions" path="/ui/plugins/social-icons" />
 
   <div class="row row-cards">
     <div class="col-12">

--- a/preview/pages/social-icons.astro
+++ b/preview/pages/social-icons.astro
@@ -11,7 +11,6 @@ import Icon from '@ui/Icon.astro'
 import socialTiles from '@data/social-tiles.json'
 import socials from '@data/socials.json'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 interface SocialTile {
   icon: string
@@ -32,13 +31,10 @@ const fillers = Array.from({ length: 21 })
 const socialDocsUrl = getDocsUrl('/ui/plugins/social-icons')
 ---
 
-<DefaultLayout title="Social icons" pageMenu="base.social" description="Branded icons and helpers for linking out to, or signing in with, social networks.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Social icons</PageTitle>
-    <a href={socialDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Social icons" pageHeader="Social icons" pageMenu="base.social" description="Branded icons and helpers for linking out to, or signing in with, social networks.">
+  <a slot="page-header-actions" href={socialDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     <div class="col-12">

--- a/preview/pages/stars-rating.astro
+++ b/preview/pages/stars-rating.astro
@@ -7,18 +7,14 @@ import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
 import Icon from '@ui/Icon.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const starsRatingDocsUrl = getDocsUrl('/ui/components/star-rating')
 ---
 
-<DefaultLayout title="Star Ratings" pageMenu="base.stars-rating" pageLibs={['tabler-flags', 'star-rating.js']} description="An interactive star rating built on the star-rating.js widget, backed by a hidden select for accessibility and forms.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Star Ratings</PageTitle>
-    <a href={starsRatingDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Star Ratings" pageHeader="Star Ratings" pageMenu="base.stars-rating" pageLibs={['tabler-flags', 'star-rating.js']} description="An interactive star rating built on the star-rating.js widget, backed by a hidden select for accessibility and forms.">
+  <a slot="page-header-actions" href={starsRatingDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards mb-5">
     <div class="col-md-6 col-lg-4">

--- a/preview/pages/stars-rating.astro
+++ b/preview/pages/stars-rating.astro
@@ -5,16 +5,11 @@ import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
-import Icon from '@ui/Icon.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const starsRatingDocsUrl = getDocsUrl('/ui/components/star-rating')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Star Ratings" pageHeader="Star Ratings" pageMenu="base.stars-rating" pageLibs={['tabler-flags', 'star-rating.js']} description="An interactive star rating built on the star-rating.js widget, backed by a hidden select for accessibility and forms.">
-  <a slot="page-header-actions" href={starsRatingDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Star Ratings" pageMenu="base.stars-rating" pageLibs={['tabler-flags', 'star-rating.js']} description="An interactive star rating built on the star-rating.js widget, backed by a hidden select for accessibility and forms.">
+  <DocsLink slot="page-header-actions" path="/ui/components/star-rating" />
 
   <div class="row row-cards mb-5">
     <div class="col-md-6 col-lg-4">

--- a/preview/pages/steps.astro
+++ b/preview/pages/steps.astro
@@ -6,18 +6,14 @@ import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
 import Icon from '@ui/Icon.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const stepDocsUrl = getDocsUrl('/ui/components/step')
 ---
 
-<DefaultLayout title="Steps" pageMenu="base.steps" description="Steps show progress through a numbered or labeled sequence, as a horizontal bar, breadcrumb, or vertical timeline.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Steps</PageTitle>
-    <a href={stepDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Steps" pageHeader="Steps" pageMenu="base.steps" description="Steps show progress through a numbered or labeled sequence, as a horizontal bar, breadcrumb, or vertical timeline.">
+  <a slot="page-header-actions" href={stepDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards mb-5">
     <div class="col-12">

--- a/preview/pages/steps.astro
+++ b/preview/pages/steps.astro
@@ -4,16 +4,11 @@ import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
-import Icon from '@ui/Icon.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const stepDocsUrl = getDocsUrl('/ui/components/step')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Steps" pageHeader="Steps" pageMenu="base.steps" description="Steps show progress through a numbered or labeled sequence, as a horizontal bar, breadcrumb, or vertical timeline.">
-  <a slot="page-header-actions" href={stepDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Steps" pageMenu="base.steps" description="Steps show progress through a numbered or labeled sequence, as a horizontal bar, breadcrumb, or vertical timeline.">
+  <DocsLink slot="page-header-actions" path="/ui/components/step" />
 
   <div class="row row-cards mb-5">
     <div class="col-12">

--- a/preview/pages/tables.astro
+++ b/preview/pages/tables.astro
@@ -7,7 +7,7 @@ import AdvancedTable from '@ui/AdvancedTable.astro'
 import Card from '@ui/Card.astro'
 ---
 
-<DefaultLayout title="Tables" pageHeader="Tables" pageMenu="base.tables" pageLibs={['lists']}>
+<DefaultLayout title="Tables" pageMenu="base.tables" pageLibs={['lists']}>
   <div class="row row-cards">
     <div class="col-lg-8">
       <Card>

--- a/preview/pages/tabs.astro
+++ b/preview/pages/tabs.astro
@@ -1,16 +1,11 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import TabsCard from '@shared/components/cards/TabsCard.astro'
-import Icon from '@ui/Icon.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const tabsDocsUrl = getDocsUrl('/ui/layout/navs-tabs')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Tabs" pageHeader="Tabs" pageMenu="base.tabs" description="Tabs switch between related panels of content inside a card.">
-  <a slot="page-header-actions" href={tabsDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Tabs" pageMenu="base.tabs" description="Tabs switch between related panels of content inside a card.">
+  <DocsLink slot="page-header-actions" path="/ui/layout/navs-tabs" />
 
   <div class="row row-cards">
     <div class="col-md-4"><TabsCard id="1" settings /></div>

--- a/preview/pages/tabs.astro
+++ b/preview/pages/tabs.astro
@@ -3,18 +3,14 @@ import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import TabsCard from '@shared/components/cards/TabsCard.astro'
 import Icon from '@ui/Icon.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const tabsDocsUrl = getDocsUrl('/ui/layout/navs-tabs')
 ---
 
-<DefaultLayout title="Tabs" pageMenu="base.tabs" description="Tabs switch between related panels of content inside a card.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Tabs</PageTitle>
-    <a href={tabsDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Tabs" pageHeader="Tabs" pageMenu="base.tabs" description="Tabs switch between related panels of content inside a card.">
+  <a slot="page-header-actions" href={tabsDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     <div class="col-md-4"><TabsCard id="1" settings /></div>

--- a/preview/pages/tags.astro
+++ b/preview/pages/tags.astro
@@ -11,7 +11,6 @@ import people from '@data/people.json'
 import flags from '@data/flags.json'
 import siteData from '@data/site.json'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const tagIcons = ['bold', 'italic', 'underline', 'copy', 'scissors', 'file-plus', 'file-minus', 'ghost', 'star', 'script', 'photo', 'dog', 'piano']
 
@@ -26,13 +25,10 @@ const colors = Object.values(siteData.colors) as { class: string; title: string 
 const tagDocsUrl = getDocsUrl('/ui/components/tag')
 ---
 
-<DefaultLayout title="Tags" pageMenu="base.tags" description="Tags are compact labels for filters, categories, and keywords.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Tags</PageTitle>
-    <a href={tagDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Tags" pageHeader="Tags" pageMenu="base.tags" description="Tags are compact labels for filters, categories, and keywords.">
+  <a slot="page-header-actions" href={tagDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards row-cols-1 row-cols-md-2 row-cols-lg-3">
     <div class="col">

--- a/preview/pages/tags.astro
+++ b/preview/pages/tags.astro
@@ -6,11 +6,10 @@ import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
-import Icon from '@ui/Icon.astro'
 import people from '@data/people.json'
 import flags from '@data/flags.json'
 import siteData from '@data/site.json'
-import { getDocsUrl } from '@shared/lib/string-format'
+import DocsLink from '@ui/DocsLink.astro'
 
 const tagIcons = ['bold', 'italic', 'underline', 'copy', 'scissors', 'file-plus', 'file-minus', 'ghost', 'star', 'script', 'photo', 'dog', 'piano']
 
@@ -21,14 +20,10 @@ const people8 = people.slice(0, 8)
 
 // site.colors yields value objects with .class / .title.
 const colors = Object.values(siteData.colors) as { class: string; title: string }[]
-
-const tagDocsUrl = getDocsUrl('/ui/components/tag')
 ---
 
-<DefaultLayout title="Tags" pageHeader="Tags" pageMenu="base.tags" description="Tags are compact labels for filters, categories, and keywords.">
-  <a slot="page-header-actions" href={tagDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Tags" pageMenu="base.tags" description="Tags are compact labels for filters, categories, and keywords.">
+  <DocsLink slot="page-header-actions" path="/ui/components/tag" />
 
   <div class="row row-cards row-cols-1 row-cols-md-2 row-cols-lg-3">
     <div class="col">

--- a/preview/pages/tasks-list.astro
+++ b/preview/pages/tasks-list.astro
@@ -11,6 +11,7 @@ import FormGroup from '@ui/FormGroup.astro'
 import tasks from '@data/tasks.json'
 import people from '@data/people.json'
 import { requireIndex } from '@shared/lib/array'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Person {
   id?: string
@@ -40,14 +41,14 @@ const peopleList = people as Person[]
 const selectedPeople = [5, 6, 2, 3].map((id) => requireIndex(peopleList, id - 1))
 ---
 
-<DefaultLayout title="Task List" pageHeader="Task List" pageMenu="extra.tasks.list">
+<DefaultLayout title="Task List" pageMenu="extra.tasks.list">
   <div class="row">
     <div class="col-12">
       {
         columns.map((section) => (
           <div class="card mb-4">
             <div class="card-header">
-              <h3 class="card-title mb-0">{section.name}</h3>
+              <CardTitle class="mb-0">{section.name}</CardTitle>
               <CardActions>
                 <Button text="New Task" icon="plus" modalId="add-task" size="sm" />
               </CardActions>

--- a/preview/pages/tasks.astro
+++ b/preview/pages/tasks.astro
@@ -1,9 +1,11 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Tasks from '@shared/components/parts/Tasks.astro'
+import HeaderActionsAddBoard from '@shared/components/layout/HeaderActionsAddBoard.astro'
 ---
 
-<DefaultLayout title="Tasks" pageHeader="Tabler Inc. Tasks" pageMenu="extra.tasks.kanban" actions="add-board">
+<DefaultLayout title="Tasks" pageHeader="Tabler Inc. Tasks" pageMenu="extra.tasks.kanban">
+  <HeaderActionsAddBoard slot="page-header-actions" />
   <ul class="nav nav-bordered mb-4">
     <li class="nav-item">
       <a class="nav-link active" aria-current="page" href="#">View all</a>

--- a/preview/pages/text-features.astro
+++ b/preview/pages/text-features.astro
@@ -7,7 +7,7 @@ import siteData from '@data/site.json'
 const homepage = siteData.homepage
 ---
 
-<DefaultLayout title="Text features" pageHeader="Text features" pageMenu="extra.text-features">
+<DefaultLayout title="Text features" pageMenu="extra.text-features">
   <div class="row">
     <div class="col-7">
       <div class="card card-lg">

--- a/preview/pages/toasts.astro
+++ b/preview/pages/toasts.astro
@@ -4,17 +4,12 @@ import Button from '@ui/Button.astro'
 import ButtonList from '@ui/ButtonList.astro'
 import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
-import Icon from '@ui/Icon.astro'
 import Toast from '@ui/Toast.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
-
-const toastDocsUrl = getDocsUrl('/ui/components/toast')
+import DocsLink from '@ui/DocsLink.astro'
 ---
 
-<DefaultLayout title="Toasts" pageHeader="Toasts" pageMenu="base.toasts" description="Toasts show a brief, dismissible notification in the corner of the screen.">
-  <a slot="page-header-actions" href={toastDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Toasts" pageMenu="base.toasts" description="Toasts show a brief, dismissible notification in the corner of the screen.">
+  <DocsLink slot="page-header-actions" path="/ui/components/toast" />
 
   <Card>
     <CardBody>

--- a/preview/pages/toasts.astro
+++ b/preview/pages/toasts.astro
@@ -7,18 +7,14 @@ import CardBody from '@ui/CardBody.astro'
 import Icon from '@ui/Icon.astro'
 import Toast from '@ui/Toast.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 const toastDocsUrl = getDocsUrl('/ui/components/toast')
 ---
 
-<DefaultLayout title="Toasts" pageMenu="base.toasts" description="Toasts show a brief, dismissible notification in the corner of the screen.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Toasts</PageTitle>
-    <a href={toastDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Toasts" pageHeader="Toasts" pageMenu="base.toasts" description="Toasts show a brief, dismissible notification in the corner of the screen.">
+  <a slot="page-header-actions" href={toastDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <Card>
     <CardBody>

--- a/preview/pages/tour.astro
+++ b/preview/pages/tour.astro
@@ -12,7 +12,7 @@ import Badge from '@ui/Badge.astro'
 import Icon from '@ui/Icon.astro'
 ---
 
-<DefaultLayout title="Driver Tour" pageHeader="Driver Tour" pageMenu="plugins.tour" pageLibs={['driver.js']}>
+<DefaultLayout title="Driver Tour" pageMenu="plugins.tour" pageLibs={['driver.js']}>
   <div class="row row-cards">
     <div class="col-12">
       <Card>

--- a/preview/pages/tracking.astro
+++ b/preview/pages/tracking.astro
@@ -7,7 +7,6 @@ import CardSubtitle from '@ui/CardSubtitle.astro'
 import Icon from '@ui/Icon.astro'
 import StatusMonitoring from '@shared/components/cards/StatusMonitoring.astro'
 import { getDocsUrl } from '@shared/lib/string-format'
-import PageTitle from '@ui/PageTitle.astro'
 
 interface TrackingItem {
   status?: 'success' | 'warning' | 'danger'
@@ -51,13 +50,10 @@ const uptime: TrackingItem[] = [
 const trackingDocsUrl = getDocsUrl('/ui/components/tracking')
 ---
 
-<DefaultLayout title="Tracking" pageMenu="base.tracking" description="Tracking blocks show an uptime or activity history as a row of colored bars.">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <PageTitle>Tracking</PageTitle>
-    <a href={trackingDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-      Docs <Icon name="external-link" class="icon-sm" />
-    </a>
-  </div>
+<DefaultLayout title="Tracking" pageHeader="Tracking" pageMenu="base.tracking" description="Tracking blocks show an uptime or activity history as a row of colored bars.">
+  <a slot="page-header-actions" href={trackingDocsUrl} target="_blank" rel="noopener" class="link-secondary">
+    Docs <Icon name="external-link" class="icon-sm" />
+  </a>
 
   <div class="row row-cards">
     <div class="col-12">

--- a/preview/pages/tracking.astro
+++ b/preview/pages/tracking.astro
@@ -4,9 +4,8 @@ import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import CardSubtitle from '@ui/CardSubtitle.astro'
-import Icon from '@ui/Icon.astro'
 import StatusMonitoring from '@shared/components/cards/StatusMonitoring.astro'
-import { getDocsUrl } from '@shared/lib/string-format'
+import DocsLink from '@ui/DocsLink.astro'
 
 interface TrackingItem {
   status?: 'success' | 'warning' | 'danger'
@@ -46,14 +45,10 @@ const uptime: TrackingItem[] = [
   { status: 'success', label: 'Operational' },
   { status: 'success', label: 'Operational' },
 ]
-
-const trackingDocsUrl = getDocsUrl('/ui/components/tracking')
 ---
 
-<DefaultLayout title="Tracking" pageHeader="Tracking" pageMenu="base.tracking" description="Tracking blocks show an uptime or activity history as a row of colored bars.">
-  <a slot="page-header-actions" href={trackingDocsUrl} target="_blank" rel="noopener" class="link-secondary">
-    Docs <Icon name="external-link" class="icon-sm" />
-  </a>
+<DefaultLayout title="Tracking" pageMenu="base.tracking" description="Tracking blocks show an uptime or activity history as a row of colored bars.">
+  <DocsLink slot="page-header-actions" path="/ui/components/tracking" />
 
   <div class="row row-cards">
     <div class="col-12">

--- a/preview/pages/typography.astro
+++ b/preview/pages/typography.astro
@@ -2,7 +2,7 @@
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 ---
 
-<DefaultLayout title="Typography" pageHeader="Typography" pageMenu="base.typography">
+<DefaultLayout title="Typography" pageMenu="base.typography">
   <div class="card card-lg">
     <div class="card-body">
       <div class="row g-4">

--- a/preview/pages/users.astro
+++ b/preview/pages/users.astro
@@ -31,9 +31,9 @@ const users = (people as Person[]).slice(0, 18)
             <Card>
               <CardBody class="p-4 text-center">
                 <Avatar size="xl" person={person} class="mb-3" />
-                <h3 class="m-0 mb-1">
+                <h2 class="m-0 mb-1">
                   <a href="#">{person.full_name}</a>
-                </h3>
+                </h2>
                 <div class="text-secondary">{person.job_title}</div>
 
                 <div class="mt-3">{index === 1 ? <span class="badge bg-purple-lt">Owner</span> : index < 5 ? <span class="badge bg-green-lt">Admin</span> : null}</div>

--- a/preview/pages/users.astro
+++ b/preview/pages/users.astro
@@ -8,6 +8,7 @@ import CardBody from '@ui/CardBody.astro'
 import Icon from '@ui/Icon.astro'
 import Pagination from '@ui/Pagination.astro'
 import people from '@data/people.json'
+import HeaderActionsUsers from '@shared/components/layout/HeaderActionsUsers.astro'
 
 interface Person {
   full_name?: string
@@ -19,7 +20,8 @@ interface Person {
 const users = (people as Person[]).slice(0, 18)
 ---
 
-<DefaultLayout title="Users list" pageHeader="Users" actions="users" description="1-18 of 413 people" pageMenu="extra.users">
+<DefaultLayout title="Users list" pageHeader="Users" description="1-18 of 413 people" pageMenu="extra.users">
+  <HeaderActionsUsers slot="page-header-actions" />
   <div class="row row-cards">
     {
       users.map((person, idx) => {

--- a/preview/pages/widgets.astro
+++ b/preview/pages/widgets.astro
@@ -14,7 +14,7 @@ import UserInfo from '@shared/components/cards/UserInfo.astro'
 import Configuration from '@shared/components/cards/Configuration.astro'
 ---
 
-<DefaultLayout title="Widgets" pageHeader="Widgets" pageMenu="extra.widgets" pageLibs={['apexcharts']}>
+<DefaultLayout title="Widgets" pageMenu="extra.widgets" pageLibs={['apexcharts']}>
   <div class="row row-cards">
     <div class="col-12 col-md-6 col-xxl-3 mb-4 mb-xxl-0">
       <StatCard title="Earned" value="$2,847" icon="credit-card" />

--- a/preview/pages/wysiwyg.astro
+++ b/preview/pages/wysiwyg.astro
@@ -7,7 +7,7 @@ import Wysiwyg from '@ui/Wysiwyg.astro'
 import FormGroup from '@ui/FormGroup.astro'
 ---
 
-<DefaultLayout title="HugeRTE" pageHeader="HugeRTE" pageLibs={['hugerte']}>
+<DefaultLayout title="HugeRTE" pageLibs={['hugerte']}>
   <Card>
     <CardBody>
       <FormGroup label="Your name" for="wysiwyg-name">

--- a/shared/components/cards/AuthLockCard.astro
+++ b/shared/components/cards/AuthLockCard.astro
@@ -11,7 +11,7 @@ const person = requireIndex(people, 0)
 <form class="card card-md" action="./" method="get" novalidate>
   <div class="card-body text-center">
     <div class="mb-4">
-      <CardTitle as="h2">Account Locked</CardTitle>
+      <CardTitle>Account Locked</CardTitle>
       <p class="text-secondary">Please enter your password to unlock your account</p>
     </div>
 

--- a/shared/components/cards/AuthenticateAccount.astro
+++ b/shared/components/cards/AuthenticateAccount.astro
@@ -3,11 +3,12 @@ import FormFooter from '@ui/FormFooter.astro'
 import Button from '@ui/Button.astro'
 import ButtonList from '@ui/ButtonList.astro'
 import CaptureScript from '../CaptureScript.astro'
+import CardTitle from '@ui/CardTitle.astro'
 ---
 
 <form class="card card-md" action="#" method="get" autocomplete="off" novalidate>
   <div class="card-body">
-    <h2 class="card-title card-title-lg text-center mb-4">Authenticate Your Account</h2>
+    <CardTitle class="card-title-lg text-center mb-4">Authenticate Your Account</CardTitle>
 
     <p class="my-4 text-center">
       Please confirm your account by entering the authorization code sent to <strong>+1 856-672-8552</strong>.

--- a/shared/components/cards/Card.astro
+++ b/shared/components/cards/Card.astro
@@ -6,6 +6,7 @@ import Empty from '@ui/Empty.astro';
 import Progress from '@ui/Progress.astro';
 import photos from '@data/photos.json';
 import { requireIndex } from '@shared/lib/array';
+import CardTitle from '@ui/CardTitle.astro';
 
 interface Props {
 	class?: string;
@@ -113,13 +114,17 @@ const imgBottomPhoto = requireIndex(photos as { file: string; title: string }[],
 								</li>
 							</ul>
 						) : (
-							<h3 class="card-title">Header title</h3>
+							<CardTitle>Header title</CardTitle>
 						)}
 					</div>
 				)}
 
 				<div class="card-body">
-					{title && <h3 class="card-title" set:html={title} />}
+					{title && (
+						<CardTitle>
+							<Fragment set:html={title} />
+						</CardTitle>
+					)}
 
 					<p class="text-secondary">
 						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam deleniti fugit incidunt, iste, itaque

--- a/shared/components/cards/CardImage.astro
+++ b/shared/components/cards/CardImage.astro
@@ -2,6 +2,7 @@
 import { staticPath } from '@shared/lib/assets'
 import photos from '@data/photos.json'
 import { requireIndex } from '@shared/lib/array'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Props {
   title?: string
@@ -23,7 +24,13 @@ const imgClass = `w-100 h-100 object-cover ${right ? 'card-img-end' : 'card-img-
     </div>
     <div class="col">
       <div class="card-body">
-        {title && <h3 class="card-title" set:html={title} />}
+        {
+          title && (
+            <CardTitle>
+              <Fragment set:html={title} />
+            </CardTitle>
+          )
+        }
         <p class="text-secondary">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam deleniti fugit incidunt, iste, itaque minima neque pariatur perferendis sed suscipit velit vitae voluptatem.</p>
       </div>
     </div>

--- a/shared/components/cards/CardTabs.astro
+++ b/shared/components/cards/CardTabs.astro
@@ -22,7 +22,7 @@ ${tabs
     (tab, i) => `   <!-- Content of card #${tab} -->
    <div id="tab-${id}-${i + 1}" class="card tab-pane${i === 0 ? ' active show' : ''}" role="tabpanel" aria-labelledby="tab-${id}-${i + 1}-tab">
       <div class="card-body">
-         <h3 class="card-title">${tab}</h3>
+         <h2 class="card-title">${tab}</h2>
          <p class="text-secondary">
             Lorem ipsum dolor sit amet, consectetur adipisicing elit. Adipisci, alias aliquid distinctio dolorem expedita, fugiat hic magni molestiae molestias odit.
          </p>

--- a/shared/components/cards/ChurnRisk.astro
+++ b/shared/components/cards/ChurnRisk.astro
@@ -5,6 +5,7 @@ import Badge from '@ui/Badge.astro'
 import ListGroup from '@ui/ListGroup.astro'
 import ListGroupItem from '@ui/ListGroupItem.astro'
 import crmDashboard from '@data/crm-dashboard.json'
+import CardTitle from '@ui/CardTitle.astro'
 
 const churn = crmDashboard.churn_risk
 ---
@@ -13,7 +14,7 @@ const churn = crmDashboard.churn_risk
   <div class="card-header">
     <div class="d-flex align-items-center gap-2">
       <Icon name="alert-triangle" class="text-red" />
-      <h3 class="card-title mb-0">Churn risk</h3>
+      <CardTitle class="mb-0">Churn risk</CardTitle>
     </div>
     <CardActions>
       <Badge text={`${churn.items.length} accounts`} color="red" />

--- a/shared/components/cards/DevelopmentActivity.astro
+++ b/shared/components/cards/DevelopmentActivity.astro
@@ -5,6 +5,7 @@ import Icon from '@ui/Icon.astro'
 import Avatar from '@ui/Avatar.astro'
 import commits from '@data/commits.json'
 import { formatCommitDate } from '@shared/lib/date-format'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Commit {
   hash: string
@@ -19,7 +20,7 @@ const rows = (commits as Commit[]).slice(0, 5)
 
 <div class="card">
   <div class="card-header border-0">
-    <h3 class="card-title">Development activity</h3>
+    <CardTitle>Development activity</CardTitle>
   </div>
   <div class="position-relative">
     <div class="position-absolute top-0 left-0 px-3 mt-1 w-75">

--- a/shared/components/cards/ForgotPasswordCard.astro
+++ b/shared/components/cards/ForgotPasswordCard.astro
@@ -2,11 +2,12 @@
 import FormFooter from '@ui/FormFooter.astro'
 import Button from '@ui/Button.astro'
 import FormGroup from '@ui/FormGroup.astro'
+import CardTitle from '@ui/CardTitle.astro'
 ---
 
 <form class="card card-md" action="./" method="get" novalidate>
   <div class="card-body">
-    <h2 class="card-title text-center mb-4">Forgot password</h2>
+    <CardTitle class="text-center mb-4">Forgot password</CardTitle>
 
     <p class="text-secondary mb-4">Enter your email address and your password will be reset and emailed to you.</p>
 

--- a/shared/components/cards/Icons.astro
+++ b/shared/components/cards/Icons.astro
@@ -1,6 +1,7 @@
 ---
 import Icon from '@ui/Icon.astro'
 import icons from '@data/icons.json'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Props {
   title?: string
@@ -19,7 +20,7 @@ const entries = Object.entries(icons as Record<string, { svg?: Record<string, st
 
 <div class="card">
   <div class="card-header">
-    <h3 class="card-title">{title}</h3>
+    <CardTitle>{title}</CardTitle>
   </div>
   <div class="card-body p-0">
     <div class="demo-icons-list-wrap">

--- a/shared/components/cards/MapVectorCard.astro
+++ b/shared/components/cards/MapVectorCard.astro
@@ -1,5 +1,6 @@
 ---
 import MapVector from '@ui/MapVector.astro'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Props {
   title?: string
@@ -11,7 +12,7 @@ const map = 'world'
 
 <div class="card">
   <div class="card-body">
-    {title && <h3 class="card-title">{title}</h3>}
+    {title && <CardTitle>{title}</CardTitle>}
     <MapVector mapId={map} color="primary" ratio="21x9" />
   </div>
 </div>

--- a/shared/components/cards/ProjectProgress.astro
+++ b/shared/components/cards/ProjectProgress.astro
@@ -3,6 +3,7 @@ import Progress from '@ui/Progress.astro'
 import CardDropdown from '@ui/CardDropdown.astro'
 import projects from '@data/projects.json'
 import { requireIndex } from '@shared/lib/array'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Project {
   title?: string
@@ -27,9 +28,9 @@ const project = requireIndex(projects as Project[], projectId)
         <img src={project.image} alt={project.title} class="rounded" />
       </div>
       <div class="col">
-        <h3 class="card-title mb-1">
+        <CardTitle class="mb-1">
           <a href="#" class="text-reset">{project.title}</a>
-        </h3>
+        </CardTitle>
         <div class="text-secondary">Updated {daysAgo} days ago</div>
 
         <div class="mt-3">

--- a/shared/components/cards/SignUpCard.astro
+++ b/shared/components/cards/SignUpCard.astro
@@ -2,11 +2,12 @@
 import FormFooter from '@ui/FormFooter.astro'
 import InputGroup from '@ui/InputGroup.astro'
 import FormGroup from '@ui/FormGroup.astro'
+import CardTitle from '@ui/CardTitle.astro'
 ---
 
 <form class="card card-md" action="./" method="get" novalidate>
   <div class="card-body">
-    <h2 class="card-title text-center mb-4">Create new account</h2>
+    <CardTitle class="text-center mb-4">Create new account</CardTitle>
 
     <FormGroup label="Name" for="signup-name">
       <input type="text" class="form-control" placeholder="Enter name" id="signup-name" autocomplete="name" required />

--- a/shared/components/cards/Subscribe.astro
+++ b/shared/components/cards/Subscribe.astro
@@ -3,6 +3,7 @@ import Avatar from '@ui/Avatar.astro'
 import CardDropdown from '@ui/CardDropdown.astro'
 import people from '@data/people.json'
 import { requireIndex } from '@shared/lib/array'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Person {
   full_name?: string
@@ -26,9 +27,9 @@ const person = requireIndex(people as Person[], personId)
         <Avatar person={person} size="lg" />
       </div>
       <div class="col">
-        <h4 class="card-title m-0">
+        <CardTitle class="m-0">
           <a href="#">{person.full_name}</a>
-        </h4>
+        </CardTitle>
         <div class="text-secondary">
           Working in {person.company}
         </div>

--- a/shared/components/cards/TasksDue.astro
+++ b/shared/components/cards/TasksDue.astro
@@ -4,6 +4,7 @@ import Icon from '@ui/Icon.astro'
 import ListGroup from '@ui/ListGroup.astro'
 import ListGroupItem from '@ui/ListGroupItem.astro'
 import crmDashboard from '@data/crm-dashboard.json'
+import CardTitle from '@ui/CardTitle.astro'
 
 const tasks = crmDashboard.tasks_due
 ---
@@ -11,7 +12,7 @@ const tasks = crmDashboard.tasks_due
 <div class="card h-100">
   <div class="card-header">
     <div class="d-flex align-items-center gap-2">
-      <h3 class="card-title mb-0">{tasks.title}</h3>
+      <CardTitle class="mb-0">{tasks.title}</CardTitle>
       <span class="badge bg-red text-white">{tasks.badge}</span>
     </div>
     <CardActions>

--- a/shared/components/cards/TeamLeaderboard.astro
+++ b/shared/components/cards/TeamLeaderboard.astro
@@ -5,6 +5,7 @@ import ListGroup from '@ui/ListGroup.astro'
 import ListGroupItem from '@ui/ListGroupItem.astro'
 import Progress from '@ui/Progress.astro'
 import crmDashboard from '@data/crm-dashboard.json'
+import CardTitle from '@ui/CardTitle.astro'
 
 const leaderboard = crmDashboard.leaderboard
 ---
@@ -12,7 +13,7 @@ const leaderboard = crmDashboard.leaderboard
 <div class="card h-100">
   <div class="card-header">
     <div>
-      <h3 class="card-title mb-0">Team leaderboard</h3>
+      <CardTitle class="mb-0">Team leaderboard</CardTitle>
       <CardSubtitle as="div">Q2 - May 1, 2026</CardSubtitle>
     </div>
   </div>

--- a/shared/components/cards/UserCardBg.astro
+++ b/shared/components/cards/UserCardBg.astro
@@ -5,6 +5,7 @@ import Avatar from '@ui/Avatar.astro'
 import people from '@data/people.json'
 import photos from '@data/photos.json'
 import { requireIndex } from '@shared/lib/array'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Person {
   full_name?: string
@@ -33,7 +34,7 @@ const photo = requireIndex(photos as Photo[], personId)
     <Avatar size="xl" person={person} thumb />
   </div>
   <div class="card-body text-center">
-    <h3 class="card-title mb-1">{person.full_name}</h3>
+    <CardTitle class="mb-1">{person.full_name}</CardTitle>
     <div class="text-secondary">{person.job_title}</div>
   </div>
 </a>

--- a/shared/components/cards/UserCardBig.astro
+++ b/shared/components/cards/UserCardBig.astro
@@ -2,6 +2,7 @@
 import Avatar from '@ui/Avatar.astro'
 import people from '@data/people.json'
 import { requireIndex } from '@shared/lib/array'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Person {
   full_name?: string
@@ -23,7 +24,7 @@ const person = requireIndex(people as Person[], personId)
     <div class="mb-3">
       <Avatar size="xl" person={person} />
     </div>
-    <h3 class="card-title mb-1">{person.full_name}</h3>
+    <CardTitle class="mb-1">{person.full_name}</CardTitle>
     <div class="text-secondary">{person.job_title}</div>
   </div>
   <a href="#" class="card-btn">View full profile</a>

--- a/shared/components/cards/UserInfo.astro
+++ b/shared/components/cards/UserInfo.astro
@@ -4,6 +4,7 @@ import Icon from '@ui/Icon.astro'
 import Flag from '@ui/Flag.astro'
 import people from '@data/people.json'
 import { requireIndex } from '@shared/lib/array'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Person {
   university?: string
@@ -21,7 +22,7 @@ const person = requireIndex(people as Person[], 24)
 
 <div class="card">
   <div class="card-body">
-    <h3 class="card-title">Basic info</h3>
+    <CardTitle>Basic info</CardTitle>
     <div class="mb-2">
       <Icon name="book" class="me-2 text-secondary" />
       Went to: <strong>{person.university}</strong>

--- a/shared/components/cards/Weather.astro
+++ b/shared/components/cards/Weather.astro
@@ -1,5 +1,6 @@
 ---
 import Icon from '@ui/Icon.astro'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Props {
   city?: string
@@ -18,7 +19,7 @@ const { city = 'Warsaw', temperature = 20, color = 'blue', icon = 'cloud-rain', 
       <div class="col">
         <div class="row">
           <div class="col-auto">
-            <h3 class="card-title mb-2">{city}</h3>
+            <CardTitle class="mb-2">{city}</CardTitle>
           </div>
           <div class="col">
             <Icon name={icon} />

--- a/shared/components/cards/charts/PipelineFunnel.astro
+++ b/shared/components/cards/charts/PipelineFunnel.astro
@@ -1,18 +1,19 @@
 ---
 import Progress from '@ui/Progress.astro'
 import crmDashboard from '@data/crm-dashboard.json'
+import CardTitle from '@ui/CardTitle.astro'
 
 const funnel = crmDashboard.pipeline_funnel
 ---
 
 <div class="card h-100">
   <div class="card-body">
-    <h3 class="card-title">
+    <CardTitle>
       <div class="d-flex align-items-center justify-content-between">
         <div class="fw-medium">{funnel.title}</div>
         <div class="text-secondary">{funnel.period}</div>
       </div>
-    </h3>
+    </CardTitle>
     <div class="d-flex flex-column gap-2">
       {
         funnel.items.map((item) => (

--- a/shared/components/layout/PageHeader.astro
+++ b/shared/components/layout/PageHeader.astro
@@ -2,13 +2,6 @@
 // Layout front-matter flags are plain props here.
 // TODO: layout-navbar-overlap && layout-navbar-dark → extra text-white class
 // on .page-header — both unset on the homepage.
-import HeaderActionsButtons from './HeaderActionsButtons.astro';
-import HeaderActionsPrint from './HeaderActionsPrint.astro';
-import HeaderActionsPhotos from './HeaderActionsPhotos.astro';
-import HeaderActionsBreadcrumb from './HeaderActionsBreadcrumb.astro';
-import HeaderActionsAddBoard from './HeaderActionsAddBoard.astro';
-import HeaderActionsAddJob from './HeaderActionsAddJob.astro';
-import HeaderActionsUsers from './HeaderActionsUsers.astro';
 import HeaderProfile from './HeaderProfile.astro';
 import HeaderUptime from './HeaderUptime.astro';
 import PageTitle from '@ui/PageTitle.astro';
@@ -20,9 +13,6 @@ interface Props {
 	pretitle?: string | undefined;
 	/** page-header-description */
 	description?: string | undefined;
-	/** page-header-actions — name of an include from layout/header-actions/, e.g. "buttons".
-	 * Legacy preset list; prefer the `actions` slot for page-specific markup. */
-	actions?: string | undefined;
 	/** page-header-class */
 	class?: string;
 	/** page-header-file — name of an include from layout/headers/, e.g. "profile" */
@@ -31,10 +21,10 @@ interface Props {
 	textWhite?: boolean | undefined;
 }
 
-const { title, pretitle, description, actions, class: className, file, textWhite } = Astro.props;
+const { title, pretitle, description, class: className, file, textWhite } = Astro.props;
 
-// The `actions` slot wins over the preset names above. A slot forwarded from a layout registers
-// here even when the page fills nothing, so test the rendered content, not Astro.slots.has().
+// A slot forwarded from a layout registers here even when the page fills nothing,
+// so test the rendered content, not Astro.slots.has().
 const actionsSlot = Astro.slots.has('actions') ? (await Astro.slots.render('actions')).trim() : '';
 ---
 
@@ -59,18 +49,11 @@ const actionsSlot = Astro.slots.has('actions') ? (await Astro.slots.render('acti
 						{description && <div class="text-secondary mt-1">{description}</div>}
 					</div>
 
-					{(actionsSlot || actions) && (
+					{actionsSlot && (
 						<Fragment>
 							<!-- Page title actions -->
 							<div class="col-auto ms-auto d-print-none">
 								<Fragment set:html={actionsSlot} />
-								{actions === 'buttons' && <HeaderActionsButtons dark={textWhite} />}
-								{actions === 'print' && <HeaderActionsPrint />}
-								{actions === 'photos' && <HeaderActionsPhotos />}
-								{actions === 'breadcrumb' && <HeaderActionsBreadcrumb />}
-								{actions === 'add-board' && <HeaderActionsAddBoard />}
-								{actions === 'add-job' && <HeaderActionsAddJob />}
-									{actions === 'users' && <HeaderActionsUsers />}
 							</div>
 						</Fragment>
 					)}

--- a/shared/components/layout/PageHeader.astro
+++ b/shared/components/layout/PageHeader.astro
@@ -20,7 +20,8 @@ interface Props {
 	pretitle?: string | undefined;
 	/** page-header-description */
 	description?: string | undefined;
-	/** page-header-actions — name of an include from layout/header-actions/, e.g. "buttons" */
+	/** page-header-actions — name of an include from layout/header-actions/, e.g. "buttons".
+	 * Legacy preset list; prefer the `actions` slot for page-specific markup. */
 	actions?: string | undefined;
 	/** page-header-class */
 	class?: string;
@@ -31,6 +32,10 @@ interface Props {
 }
 
 const { title, pretitle, description, actions, class: className, file, textWhite } = Astro.props;
+
+// The `actions` slot wins over the preset names above. A slot forwarded from a layout registers
+// here even when the page fills nothing, so test the rendered content, not Astro.slots.has().
+const actionsSlot = Astro.slots.has('actions') ? (await Astro.slots.render('actions')).trim() : '';
 ---
 
 {file === 'profile' && <HeaderProfile />}
@@ -54,10 +59,11 @@ const { title, pretitle, description, actions, class: className, file, textWhite
 						{description && <div class="text-secondary mt-1">{description}</div>}
 					</div>
 
-					{actions && (
+					{(actionsSlot || actions) && (
 						<Fragment>
 							<!-- Page title actions -->
 							<div class="col-auto ms-auto d-print-none">
+								<Fragment set:html={actionsSlot} />
 								{actions === 'buttons' && <HeaderActionsButtons dark={textWhite} />}
 								{actions === 'print' && <HeaderActionsPrint />}
 								{actions === 'photos' && <HeaderActionsPhotos />}

--- a/shared/components/layout/PageHeader.astro
+++ b/shared/components/layout/PageHeader.astro
@@ -23,9 +23,7 @@ interface Props {
 
 const { title, pretitle, description, class: className, file, textWhite } = Astro.props;
 
-// A slot forwarded from a layout registers here even when the page fills nothing,
-// so test the rendered content, not Astro.slots.has().
-const actionsSlot = Astro.slots.has('actions') ? (await Astro.slots.render('actions')).trim() : '';
+const actionsSlot = ((await Astro.slots.render('actions')) ?? '').trim();
 ---
 
 {file === 'profile' && <HeaderProfile />}

--- a/shared/components/navbar/NavbarSideApps.astro
+++ b/shared/components/navbar/NavbarSideApps.astro
@@ -3,6 +3,7 @@ import { staticPath } from '@shared/lib/assets'
 import CardActions from '@ui/CardActions.astro'
 import Icon from '@ui/Icon.astro'
 import brands from '@data/brands.json'
+import CardTitle from '@ui/CardTitle.astro'
 ---
 
 <!-- BEGIN APPS -->
@@ -14,7 +15,7 @@ import brands from '@data/brands.json'
   <div class="dropdown-menu dropdown-menu-arrow dropdown-menu-end dropdown-menu-card">
     <div class="card">
       <div class="card-header">
-        <h3 class="card-title">My Apps</h3>
+        <CardTitle>My Apps</CardTitle>
 
         <CardActions class="btn-actions">
           <a href="#" class="btn-action">

--- a/shared/layouts/BaseLayout.astro
+++ b/shared/layouts/BaseLayout.astro
@@ -15,9 +15,11 @@ interface Props {
   rtl?: boolean | undefined
   /** Relative asset base: '.' for root pages, '..' one level deep */
   base?: string
+  /** <meta name="description"> — falls back to the site description */
+  description?: string | undefined
 }
 
-const { title, pageLibs = [], bodyClass, rtl = false, base = '.' } = Astro.props
+const { title, pageLibs = [], bodyClass, rtl = false, base = '.', description } = Astro.props
 
 // Development build: unminified assets, dev favicon.
 const environment = 'development'
@@ -44,6 +46,7 @@ const libJsFiles = (head: boolean) => pageLibEntries.filter(([, lib]) => Boolean
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
     <title>{title ? `${title} - ` : ''}{site.title} - {site.descriptionShort}</title>
+    <meta name="description" content={description ?? site.descriptionShort} />
 
     <link rel="icon" href={`${base}/favicon-dev.ico`} type="image/x-icon" />
     <link rel="shortcut icon" href={`${base}/favicon-dev.ico`} type="image/x-icon" />

--- a/shared/layouts/DefaultLayout.astro
+++ b/shared/layouts/DefaultLayout.astro
@@ -18,8 +18,6 @@ interface Props {
   pretitle?: string | undefined
   /** page-header-description */
   description?: string | undefined
-  /** page-header-actions, e.g. "buttons" */
-  actions?: string | undefined
   /** page-menu from the front matter, e.g. "layout.vertical" — active menu entry */
   pageMenu?: string | undefined
   /** layout-sidebar */
@@ -56,8 +54,7 @@ interface Props {
   navbarClass?: string
 }
 
-const { title, pageLibs, pageHeader, pageHeaderFile, pretitle, description, actions, pageMenu, sidebar, sidebarDark, hideTopbar, containerCentered, wrapperFull, containerClass, bodyClass, rtl, sidebarEnd, navbarTransparent, navbarCondensed, navbarDark, navbarOverlap, navbarSticky, navbarHideBrand, navbarClass } =
-  Astro.props
+const { title, pageLibs, pageHeader, pageHeaderFile, pretitle, description, pageMenu, sidebar, sidebarDark, hideTopbar, containerCentered, wrapperFull, containerClass, bodyClass, rtl, sidebarEnd, navbarTransparent, navbarCondensed, navbarDark, navbarOverlap, navbarSticky, navbarHideBrand, navbarClass } = Astro.props
 ---
 
 <BaseLayout title={title} pageLibs={pageLibs} bodyClass={bodyClass} rtl={rtl}>
@@ -84,7 +81,7 @@ const { title, pageLibs, pageHeader, pageHeaderFile, pretitle, description, acti
 
     <div class:list={['page-wrapper', wrapperFull && 'page-wrapper-full']}>
       <!-- BEGIN PAGE HEADER -->
-      <PageHeader title={pageHeader} pretitle={pretitle} description={description} actions={actions} file={pageHeaderFile} textWhite={navbarOverlap && navbarDark}>
+      <PageHeader title={pageHeader} pretitle={pretitle} description={description} file={pageHeaderFile} textWhite={navbarOverlap && navbarDark}>
         <slot name="page-header-actions" slot="actions" />
       </PageHeader>
       <!-- END PAGE HEADER -->

--- a/shared/layouts/DefaultLayout.astro
+++ b/shared/layouts/DefaultLayout.astro
@@ -84,7 +84,9 @@ const { title, pageLibs, pageHeader, pageHeaderFile, pretitle, description, acti
 
     <div class:list={['page-wrapper', wrapperFull && 'page-wrapper-full']}>
       <!-- BEGIN PAGE HEADER -->
-      <PageHeader title={pageHeader} pretitle={pretitle} description={description} actions={actions} file={pageHeaderFile} textWhite={navbarOverlap && navbarDark} />
+      <PageHeader title={pageHeader} pretitle={pretitle} description={description} actions={actions} file={pageHeaderFile} textWhite={navbarOverlap && navbarDark}>
+        <slot name="page-header-actions" slot="actions" />
+      </PageHeader>
       <!-- END PAGE HEADER -->
 
       <!-- BEGIN PAGE BODY -->

--- a/shared/layouts/DefaultLayout.astro
+++ b/shared/layouts/DefaultLayout.astro
@@ -10,8 +10,8 @@ interface Props {
   title?: string | undefined
   /** Script/CSS library keys passed to BaseLayout */
   pageLibs?: string[]
-  /** page-header — the title in the page header */
-  pageHeader?: string | undefined
+  /** page-header — the title in the page header. Defaults to `title`; pass false for no page header */
+  pageHeader?: string | false | undefined
   /** page-header-file — renders a layout/headers/{file} component instead of the title block */
   pageHeaderFile?: string | undefined
   /** page-header-pretitle */
@@ -55,9 +55,13 @@ interface Props {
 }
 
 const { title, pageLibs, pageHeader, pageHeaderFile, pretitle, description, pageMenu, sidebar, sidebarDark, hideTopbar, containerCentered, wrapperFull, containerClass, bodyClass, rtl, sidebarEnd, navbarTransparent, navbarCondensed, navbarDark, navbarOverlap, navbarSticky, navbarHideBrand, navbarClass } = Astro.props
+
+// Most pages repeat the page title verbatim, so `pageHeader` falls back to `title`.
+// Pages that deliberately have no header (blank, playgrounds) pass pageHeader={false}.
+const headerTitle = pageHeader === false ? undefined : (pageHeader ?? title)
 ---
 
-<BaseLayout title={title} pageLibs={pageLibs} bodyClass={bodyClass} rtl={rtl}>
+<BaseLayout title={title} pageLibs={pageLibs} bodyClass={bodyClass} rtl={rtl} description={description}>
   <div class="page">
     {
       sidebar && (
@@ -81,7 +85,7 @@ const { title, pageLibs, pageHeader, pageHeaderFile, pretitle, description, page
 
     <div class:list={['page-wrapper', wrapperFull && 'page-wrapper-full']}>
       <!-- BEGIN PAGE HEADER -->
-      <PageHeader title={pageHeader} pretitle={pretitle} description={description} file={pageHeaderFile} textWhite={navbarOverlap && navbarDark}>
+      <PageHeader title={headerTitle} pretitle={pretitle} description={description} file={pageHeaderFile} textWhite={navbarOverlap && navbarDark}>
         <slot name="page-header-actions" slot="actions" />
       </PageHeader>
       <!-- END PAGE HEADER -->

--- a/shared/ui/AdvancedTable.astro
+++ b/shared/ui/AdvancedTable.astro
@@ -11,6 +11,7 @@ import people from '@data/people.json'
 import tableProperties from '@data/table-properties.json'
 import CaptureScript from '../components/CaptureScript.astro'
 import { requireIndex } from '@shared/lib/array'
+import CardTitle from '@ui/CardTitle.astro'
 
 interface Props {
   id?: string
@@ -55,7 +56,7 @@ const sortKeys = headers.map((header) => header['data-sort'])
     <div class="card-header">
       <div class="row w-full">
         <div class="col">
-          <h3 class="card-title mb-0">Employee</h3>
+          <CardTitle class="mb-0">Employee</CardTitle>
           <p class="text-secondary m-0">Table description.</p>
         </div>
         <div class="col-md-auto col-sm-12">

--- a/shared/ui/CardHeader.astro
+++ b/shared/ui/CardHeader.astro
@@ -1,7 +1,7 @@
 ---
 import type { HTMLTag } from 'astro/types'
 
-// Card header (.card-header) with an optional h3.card-title; slot renders after the title.
+// Card header (.card-header) with an optional h2.card-title; slot renders after the title.
 
 // `as` must stay out of the Props body: Astro's frontmatter scanner bails on a member
 // literally named `as` and silently falls back to untyped props.
@@ -12,7 +12,8 @@ interface Props extends PolymorphicProps {
   class?: string
 }
 
-const { title, as: TitleTag = 'h3', class: className }: Props = Astro.props
+// h2 to match CardTitle — cards sit directly under the page h1.
+const { title, as: TitleTag = 'h2', class: className }: Props = Astro.props
 ---
 
 <div class:list={['card-header', className]}>

--- a/shared/ui/CardTitle.astro
+++ b/shared/ui/CardTitle.astro
@@ -12,7 +12,9 @@ interface Props extends PolymorphicProps {
   id?: string
 }
 
-const { as: Tag = 'h3', class: className, id }: Props = Astro.props
+// h2 by default: cards sit directly under the page h1, so h3 would skip a level.
+// Pass as="h3" for a card nested under its own h2 section heading.
+const { as: Tag = 'h2', class: className, id }: Props = Astro.props
 ---
 
 <Tag class:list={['card-title', className]} {...id ? { id } : {}}>

--- a/shared/ui/DocsLink.astro
+++ b/shared/ui/DocsLink.astro
@@ -1,0 +1,21 @@
+---
+import Icon from '@ui/Icon.astro'
+import { getDocsUrl } from '@shared/lib/string-format'
+
+// Link from a demo page to its documentation page, e.g. <DocsLink path="/ui/components/tag" />.
+
+interface Props {
+  /** Docs path, appended to the docs base URL */
+  path: string
+  /** Link label */
+  text?: string
+  class?: string
+}
+
+const { path, text = 'Docs', class: className }: Props = Astro.props
+---
+
+<a href={getDocsUrl(path)} target="_blank" rel="noopener" class:list={['link-secondary', className]}>
+  {text}
+  <Icon name="external-link" class="icon-sm" />
+</a>


### PR DESCRIPTION
## Summary

- Add an `actions` slot to `PageHeader`, forwarded from `DefaultLayout` as `page-header-actions`. Pages put their own markup next to the page title instead of naming a preset. The `actions` preset prop is gone: the 20 pages that used `actions="buttons"` and friends now import the preset component and pass it in the slot, so `PageHeader` loses its seven-way branch.
- Move the page title of 25 Interface demo pages out of the page body and into the layout page header, and drop the per-page `d-flex` wrapper around it. Those pages already passed a `description` that never rendered, because `PageHeader` only renders when it gets a `title` — it shows up under the title now.
- `pageHeader` falls back to `title`, so 73 pages stop repeating the same string twice. Pages that deliberately have no header pass `pageHeader={false}`; the 20 pages whose header differs from the browser title keep their explicit value.
- Add a `DocsLink` component for the "Docs" link, so the URL helper, `target`, `rel` and the icon live in one place instead of 25 copies.
- `CardTitle` and `CardHeader` now render `h2`. Cards sit directly under the page `h1`, so `h3` skipped a level. 44 raw `<h3 class="card-title">` headings across `shared/components` and `preview/pages` became `CardTitle` too, which is what made pages like Alerts mix `h2` and `h3` in one card grid.
- `BaseLayout` renders `<meta name="description">` from the same `description` prop, falling back to the site description. Preview pages had no meta description at all.

## Preview

- **URL:** [Buttons](https://tabler-git-page-header-actions-slot-tabler-io.vercel.app/buttons.html), [Dashboard](https://tabler-git-page-header-actions-slot-tabler-io.vercel.app/index.html), [Navbar overlap](https://tabler-git-page-header-actions-slot-tabler-io.vercel.app/layout-navbar-overlap.html), [Cards](https://tabler-git-page-header-actions-slot-tabler-io.vercel.app/cards.html), [Users](https://tabler-git-page-header-actions-slot-tabler-io.vercel.app/users.html), [Activity](https://tabler-git-page-header-actions-slot-tabler-io.vercel.app/activity.html)
- **How to test:** On Buttons, the title sits in the page header with the description under it and the Docs link on the right. On the Dashboard, "New view" and "Create new report" still render, now passed through the slot. On Navbar overlap, "New view" must stay dark on the dark header — that page passes `dark` to `HeaderActionsButtons` itself, because the layout no longer derives it. On Activity — a page header with no actions — no empty action column is left behind. Nothing should look different anywhere; the heading changes are markup only, since `.card-title` sets the size.
- Heading order is easiest to check in devtools or with a headings extension: every demo page should go `h1` → `h2`, with no `h3` in the card grids.

## Notes / rollout

- `PageHeader` decides whether to render the action column from the rendered slot content, not from `Astro.slots.has('actions')`. A slot forwarded through a layout always registers in the child, even when the page fills nothing, which left an empty `.col-auto ms-auto` in the header.
- Card titles inside a section that has its own `h2` should now pass `as="h3"` explicitly. Nothing in the repo needs it today — the FAQ page is the only one with real `h2` sections, and it uses an accordion, not cards.
- `pageHeaderFile` (`profile`, `uptime`) is untouched. It replaces the whole header, not just the actions.
- Raw `<h3 class="card-title">` in `docs/content/**` is left alone on purpose. Those are hand-written HTML examples that document the class itself.

