### PR TITLE
Add descriptions and grouped sections to Interface demo pages

### DIFF
--- a/preview/pages/card-actions.astro
+++ b/preview/pages/card-actions.astro
@@ -11,23 +11,35 @@ import Avatar from '@ui/Avatar.astro'
 import Icon from '@ui/Icon.astro'
 import people from '@data/people.json'
 import { requireIndex } from '@shared/lib/array'
+import DocsLink from '@ui/DocsLink.astro'
 
 const person0 = requireIndex(people, 0)
 const person3 = requireIndex(people, 3)
 ---
 
 <DefaultLayout title="Card actions" pageMenu="base.cards.actions">
+  <DocsLink slot="page-header-actions" path="/ui/components/card" />
+
   <div class="row row-cards">
     <div class="col-md-6">
       <Card>
-        <CardHeader title="Sample card" />
+        <CardHeader>
+          <div>
+            <CardTitle>Sample card</CardTitle>
+            <CardSubtitle>A blank card with a title and no actions.</CardSubtitle>
+          </div>
+        </CardHeader>
         <BodyPlaceholder />
       </Card>
     </div>
 
     <div class="col-md-6">
       <Card>
-        <CardHeader title="Card with action">
+        <CardHeader>
+          <div>
+            <CardTitle>Card with action</CardTitle>
+            <CardSubtitle>Add a single action button to the header.</CardSubtitle>
+          </div>
           <CardActions>
             <Button color="primary" icon="plus" text="Add new" />
           </CardActions>
@@ -38,7 +50,11 @@ const person3 = requireIndex(people, 3)
 
     <div class="col-md-6">
       <Card>
-        <CardHeader title="Cart title">
+        <CardHeader>
+          <div>
+            <CardTitle>Card title</CardTitle>
+            <CardSubtitle>Add two secondary action buttons to the header.</CardSubtitle>
+          </div>
           <CardActions>
             <Button icon="phone" text="Phone" />
             <Button icon="mail" text="Email" />
@@ -129,7 +145,11 @@ const person3 = requireIndex(people, 3)
 
     <div class="col-md-6">
       <Card>
-        <CardHeader title="Card actions">
+        <CardHeader>
+          <div>
+            <CardTitle>Icon toolbar</CardTitle>
+            <CardSubtitle>A compact row of icon-only actions in the header.</CardSubtitle>
+          </div>
           <CardActions class="btn-actions">
             <a href="#" class="btn-action"><Icon name="refresh" /></a>
             <a href="#" class="btn-action"><Icon name="chevron-up" /></a>

--- a/preview/pages/cards.astro
+++ b/preview/pages/cards.astro
@@ -3,6 +3,8 @@ import CardSubtitle from '@ui/CardSubtitle.astro'
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import CardStamp from '@ui/CardStamp.astro'
 import CardTitle from '@ui/CardTitle.astro'
+import SectionCard from '@ui/Card.astro'
+import SectionCardBody from '@ui/CardBody.astro'
 import Card from '@shared/components/cards/Card.astro'
 import CardImage from '@shared/components/cards/CardImage.astro'
 import CardTabs from '@shared/components/cards/CardTabs.astro'
@@ -21,239 +23,360 @@ const cardsStackColors = ['red', 'green', 'blue']
 <DefaultLayout title="Cards" pageMenu="base.cards.base">
   <DocsLink slot="page-header-actions" path="/ui/components/card" />
   <div class="row row-cards">
-    <div class="col-md-6 col-lg-3">
-      <div class="card">
-        <div class="card-header">
-          <CardTitle>Card title</CardTitle>
-        </div>
-        <div class="card-body">Simple card</div>
-      </div>
+    <div class="col-12">
+      <SectionCard>
+        <SectionCardBody>
+          <CardTitle>Headers & body styles</CardTitle>
+          <CardSubtitle>Combine a header, a tinted background, or drop the border for a simpler look.</CardSubtitle>
+          <div class="row row-cards">
+            <div class="col-md-6 col-lg-3">
+              <div class="card">
+                <div class="card-header">
+                  <CardTitle>Card title</CardTitle>
+                </div>
+                <div class="card-body">Simple card</div>
+              </div>
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <div class="card">
+                <div class="card-header card-header-light">
+                  <CardTitle>Card title</CardTitle>
+                </div>
+                <div class="card-body">Card with header background</div>
+              </div>
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <div class="card card-borderless">
+                <div class="card-body">
+                  <CardTitle>Card title</CardTitle>
+                  <div>Card without border</div>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <div class="card">
+                <div class="card-header">
+                  <CardTitle>Card title <CardSubtitle as="span">Subtitle</CardSubtitle></CardTitle>
+                </div>
+                <div class="card-body">Card with title and subtitle</div>
+              </div>
+            </div>
+          </div>
+        </SectionCardBody>
+      </SectionCard>
     </div>
-    <div class="col-md-6 col-lg-3">
-      <div class="card">
-        <div class="card-header card-header-light">
-          <CardTitle>Card title</CardTitle>
-        </div>
-        <div class="card-body">Card with header background</div>
-      </div>
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <div class="card card-borderless">
-        <div class="card-body">
-          <CardTitle>Card title</CardTitle>
-          <div>Card without border</div>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <div class="card">
-        <div class="card-header">
-          <CardTitle>Card title <CardSubtitle as="span">Subtitle</CardSubtitle></CardTitle>
-        </div>
-        <div class="card-body">Card with title and subtitle</div>
-      </div>
-    </div>
-
-    <div class="col-md-6 col-lg-3">
-      <a href="#" class="card card-link">
-        <div class="card-body">Default hover effect</div>
-      </a>
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <a href="#" class="card card-link card-link-rotate">
-        <div class="card-body">Rotate hover effect</div>
-      </a>
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <a href="#" class="card card-link card-link-pop">
-        <div class="card-body">Pop hover effect</div>
-      </a>
-    </div>
-    <div class="col-md-6 col-lg-3"></div>
-
-    <div class="col-md-6 col-lg-3">
-      <div class="card card-rotate-end">
-        <div class="card-body">Card rotate end</div>
-      </div>
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <div class="card card-rotate-start">
-        <div class="card-body">Card rotate start</div>
-      </div>
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <div class="card card-active">
-        <div class="card-body">
-          <p>This is a card with active state.</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <div class="card card-inactive">
-        <div class="card-body">
-          <p>This is some text inactive state.</p>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-md-6 col-lg-3">
-      <div class="card">
-        <CardStamp icon="bell" color="yellow" />
-        <div class="card-body">
-          <CardTitle>Card with icon bg</CardTitle>
-          <p class="text-secondary">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Architecto at consectetur culpa ducimus eum fuga fugiat, ipsa iusto, modi nostrum recusandae reiciendis saepe.</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <div class="card bg-primary-lt">
-        <div class="card-body">
-          <CardTitle>Card with primary light background</CardTitle>
-          <p class="text-secondary">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Architecto at consectetur culpa ducimus eum fuga fugiat, ipsa iusto, modi nostrum recusandae reiciendis saepe.</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <CardBackgroundIcon />
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <Card statusTop="danger" title="Card with top status" />
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <Card statusBottom="success" title="Card with bottom status" />
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <Card statusStart="primary" title="Card with side status" />
-    </div>
-
-    <div class="col-md-6 col-lg-3">
-      <CardRibbonTop />
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <CardRibbonText />
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <Card progress title="Card with progress bar" />
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <Card class="card-stacked" title="Stacked card" />
-    </div>
-    <div class="col-lg-6">
-      <CardImage title="Card with left side image" />
-    </div>
-    <div class="col-lg-6">
-      <CardImage title="Card with right side image" right imgId={3} />
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <Card imgTop title="Card with top image" />
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <Card imgBottom title="Card with bottom image" />
-    </div>
-
-    <div class="col-md-6 col-lg-3">
-      <div class="card">
-        <div class="card-body">
-          <CardTitle>Card with footer</CardTitle>
-          <p class="text-secondary">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam deleniti fugit incidunt, iste, itaque minima neque pariatur perferendis sed suscipit velit vitae voluptatem.</p>
-        </div>
-        <div class="card-footer">This is standard card footer</div>
-      </div>
-    </div>
-    <div class="col-md-6 col-lg-3">
-      <div class="card">
-        <div class="card-body">
-          <CardTitle>Card with transparent footer</CardTitle>
-          <p class="text-secondary">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam deleniti fugit incidunt, iste, itaque minima neque pariatur perferendis sed suscipit velit vitae voluptatem.</p>
-        </div>
-        <div class="card-footer card-footer-transparent">This is transparent card footer</div>
-      </div>
-    </div>
-    <div class="col-md-6 col-lg-3"><Card title="Card with footer button" footerButton /></div>
-    <div class="col-md-6 col-lg-3"><Card title="Card with footer buttons" footerButtons /></div>
-
-    <div class="col-md-6 col-lg-3"><Card footerElements={['more', '>switch']} /></div>
-    <div class="col-md-6 col-lg-3"><Card footerElements={['>avatars']} /></div>
-
-    <div class="col-md-6 col-lg-4"><Card headerTabs /></div>
-    <div class="col-md-6 col-lg-4"><Card headerPills /></div>
-    <div class="col-md-6 col-lg-4"><CardTabs /></div>
-    <div class="col-md-6 col-lg-4"><CardTabs bottom id="bottom" /></div>
 
     <div class="col-12">
-      <div class="card">
-        <div class="card-header">
-          <CardTitle>Cards inside card</CardTitle>
-        </div>
-        <div class="card-body">
+      <SectionCard>
+        <SectionCardBody>
+          <CardTitle>Link hover effects</CardTitle>
+          <CardSubtitle>Add motion cues when the whole card acts as a link.</CardSubtitle>
           <div class="row row-cards">
-            {
-              cardsStack.map((name, i) => (
-                <div class="col-md">
-                  <div class="card">
-                    <div class={`card-status-top bg-${cardsStackColors[i]}`} />
-                    <div class="card-header">
-                      <CardTitle>{name} card</CardTitle>
-                    </div>
-                    <BodyPlaceholder />
+            <div class="col-md-6 col-lg-3">
+              <a href="#" class="card card-link">
+                <div class="card-body">Default hover effect</div>
+              </a>
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <a href="#" class="card card-link card-link-rotate">
+                <div class="card-body">Rotate hover effect</div>
+              </a>
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <a href="#" class="card card-link card-link-pop">
+                <div class="card-body">Pop hover effect</div>
+              </a>
+            </div>
+          </div>
+        </SectionCardBody>
+      </SectionCard>
+    </div>
+
+    <div class="col-12">
+      <SectionCard>
+        <SectionCardBody>
+          <CardTitle>Rotation & state</CardTitle>
+          <CardSubtitle>Tilt a card slightly, or mark it as active or inactive.</CardSubtitle>
+          <div class="row row-cards">
+            <div class="col-md-6 col-lg-3">
+              <div class="card card-rotate-end">
+                <div class="card-body">Card rotate end</div>
+              </div>
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <div class="card card-rotate-start">
+                <div class="card-body">Card rotate start</div>
+              </div>
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <div class="card card-active">
+                <div class="card-body">
+                  <p>This is a card with active state.</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <div class="card card-inactive">
+                <div class="card-body">
+                  <p>This is some text inactive state.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </SectionCardBody>
+      </SectionCard>
+    </div>
+
+    <div class="col-12">
+      <SectionCard>
+        <SectionCardBody>
+          <CardTitle>Icon & background accents</CardTitle>
+          <CardSubtitle>Draw attention with a stamp icon or a tinted background.</CardSubtitle>
+          <div class="row row-cards">
+            <div class="col-md-6 col-lg-4">
+              <div class="card">
+                <CardStamp icon="bell" color="yellow" />
+                <div class="card-body">
+                  <CardTitle>Card with icon bg</CardTitle>
+                  <p class="text-secondary">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Architecto at consectetur culpa ducimus eum fuga fugiat, ipsa iusto, modi nostrum recusandae reiciendis saepe.</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-6 col-lg-4">
+              <div class="card bg-primary-lt">
+                <div class="card-body">
+                  <CardTitle>Card with primary light background</CardTitle>
+                  <p class="text-secondary">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Architecto at consectetur culpa ducimus eum fuga fugiat, ipsa iusto, modi nostrum recusandae reiciendis saepe.</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-6 col-lg-4">
+              <CardBackgroundIcon />
+            </div>
+          </div>
+        </SectionCardBody>
+      </SectionCard>
+    </div>
+
+    <div class="col-12">
+      <SectionCard>
+        <SectionCardBody>
+          <CardTitle>Status indicators</CardTitle>
+          <CardSubtitle>Mark a card's state with a colored edge on any side.</CardSubtitle>
+          <div class="row row-cards">
+            <div class="col-md-6 col-lg-4">
+              <Card statusTop="danger" title="Card with top status" />
+            </div>
+            <div class="col-md-6 col-lg-4">
+              <Card statusBottom="success" title="Card with bottom status" />
+            </div>
+            <div class="col-md-6 col-lg-4">
+              <Card statusStart="primary" title="Card with side status" />
+            </div>
+          </div>
+        </SectionCardBody>
+      </SectionCard>
+    </div>
+
+    <div class="col-12">
+      <SectionCard>
+        <SectionCardBody>
+          <CardTitle>Ribbons & progress</CardTitle>
+          <CardSubtitle>Flag content with a ribbon, or track progress right inside the card.</CardSubtitle>
+          <div class="row row-cards">
+            <div class="col-md-6 col-lg-3">
+              <CardRibbonTop />
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <CardRibbonText />
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <Card progress title="Card with progress bar" />
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <Card class="card-stacked" title="Stacked card" />
+            </div>
+          </div>
+        </SectionCardBody>
+      </SectionCard>
+    </div>
+
+    <div class="col-12">
+      <SectionCard>
+        <SectionCardBody>
+          <CardTitle>Card images</CardTitle>
+          <CardSubtitle>Pair a card with an image on the left, right, top, or bottom.</CardSubtitle>
+          <div class="row row-cards">
+            <div class="col-lg-6">
+              <CardImage title="Card with left side image" />
+            </div>
+            <div class="col-lg-6">
+              <CardImage title="Card with right side image" right imgId={3} />
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <Card imgTop title="Card with top image" />
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <Card imgBottom title="Card with bottom image" />
+            </div>
+          </div>
+        </SectionCardBody>
+      </SectionCard>
+    </div>
+
+    <div class="col-12">
+      <SectionCard>
+        <SectionCardBody>
+          <CardTitle>Footers</CardTitle>
+          <CardSubtitle>Add a footer for metadata, a single action, or a group of buttons.</CardSubtitle>
+          <div class="row row-cards">
+            <div class="col-md-6 col-lg-3">
+              <div class="card">
+                <div class="card-body">
+                  <CardTitle>Card with footer</CardTitle>
+                  <p class="text-secondary">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam deleniti fugit incidunt, iste, itaque minima neque pariatur perferendis sed suscipit velit vitae voluptatem.</p>
+                </div>
+                <div class="card-footer">This is standard card footer</div>
+              </div>
+            </div>
+            <div class="col-md-6 col-lg-3">
+              <div class="card">
+                <div class="card-body">
+                  <CardTitle>Card with transparent footer</CardTitle>
+                  <p class="text-secondary">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam deleniti fugit incidunt, iste, itaque minima neque pariatur perferendis sed suscipit velit vitae voluptatem.</p>
+                </div>
+                <div class="card-footer card-footer-transparent">This is transparent card footer</div>
+              </div>
+            </div>
+            <div class="col-md-6 col-lg-3"><Card title="Card with footer button" footerButton /></div>
+            <div class="col-md-6 col-lg-3"><Card title="Card with footer buttons" footerButtons /></div>
+          </div>
+        </SectionCardBody>
+      </SectionCard>
+    </div>
+
+    <div class="col-12">
+      <SectionCard>
+        <SectionCardBody>
+          <CardTitle>Footer elements</CardTitle>
+          <CardSubtitle>Compose footer content from prebuilt elements like links, switches, or avatars.</CardSubtitle>
+          <div class="row row-cards">
+            <div class="col-md-6 col-lg-3"><Card footerElements={['more', '>switch']} /></div>
+            <div class="col-md-6 col-lg-3"><Card footerElements={['>avatars']} /></div>
+          </div>
+        </SectionCardBody>
+      </SectionCard>
+    </div>
+
+    <div class="col-12">
+      <SectionCard>
+        <SectionCardBody>
+          <CardTitle>Header tabs & pills</CardTitle>
+          <CardSubtitle>Navigate between panes right from the card header.</CardSubtitle>
+          <div class="row row-cards">
+            <div class="col-md-6 col-lg-3"><Card headerTabs /></div>
+            <div class="col-md-6 col-lg-3"><Card headerPills /></div>
+            <div class="col-md-6 col-lg-3"><CardTabs /></div>
+            <div class="col-md-6 col-lg-3"><CardTabs bottom id="bottom" /></div>
+          </div>
+        </SectionCardBody>
+      </SectionCard>
+    </div>
+
+    <div class="col-12">
+      <SectionCard>
+        <SectionCardBody>
+          <CardTitle>Nested & grouped cards</CardTitle>
+          <CardSubtitle>Combine cards inside a card, a full-bleed group, or a matched-height deck.</CardSubtitle>
+          <div class="row row-cards">
+            <div class="col-12">
+              <div class="card">
+                <div class="card-header">
+                  <CardTitle>Cards inside card</CardTitle>
+                </div>
+                <div class="card-body">
+                  <div class="row row-cards">
+                    {
+                      cardsStack.map((name, i) => (
+                        <div class="col-md">
+                          <div class="card">
+                            <div class={`card-status-top bg-${cardsStackColors[i]}`} />
+                            <div class="card-header">
+                              <CardTitle>{name} card</CardTitle>
+                            </div>
+                            <BodyPlaceholder />
+                          </div>
+                        </div>
+                      ))
+                    }
                   </div>
                 </div>
-              ))
-            }
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-12">
-      <div class="card-group">
-        {
-          cardsStack.map((name) => (
-            <div class="card">
-              <div class="card-header">
-                <CardTitle>{name} card</CardTitle>
               </div>
-              <BodyPlaceholder />
             </div>
-          ))
-        }
-      </div>
+
+            <div class="col-12">
+              <div class="card-group">
+                {
+                  cardsStack.map((name) => (
+                    <div class="card">
+                      <div class="card-header">
+                        <CardTitle>{name} card</CardTitle>
+                      </div>
+                      <BodyPlaceholder />
+                    </div>
+                  ))
+                }
+              </div>
+            </div>
+
+            <div class="col-12">
+              <div class="row row-cards row-deck">
+                <div class="col">
+                  <div class="card">
+                    <div class="card-header">
+                      <CardTitle>Card title</CardTitle>
+                    </div>
+                    <div class="card-body">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</div>
+                    <div class="card-footer">Last updated 3 mins ago</div>
+                  </div>
+                </div>
+                <div class="col">
+                  <div class="card">
+                    <div class="card-header">
+                      <CardTitle>Card title</CardTitle>
+                    </div>
+                    <div class="card-body">This card has supporting text below as a natural lead-in to additional content.</div>
+                    <div class="card-footer">Last updated 3 mins ago</div>
+                  </div>
+                </div>
+                <div class="col">
+                  <div class="card">
+                    <div class="card-header">
+                      <CardTitle>Card with very long content</CardTitle>
+                    </div>
+                    <div class="card-body">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</div>
+                    <div class="card-footer">Last updated 3 mins ago</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </SectionCardBody>
+      </SectionCard>
     </div>
 
     <div class="col-12">
-      <div class="row row-cards row-deck">
-        <div class="col">
-          <div class="card">
-            <div class="card-header">
-              <CardTitle>Card title</CardTitle>
-            </div>
-            <div class="card-body">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</div>
-            <div class="card-footer">Last updated 3 mins ago</div>
+      <SectionCard>
+        <SectionCardBody>
+          <CardTitle>Special states</CardTitle>
+          <CardSubtitle>An empty state, a team placeholder, and a specialty credit card layout.</CardSubtitle>
+          <div class="row row-cards">
+            <div class="col-lg-4"><Card empty /></div>
+            <div class="col-lg-4"><EmptyTeam /></div>
+            <div class="col-lg-4"><CreditCard /></div>
           </div>
-        </div>
-        <div class="col">
-          <div class="card">
-            <div class="card-header">
-              <CardTitle>Card title</CardTitle>
-            </div>
-            <div class="card-body">This card has supporting text below as a natural lead-in to additional content.</div>
-            <div class="card-footer">Last updated 3 mins ago</div>
-          </div>
-        </div>
-        <div class="col">
-          <div class="card">
-            <div class="card-header">
-              <CardTitle>Card with very long content</CardTitle>
-            </div>
-            <div class="card-body">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</div>
-            <div class="card-footer">Last updated 3 mins ago</div>
-          </div>
-        </div>
-      </div>
+        </SectionCardBody>
+      </SectionCard>
     </div>
-
-    <div class="col-lg-4"><Card empty /></div>
-    <div class="col-lg-4"><EmptyTeam /></div>
-    <div class="col-lg-4"><CreditCard /></div>
   </div>
 </DefaultLayout>

--- a/preview/pages/colorpicker.astro
+++ b/preview/pages/colorpicker.astro
@@ -3,6 +3,7 @@ import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
+import CardSubtitle from '@ui/CardSubtitle.astro'
 import Colorpicker from '@ui/Colorpicker.astro'
 import site from '@data/site.json'
 import DocsLink from '@ui/DocsLink.astro'
@@ -15,6 +16,7 @@ const colors = Object.values(site.colors) as { hex: string; title: string }[]
   <Card>
     <CardBody>
       <CardTitle>Basic</CardTitle>
+      <CardSubtitle>Click a swatch to open the picker and choose any color.</CardSubtitle>
       <div class="row g-3">
         {
           colors.map((color, index) => (

--- a/preview/pages/datatables.astro
+++ b/preview/pages/datatables.astro
@@ -3,7 +3,10 @@ import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import { toUnixSeconds, formatLongDate } from '@shared/lib/date-format'
 import { randomNumber, randomDate } from '@shared/lib/pseudo-random'
 import Card from '@ui/Card.astro'
+import CardHeader from '@ui/CardHeader.astro'
 import CardBody from '@ui/CardBody.astro'
+import CardTitle from '@ui/CardTitle.astro'
+import CardSubtitle from '@ui/CardSubtitle.astro'
 import Progress from '@ui/Progress.astro'
 import TablerList from '@shared/components/js/TablerList.astro'
 import rollercoasters from '@data/rollercoasters.json'
@@ -35,6 +38,12 @@ const valueNames = ['sort-name', 'sort-type', 'sort-city', 'sort-score', { attr:
 
 <DefaultLayout title="Datatables" pageMenu="plugins.datatables" pageLibs={['lists']}>
   <Card>
+    <CardHeader>
+      <div>
+        <CardTitle>Sortable table</CardTitle>
+        <CardSubtitle>Click a column header to sort the rows by that value.</CardSubtitle>
+      </div>
+    </CardHeader>
     <CardBody class="p-0">
       <div id={`table-${id}`} class="table-responsive">
         <table class="table">

--- a/preview/pages/dropzone.astro
+++ b/preview/pages/dropzone.astro
@@ -4,6 +4,7 @@ import Dropzone from '@ui/Dropzone.astro'
 import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
+import CardSubtitle from '@ui/CardSubtitle.astro'
 import DocsLink from '@ui/DocsLink.astro'
 ---
 
@@ -14,6 +15,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle>Basic Usage</CardTitle>
+          <CardSubtitle>Drag a file in or click to browse — a single drop target for one upload.</CardSubtitle>
           <Dropzone id="default" />
         </CardBody>
       </Card>
@@ -22,6 +24,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle>Multiple File Upload</CardTitle>
+          <CardSubtitle>Accept and preview several files at once from the same drop target.</CardSubtitle>
           <Dropzone id="multiple" multiple={true} />
         </CardBody>
       </Card>
@@ -30,6 +33,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle>Custom Dropzone</CardTitle>
+          <CardSubtitle>Swap in your own label and helper text for the drop target.</CardSubtitle>
           <Dropzone id="custom" custom={true} text="Your text here" description="Your custom description here" />
         </CardBody>
       </Card>

--- a/preview/pages/emails.astro
+++ b/preview/pages/emails.astro
@@ -7,11 +7,14 @@ import Prose from '@ui/Prose.astro'
 import CaptureScript from '@shared/components/CaptureScript.astro'
 import { site } from '@shared/lib/site'
 import emails from '@data/emails.json'
+import DocsLink from '@ui/DocsLink.astro'
 
 const emailEntries = Object.entries(emails)
 ---
 
 <DefaultLayout pageHeader="Email templates" pageMenu="addons.emails" pageLibs={['masonry', 'fslightbox']}>
+  <DocsLink slot="page-header-actions" path="/emails" />
+
   <div class="row row-cards">
     <div class="col-12">
       <div class="card card-md">

--- a/preview/pages/form-layout.astro
+++ b/preview/pages/form-layout.astro
@@ -10,20 +10,30 @@ import FormGroup from '@ui/FormGroup.astro'
 import Card from '@ui/Card.astro'
 import CardHeader from '@ui/CardHeader.astro'
 import CardBody from '@ui/CardBody.astro'
+import CardTitle from '@ui/CardTitle.astro'
+import CardSubtitle from '@ui/CardSubtitle.astro'
 import Layout from '@shared/components/cards/form/Layout.astro'
 import Payment from '@shared/components/cards/form/Payment.astro'
 import flags from '@data/flags.json'
+import DocsLink from '@ui/DocsLink.astro'
 
 const countries = flags as { name: string }[]
 ---
 
 <DefaultLayout title="Form layout" pageHeader="Form Layout" pageMenu="form.layout" pageLibs={['litepicker']}>
+  <DocsLink slot="page-header-actions" path="/ui/forms" />
+
   <div class="row row-cards row-cols-1 row-cols-md-3">
     <div class="col">
       <div class="row row-cards">
         <div class="col-12">
           <Card>
-            <CardHeader title="Basic Form" />
+            <CardHeader>
+              <div>
+                <CardTitle>Basic Form</CardTitle>
+                <CardSubtitle>A minimal sign-up form with just the essentials.</CardSubtitle>
+              </div>
+            </CardHeader>
             <CardBody>
               <form class="space-y">
                 <div class="row">
@@ -47,7 +57,12 @@ const countries = flags as { name: string }[]
         </div>
         <div class="col-12">
           <Card>
-            <CardHeader title="Example Form" />
+            <CardHeader>
+              <div>
+                <CardTitle>Example Form</CardTitle>
+                <CardSubtitle>A contact form with a subject select and a message field.</CardSubtitle>
+              </div>
+            </CardHeader>
             <CardBody>
               <form>
                 <div class="space-y">
@@ -81,7 +96,12 @@ const countries = flags as { name: string }[]
       <div class="row row-cards">
         <div class="col-12">
           <Card>
-            <CardHeader title="Example Form with Icons" />
+            <CardHeader>
+              <div>
+                <CardTitle>Example Form with Icons</CardTitle>
+                <CardSubtitle>Prefix each field with an icon for a friendlier sign-up flow.</CardSubtitle>
+              </div>
+            </CardHeader>
             <CardBody>
               <form class="space-y">
                 <div><InputIcon icon="user" placeholder="Username" prepend /></div>
@@ -101,7 +121,12 @@ const countries = flags as { name: string }[]
 
         <div class="col-12">
           <Card>
-            <CardHeader title="Form with Icons and Validation" />
+            <CardHeader>
+              <div>
+                <CardTitle>Form with Icons and Validation</CardTitle>
+                <CardSubtitle>Pair an icon input with valid and invalid feedback states.</CardSubtitle>
+              </div>
+            </CardHeader>
             <CardBody>
               <form class="space-y">
                 <div>
@@ -127,7 +152,12 @@ const countries = flags as { name: string }[]
 
         <div class="col-12">
           <Card>
-            <CardHeader title="Example Form" />
+            <CardHeader>
+              <div>
+                <CardTitle>Example Form</CardTitle>
+                <CardSubtitle>A longer profile form grouped into personal info and address sections.</CardSubtitle>
+              </div>
+            </CardHeader>
             <CardBody>
               <form>
                 <div class="space-y">

--- a/preview/pages/fullcalendar.astro
+++ b/preview/pages/fullcalendar.astro
@@ -2,6 +2,8 @@
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
+import CardTitle from '@ui/CardTitle.astro'
+import CardSubtitle from '@ui/CardSubtitle.astro'
 import Fullcalendar from '@ui/Fullcalendar.astro'
 import DocsLink from '@ui/DocsLink.astro'
 ---
@@ -10,6 +12,8 @@ import DocsLink from '@ui/DocsLink.astro'
   <DocsLink slot="page-header-actions" path="/ui/components/fullcalendar" />
   <Card>
     <CardBody>
+      <CardTitle>Full calendar</CardTitle>
+      <CardSubtitle>Drag to create an event, click one to edit it — populated here with sample events.</CardSubtitle>
       <Fullcalendar sampleEvents />
     </CardBody>
   </Card>

--- a/preview/pages/illustrations.astro
+++ b/preview/pages/illustrations.astro
@@ -11,6 +11,7 @@ import illustrationsList from '@data/illustrations.json'
 import siteData from '@data/site.json'
 import { requireIndex } from '@shared/lib/array'
 import PageTitle from '@ui/PageTitle.astro'
+import DocsLink from '@ui/DocsLink.astro'
 
 const autodark = (freeIllustrations as { autodark: Record<string, string> }).autodark
 const autodarkEntries = Object.entries(autodark)
@@ -34,6 +35,8 @@ const illustrationsData = Object.fromEntries(autodarkEntries.map(([key, svg]) =>
 ---
 
 <DefaultLayout title="SVG Illustrations" pageMenu="addons.illustrations">
+  <DocsLink slot="page-header-actions" path="/illustrations" />
+
   <div class="mb-7" style={`--tblr-illustrations-primary: var(--tblr-color-primary); --tblr-illustrations-skin: ${skinFirst.hex};`} id="current-illustration-style">
     <div class="row row-cards">
       <div class="col-12">

--- a/preview/pages/lightbox.astro
+++ b/preview/pages/lightbox.astro
@@ -8,7 +8,7 @@ import DocsLink from '@ui/DocsLink.astro'
 const filteredPhotos = photos.filter((photo) => photo.horizontal)
 ---
 
-<DefaultLayout title="Lightbox" pageMenu="plugins.lightbox" pageLibs={['fslightbox']}>
+<DefaultLayout title="Lightbox" pageMenu="plugins.lightbox" pageLibs={['fslightbox']} description="Click any photo to open it full-screen, then arrow or swipe through the rest of the gallery.">
   <DocsLink slot="page-header-actions" path="/ui/components/lightbox" />
   <div class="row row-cols-3 row-cols-md-4 row-cols-lg-6 g-3">
     {

--- a/preview/pages/maps.astro
+++ b/preview/pages/maps.astro
@@ -12,7 +12,7 @@ type MapData = { title?: string; card?: boolean }
 const mapEntries = Object.entries(maps as Record<string, MapData>)
 ---
 
-<DefaultLayout title="Maps" pageMenu="plugins.maps" pageLibs={['mapbox']}>
+<DefaultLayout title="Maps" pageMenu="plugins.maps" pageLibs={['mapbox']} description="Interactive Mapbox maps — plain, styled, or full-card with custom markers.">
   <DocsLink slot="page-header-actions" path="/ui/components/map" />
   <div class="row row-cards">
     {

--- a/preview/pages/patterns.astro
+++ b/preview/pages/patterns.astro
@@ -4,6 +4,7 @@ import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
 import BackgroundPattern from '@ui/BackgroundPattern.astro'
+import CardSubtitle from '@ui/CardSubtitle.astro'
 import site from '@data/site.json'
 import DocsLink from '@ui/DocsLink.astro'
 
@@ -21,6 +22,7 @@ const patterns = ['diagonal', 'diagonal-2', 'dots', 'rectangles', 'lines', 'line
       <Card>
         <CardBody>
           <CardTitle>Pattern types</CardTitle>
+          <CardSubtitle>Apply a repeating background pattern to any element with a single utility class.</CardSubtitle>
           <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 row-cols-xl-6 g-3">
             {
               patterns.map((pattern) => (
@@ -38,6 +40,7 @@ const patterns = ['diagonal', 'diagonal-2', 'dots', 'rectangles', 'lines', 'line
       <Card>
         <CardBody>
           <CardTitle>Pattern colors</CardTitle>
+          <CardSubtitle>Tint the pattern with any theme color from the palette.</CardSubtitle>
           <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 row-cols-xl-6 g-3">
             {
               patternColors.map((color) => (
@@ -55,6 +58,7 @@ const patterns = ['diagonal', 'diagonal-2', 'dots', 'rectangles', 'lines', 'line
       <Card>
         <CardBody>
           <CardTitle>Pattern sizes</CardTitle>
+          <CardSubtitle>Scale the pattern from <code>sm</code> to <code>xl</code>.</CardSubtitle>
           <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 row-cols-xl-6 g-3">
             {
               patternSizes.map((size) => (

--- a/preview/pages/payment-providers.astro
+++ b/preview/pages/payment-providers.astro
@@ -6,6 +6,7 @@ import CardHeader from '@ui/CardHeader.astro'
 import CardBody from '@ui/CardBody.astro'
 import payments from '@data/payments.json'
 import CardTitle from '@ui/CardTitle.astro'
+import CardSubtitle from '@ui/CardSubtitle.astro'
 import DocsLink from '@ui/DocsLink.astro'
 
 const providers = payments as { name: string; logo: string }[]
@@ -13,11 +14,15 @@ const providers = payments as { name: string; logo: string }[]
 
 <DefaultLayout title="Payment Providers" pageMenu="addons.payment-providers">
   <DocsLink slot="page-header-actions" path="/ui/plugins/payments" />
+
   <div class="row row-cards">
     <div class="col-12">
       <Card>
         <CardHeader>
-          <CardTitle>Light version</CardTitle>
+          <div>
+            <CardTitle>Light version</CardTitle>
+            <CardSubtitle>Provider logos on a light background, for use on white or light cards.</CardSubtitle>
+          </div>
         </CardHeader>
         <CardBody>
           <div class="row g-5 row-cols-5">
@@ -45,7 +50,10 @@ const providers = payments as { name: string; logo: string }[]
     <div class="col-12">
       <Card>
         <CardHeader>
-          <CardTitle>Dark version</CardTitle>
+          <div>
+            <CardTitle>Dark version</CardTitle>
+            <CardSubtitle>Provider logos with an inverted color scheme, for dark backgrounds.</CardSubtitle>
+          </div>
         </CardHeader>
         <CardBody>
           <div class="row g-5 row-cols-5">

--- a/preview/pages/progress.astro
+++ b/preview/pages/progress.astro
@@ -5,6 +5,7 @@ import ButtonList from '@ui/ButtonList.astro'
 import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
 import CardTitle from '@ui/CardTitle.astro'
+import CardSubtitle from '@ui/CardSubtitle.astro'
 import Progress from '@ui/Progress.astro'
 import ProgressSteps from '@ui/ProgressSteps.astro'
 import ProgressBg from '@ui/ProgressBg.astro'
@@ -19,6 +20,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle>Default</CardTitle>
+          <CardSubtitle>Track completion with a simple bar from empty to full.</CardSubtitle>
           <div class="space-y">
             <Progress value="0" />
             <Progress value="20" />
@@ -32,6 +34,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle>With value</CardTitle>
+          <CardSubtitle>Show the exact percentage inside a larger bar with <code>showValue</code>.</CardSubtitle>
           <div class="space-y">
             <Progress value="10" showValue size="lg" />
             <Progress value="20" showValue size="lg" />
@@ -44,6 +47,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle>Colors</CardTitle>
+          <CardSubtitle>Match the bar color to the context with any theme color.</CardSubtitle>
           <div class="space-y">
             <Progress color="blue" value="20" />
             <Progress color="green" value="40" />
@@ -57,6 +61,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle>Sizes</CardTitle>
+          <CardSubtitle>Scale a bar from <code>sm</code> to <code>xl</code>.</CardSubtitle>
           <div class="space-y">
             <Progress value="20" size="sm" />
             <Progress value="40" />
@@ -70,6 +75,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle>Indeterminate</CardTitle>
+          <CardSubtitle>Animate a bar with no known end point using <code>indeterminate</code>.</CardSubtitle>
           <div class="space-y">
             <Progress indeterminate />
           </div>
@@ -80,6 +86,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle>Multiple values</CardTitle>
+          <CardSubtitle>Stack several segments in one bar to compare parts of a whole.</CardSubtitle>
           <div class="space-y">
             <Progress values={[20, 30, 10]} />
             <Progress values={[10, 20, 30, 40]} class="progress-separated" />
@@ -91,6 +98,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle>Striped</CardTitle>
+          <CardSubtitle>Add diagonal stripes with <code>striped</code> for a textured look.</CardSubtitle>
           <div class="space-y">
             <Progress color="blue" value="20" striped />
             <Progress color="green" value="40" striped />
@@ -104,6 +112,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle>Animated</CardTitle>
+          <CardSubtitle>Combine <code>striped</code> with <code>animated</code> to keep the stripes moving.</CardSubtitle>
           <div class="space-y">
             <Progress value="20" striped animated />
             <Progress value="40" color="green" striped animated />
@@ -117,6 +126,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle> Animated with JavaScript </CardTitle>
+          <CardSubtitle>Update the bar's width at runtime and watch it react.</CardSubtitle>
           <div class="row align-items-center g-0">
             <div class="col">
               <Progress value="0" id="progress-animated" />
@@ -175,6 +185,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle> Steps Progress </CardTitle>
+          <CardSubtitle>Mark discrete steps instead of a continuous percentage.</CardSubtitle>
           <div class="space-y">
             <ProgressSteps count={3} />
             <ProgressSteps count={5} active={4} />
@@ -188,6 +199,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle> Progress Background </CardTitle>
+          <CardSubtitle>Fill a row's background as the progress indicator itself.</CardSubtitle>
           <div class="space-y">
             <ProgressBg value="85" text="Poland" showValue />
             <ProgressBg value="65" text="Germany" showValue />
@@ -201,6 +213,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle> Progress Background Colors </CardTitle>
+          <CardSubtitle>Pair a light background fill with a matching accent color.</CardSubtitle>
           <div class="space-y">
             <ProgressBg value="75" text="Success" color="success-lt" showValue />
             <ProgressBg value="60" text="Warning" color="warning-lt" showValue />
@@ -214,6 +227,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle> Progress Description </CardTitle>
+          <CardSubtitle>Pair a label and percentage with the bar for more context.</CardSubtitle>
           <div class="space-y">
             <ProgressDescription label="Project completion" value="85" color="green" />
             <ProgressDescription label="Storage usage" description="2.4GB of 5GB" value="48" color="blue" />
@@ -227,6 +241,7 @@ import DocsLink from '@ui/DocsLink.astro'
       <Card>
         <CardBody>
           <CardTitle> Progress Description Sizes </CardTitle>
+          <CardSubtitle>Scale the labeled progress bar from <code>sm</code> to <code>xl</code>.</CardSubtitle>
           <div class="space-y">
             <ProgressDescription label="Small progress" value="60" size="sm" color="blue" />
             <ProgressDescription label="Default progress" value="70" color="green" />

--- a/preview/pages/sortable.astro
+++ b/preview/pages/sortable.astro
@@ -3,6 +3,8 @@ import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Card from '@ui/Card.astro'
 import CardHeader from '@ui/CardHeader.astro'
 import CardBody from '@ui/CardBody.astro'
+import CardTitle from '@ui/CardTitle.astro'
+import CardSubtitle from '@ui/CardSubtitle.astro'
 import ListGroup from '@ui/ListGroup.astro'
 import ListGroupItem from '@ui/ListGroupItem.astro'
 ---
@@ -11,7 +13,12 @@ import ListGroupItem from '@ui/ListGroupItem.astro'
   <div class="row row-cards">
     <div class="col-md-6">
       <Card>
-        <CardHeader title="Basic usage" />
+        <CardHeader>
+          <div>
+            <CardTitle>Basic usage</CardTitle>
+            <CardSubtitle>Drag to reorder items within a single list.</CardSubtitle>
+          </div>
+        </CardHeader>
         <CardBody>
           <ListGroup as="ul" data-sortable='{"animation":150}'>
             <ListGroupItem as="li">Element A</ListGroupItem>
@@ -24,7 +31,12 @@ import ListGroupItem from '@ui/ListGroupItem.astro'
     </div>
     <div class="col-md-6">
       <Card>
-        <CardHeader title="Two lists with drag and drop" />
+        <CardHeader>
+          <div>
+            <CardTitle>Two lists with drag and drop</CardTitle>
+            <CardSubtitle>Move items between two connected lists.</CardSubtitle>
+          </div>
+        </CardHeader>
         <CardBody>
           <div class="row g-3">
             <div class="col-sm-6">

--- a/preview/pages/tables.astro
+++ b/preview/pages/tables.astro
@@ -5,6 +5,9 @@ import Progressbg from '@shared/components/cards/tables/Progressbg.astro'
 import Invoices from '@shared/components/cards/Invoices.astro'
 import AdvancedTable from '@ui/AdvancedTable.astro'
 import Card from '@ui/Card.astro'
+import CardHeader from '@ui/CardHeader.astro'
+import CardTitle from '@ui/CardTitle.astro'
+import CardSubtitle from '@ui/CardSubtitle.astro'
 import DocsLink from '@ui/DocsLink.astro'
 ---
 
@@ -13,6 +16,12 @@ import DocsLink from '@ui/DocsLink.astro'
   <div class="row row-cards">
     <div class="col-lg-8">
       <Card>
+        <CardHeader>
+          <div>
+            <CardTitle>Basic table</CardTitle>
+            <CardSubtitle>A clean list of rows and columns, ready to drop into any card.</CardSubtitle>
+          </div>
+        </CardHeader>
         <Table card={true} limit={8} />
       </Card>
     </div>
@@ -23,18 +32,36 @@ import DocsLink from '@ui/DocsLink.astro'
 
     <div class="col-12">
       <Card>
+        <CardHeader>
+          <div>
+            <CardTitle>Striped rows</CardTitle>
+            <CardSubtitle>Alternate row shading with <code>stripped</code> to make wide tables easier to scan.</CardSubtitle>
+          </div>
+        </CardHeader>
         <Table card={true} stripped={true} offset={5} />
       </Card>
     </div>
 
     <div class="col-12">
       <Card>
+        <CardHeader>
+          <div>
+            <CardTitle>With avatars</CardTitle>
+            <CardSubtitle>Swap the plain name column for an avatar, title, and department.</CardSubtitle>
+          </div>
+        </CardHeader>
         <Table card={true} avatars={true} offset={10} />
       </Card>
     </div>
 
     <div class="col-12">
       <Card>
+        <CardHeader>
+          <div>
+            <CardTitle>Responsive with actions</CardTitle>
+            <CardSubtitle>Collapses to stacked rows on mobile and adds an actions button per row.</CardSubtitle>
+          </div>
+        </CardHeader>
         <Table card={true} mobile={true} avatars={true} offset={15} buttons={true} />
       </Card>
     </div>

--- a/preview/pages/typography.astro
+++ b/preview/pages/typography.astro
@@ -1,5 +1,6 @@
 ---
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
+import Prose from '@ui/Prose.astro'
 import DocsLink from '@ui/DocsLink.astro'
 ---
 
@@ -17,129 +18,85 @@ import DocsLink from '@ui/DocsLink.astro'
           <p>Well, we did do the nose. Why? Now, look here, my good man. Be quiet! Well, what do you want?</p>
         </div>
 
-        <div class="col-md-6 prose">
-          <h2>1/2 Text</h2>
-          <p>What do you mean? We shall say 'Ni' again to you, if you do not appease us. I have to push the pram a lot. No, no, no! Yes, yes. A bit. But she's got a wart. What a strange person.</p>
-        </div>
+  <div class="row justify-content-center">
+    <div class="col-lg-9 col-xl-8">
+      <div class="card card-lg">
+        <div class="card-body">
+          <Prose>
+            <h1>Brewing better coffee at home</h1>
+            <p class="lead">Good coffee isn't about expensive gear — it's about <mark>consistency</mark>. Get the ratio, the grind, and the water temperature right, and almost any method will taste better.</p>
 
-        <div class="col-md-6 prose">
-          <h2>1/2 Text</h2>
-          <p>And this isn't my nose. This is a false one. We found them. Listen. Strange women lying in ponds distributing swords is no basis for a system of government. Supreme executive power derives from a mandate from the masses, not from some farcical aquatic ceremony.</p>
-        </div>
+            <blockquote class="blockquote">
+              <p>Coffee is a language in itself.</p>
+              <footer class="blockquote-footer">Jackie Chan</footer>
+            </blockquote>
 
-        <div class="col-md-4 prose">
-          <h3>1/3 Text</h3>
-          <p>Knights of Ni, we are but simple travelers who seek the enchanter who lives beyond these woods. Why? Well, what do you want? …Are you suggesting that coconuts migrate?</p>
-        </div>
-        <div class="col-md-8 prose">
-          <h3>2/3 Text</h3>
-          <p>Well, I got better. Knights of Ni, we are but simple travelers who seek the enchanter who lives beyond these woods. Found them? In Mercia?! The coconut's tropical! A newt? …Are you suggesting that coconuts migrate?</p>
-        </div>
+            <h2>What you'll need</h2>
+            <ul>
+              <li>Freshly roasted beans, ground just before brewing</li>
+              <li>
+                A scale accurate to <sup>1</sup>&frasl;<sub>10</sub> of a gram
+                <ul>
+                  <li>Kitchen scales work, but a coffee scale is easier to read</li>
+                  <li>Weigh both the coffee and the water</li>
+                </ul>
+              </li>
+              <li>Water just off the boil, around 96&deg;C</li>
+            </ul>
 
-        <div class="col-md-8 prose">
-          <p>I don't want to talk to you no more, you empty-headed animal food trough water! I fart in your general direction! Your mother was a hamster and your father smelt of elderberries! Now leave before I am forced to taunt you a second time! We want a shrubbery!!</p>
-          <p>Well, how'd you become king, then? Found them? In Mercia?! The coconut's tropical! Oh, ow! I am your king.</p>
-        </div>
+            <h2>Steps</h2>
+            <ol>
+              <li>Heat the water and warm your brewing vessel.</li>
+              <li>Weigh <strong>18g of coffee</strong> for every 300g of water — a 1:16 ratio.</li>
+              <li>Grind just before brewing; <del>pre-ground coffee</del> <ins>fresh-ground coffee</ins> makes the biggest difference of all.</li>
+              <li>Pour in stages, stirring <em>gently</em> after the first pour so every ground gets wet.</li>
+              <li>Set a timer — <kbd>⌘</kbd> + <kbd>T</kbd> in most timer apps — and aim for a total brew time of 3&ndash;4 minutes.</li>
+            </ol>
 
-        <div class="col-md-3 prose">
-          <h4>Small Text</h4>
-          <p>Well, Mercia's a temperate zone! You don't vote for kings. Now, look here, my good man.</p>
-          <p class="text-secondary small lh-base">Who's that then? Well, we did do the nose.</p>
-        </div>
+            <h3>Why the ratio matters</h3>
+            <p>
+              A cup that's too weak usually means too little coffee, not too little time. Coffee contains caffeine (<abbr title="Chemical formula">C<sub>8</sub>H<sub>10</sub>N<sub>4</sub>O<sub>2</sub></abbr>), and how much of it — and everything else — ends up in your cup comes down to the <code>coffee:water</code> ratio above almost anything else.
+            </p>
 
-        <div class="col-md-4 prose">
-          <h3>Unordered list</h3>
-          <ul>
-            <li>lorem ipsum doloret</li>
-            <li>
-              lorem ipsum doloret
-              <ul>
-                <li>lorem ipsum doloret</li>
-                <li>lorem ipsum doloret</li>
-              </ul>
-            </li>
-            <li>lorem ipsum doloret</li>
-            <li>lorem ipsum doloret</li>
-          </ul>
-        </div>
+            <h4>A quick note on freshness</h4>
+            <p>Beans are at their best one to four weeks after roasting. <u>Buy smaller bags more often</u> rather than stockpiling — coffee doesn't go bad, it just goes flat.</p>
 
-        <div class="col-md-4 prose">
-          <h3>Ordered list</h3>
-          <ol>
-            <li>lorem ipsum doloret</li>
-            <li>lorem ipsum doloret</li>
-            <li>lorem ipsum doloret</li>
-            <li>lorem ipsum doloret</li>
-            <li>lorem ipsum doloret</li>
-            <li>lorem ipsum doloret</li>
-          </ol>
-        </div>
+            <h5>Grind size by method</h5>
+            <table>
+              <thead>
+                <tr>
+                  <th>Method</th>
+                  <th>Grind</th>
+                  <th>Brew time</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>French press</td>
+                  <td>Coarse</td>
+                  <td>4 min</td>
+                </tr>
+                <tr>
+                  <td>Pour over</td>
+                  <td>Medium</td>
+                  <td>3 min</td>
+                </tr>
+                <tr>
+                  <td>Espresso</td>
+                  <td>Fine</td>
+                  <td>25&ndash;30 sec</td>
+                </tr>
+              </tbody>
+            </table>
 
-        <div class="col-md-4 prose">
-          <h3>Unstyled list</h3>
-          <ul class="list-unstyled">
-            <li>lorem ipsum doloret</li>
-            <li>lorem ipsum doloret</li>
-            <li>lorem ipsum doloret</li>
-            <li>lorem ipsum doloret</li>
-            <li>lorem ipsum doloret</li>
-            <li>lorem ipsum doloret</li>
-          </ul>
-        </div>
+            <h6>Fine print</h6>
+            <p><small class="text-secondary">Ratios are a starting point, not a rule — adjust to taste once you've got the basics down.</small></p>
 
-        <div class="col-12 prose">
-          <h3>Blockquote</h3>
-
-          <blockquote class="blockquote">
-            <p>I don't want to talk to you no more, you empty-headed animal food trough water! I fart in your general direction! Your mother was a hamster and your father smelt of elderberries! Now leave before I am forced to taunt you a second time! The nose?</p>
-            <footer class="blockquote-footer">Julius Cesar</footer>
-          </blockquote>
-        </div>
-
-        <div class="col-md-4 prose">
-          <h3>Text elements</h3>
-
-          <div>You can use the mark tag to <mark>highlight</mark> text.</div>
-          <div><s>This line of text is meant to be treated as deleted</s></div>
-          <div><u>This line of text will render as underlined.</u></div>
-          <div><small>This line of text is meant to be treated as fine print.</small></div>
-          <div>The following snippet of text is <strong>rendered as bold text.</strong></div>
-          <div>The following snippet of text is <em>rendered as italicized text.</em></div>
-          <div>The following snippet of text show useful keyboard shortcut: <kbd>⌘</kbd> + <kbd>C</kbd> or <kbd>ctrl</kbd> + <kbd>C</kbd>.</div>
-        </div>
-
-        <div class="col-md-4 prose">
-          <h3>Text color</h3>
-          <div class="text-primary">This is an example of primary text.</div>
-          <div class="text-secondary">This is an example of secondary text.</div>
-          <div class="text-body">This is an example of body text.</div>
-          <div class="text-success">This is an example of success text.</div>
-          <div class="text-info">This is an example of info text.</div>
-          <div class="text-warning">This is an example of warning text.</div>
-          <div class="text-danger">This is an example of danger text.</div>
-          <div class="text-pink">This is an example of pink text.</div>
-        </div>
-
-        <div class="col-md-4 prose">
-          <h3>Addresses</h3>
-          <address>
-            <strong>Twitter, Inc. <br /> </strong>1355 Market Street, Suite 900 <br />
-            San Francisco, CA 94103 <br /><abbr title="Phone">P: </abbr>(123) 456 7890
-          </address>
-          <address><strong>Full name <br /></strong><a href="mailto:#">first.last@example.com</a></address>
-        </div>
-
-        <div class="col-md-4 prose">
-          <h3>Typography</h3>
-
-          <div>
-            {
-              [1, 2, 3, 4, 5, 6].map((i) => {
-                const Heading = `h${i}` as keyof HTMLElementTagNameMap
-                return <Heading>H{i} Lorem ipsum dolor sit amet</Heading>
-              })
-            }
-          </div>
+            <address>
+              <strong>Written by the Tabler team <br /></strong>
+              <a href="mailto:#">hello@example.com</a>
+            </address>
+          </Prose>
         </div>
       </div>
     </div>

--- a/preview/pages/typography.astro
+++ b/preview/pages/typography.astro
@@ -26,6 +26,13 @@ import DocsLink from '@ui/DocsLink.astro'
             <h1>Brewing better coffee at home</h1>
             <p class="lead">Good coffee isn't about expensive gear — it's about <mark>consistency</mark>. Get the ratio, the grind, and the water temperature right, and almost any method will taste better.</p>
 
+            <figure>
+              <img src="/static/photos/cup-of-coffee-and-an-open-book.jpg" alt="A cup of coffee next to an open book" />
+              <figcaption class="text-secondary small mt-2">Ten minutes of prep, and the rest of the morning is yours.</figcaption>
+            </figure>
+
+            <p>As <cite>The Professional Barista's Handbook</cite> puts it, most bad coffee isn't a bad bean — it's an inconsistent process.</p>
+
             <blockquote class="blockquote">
               <p>Coffee is a language in itself.</p>
               <footer class="blockquote-footer">Jackie Chan</footer>
@@ -58,6 +65,18 @@ import DocsLink from '@ui/DocsLink.astro'
               A cup that's too weak usually means too little coffee, not too little time. Coffee contains caffeine (<abbr title="Chemical formula">C<sub>8</sub>H<sub>10</sub>N<sub>4</sub>O<sub>2</sub></abbr>), and how much of it — and everything else — ends up in your cup comes down to the <code>coffee:water</code> ratio above almost anything else.
             </p>
 
+            <hr />
+
+            <h3>A few terms worth knowing</h3>
+            <dl>
+              <dt>Bloom</dt>
+              <dd>The first splash of water, which releases trapped CO&#8322; and lets the rest of the pour extract evenly.</dd>
+              <dt>Extraction</dt>
+              <dd>How much flavor the water pulls from the grounds — too little tastes sour, too much tastes bitter.</dd>
+              <dt>TDS</dt>
+              <dd>Total dissolved solids: a measure of strength, independent of how much water you used.</dd>
+            </dl>
+
             <h4>A quick note on freshness</h4>
             <p>Beans are at their best one to four weeks after roasting. <u>Buy smaller bags more often</u> rather than stockpiling — coffee doesn't go bad, it just goes flat.</p>
 
@@ -88,6 +107,27 @@ import DocsLink from '@ui/DocsLink.astro'
                 </tr>
               </tbody>
             </table>
+
+            <h5>Roast levels at a glance</h5>
+            <ul class="list-unstyled">
+              <li class="text-warning">Light — bright, acidic, tastes like the origin</li>
+              <li class="text-primary">Medium — balanced, the everyday default</li>
+              <li class="text-secondary">Medium-dark — fuller body, less acidity</li>
+              <li class="text-danger">Dark — bold and smoky, roast flavor dominates</li>
+            </ul>
+
+            <h5>Reading your cup</h5>
+            <p>Taste it before you change anything else — the cup itself tells you what to adjust:</p>
+            <ul class="list-unstyled">
+              <li class="text-success">Balanced — this is the one to repeat next time.</li>
+              <li class="text-info">Thin or sour — grind a little finer, or pour more slowly.</li>
+              <li class="text-pink">A standout — jot down the bag and roast date while you remember.</li>
+              <li class="text-body">Still figuring out your taste — that's normal, brew a few more before settling on a ratio.</li>
+            </ul>
+
+            <h5>A minimal brew config</h5>
+            <p>If you're automating a scale or a smart kettle, the whole recipe above reduces to a few numbers:</p>
+            <pre><code>{`coffee: 18g\nwater: 300g\ntemperature: 96C\nbloom: 30s\ntotal_time: 3m30s`}</code></pre>
 
             <h6>Fine print</h6>
             <p><small class="text-secondary">Ratios are a starting point, not a rule — adjust to taste once you've got the basics down.</small></p>

--- a/preview/pages/typography.astro
+++ b/preview/pages/typography.astro
@@ -6,18 +6,6 @@ import DocsLink from '@ui/DocsLink.astro'
 
 <DefaultLayout title="Typography" pageMenu="base.typography">
   <DocsLink slot="page-header-actions" path="/ui/base/typography" />
-  <div class="card card-lg">
-    <div class="card-body">
-      <div class="row g-4">
-        <div class="col-12 prose">
-          <h1>1/1 Text</h1>
-          <p>
-            I'm not a witch. Now, look here, my good man. Oh! Come and see the violence inherent in the system! Help, help, I'm being repressed! Well, I didn't vote for you. You can't expect to wield supreme power just 'cause some watery tart threw a sword at you! Bring her forward! He hasn't got shit all over him. He
-            hasn't got shit all over him. We shall say 'Ni' again to you, if you do not appease us.
-          </p>
-          <p>Well, we did do the nose. Why? Now, look here, my good man. Be quiet! Well, what do you want?</p>
-        </div>
-
   <div class="row justify-content-center">
     <div class="col-lg-9 col-xl-8">
       <div class="card card-lg">

--- a/preview/pages/typography.astro
+++ b/preview/pages/typography.astro
@@ -62,7 +62,8 @@ import DocsLink from '@ui/DocsLink.astro'
 
             <h3>Why the ratio matters</h3>
             <p>
-              A cup that's too weak usually means too little coffee, not too little time. Coffee contains caffeine (<abbr title="Chemical formula">C<sub>8</sub>H<sub>10</sub>N<sub>4</sub>O<sub>2</sub></abbr>), and how much of it — and everything else — ends up in your cup comes down to the <code>coffee:water</code> ratio above almost anything else.
+              A cup that's too weak usually means too little coffee, not too little time. Coffee contains caffeine (<abbr title="Chemical formula">C<sub>8</sub>H<sub>10</sub>N<sub>4</sub>O<sub>2</sub></abbr>), and how much of it — and everything else — ends up in your cup comes down to the <code>coffee:water</code> ratio
+              above almost anything else.
             </p>
 
             <hr />

--- a/preview/pages/wysiwyg.astro
+++ b/preview/pages/wysiwyg.astro
@@ -2,6 +2,8 @@
 import DefaultLayout from '@shared/layouts/DefaultLayout.astro'
 import Card from '@ui/Card.astro'
 import CardBody from '@ui/CardBody.astro'
+import CardTitle from '@ui/CardTitle.astro'
+import CardSubtitle from '@ui/CardSubtitle.astro'
 import Wysiwyg from '@ui/Wysiwyg.astro'
 import FormGroup from '@ui/FormGroup.astro'
 import DocsLink from '@ui/DocsLink.astro'
@@ -11,6 +13,8 @@ import DocsLink from '@ui/DocsLink.astro'
   <DocsLink slot="page-header-actions" path="/ui/components/wysiwyg" />
   <Card>
     <CardBody>
+      <CardTitle>Rich text editor</CardTitle>
+      <CardSubtitle>A formatting toolbar for headings, lists, and links, dropped into a normal form field.</CardSubtitle>
       <FormGroup label="Your name" for="wysiwyg-name">
         <input type="text" class="form-control" id="wysiwyg-name" placeholder="Name" />
       </FormGroup>


### PR DESCRIPTION
## Summary

- Reworked the `Cards` and `Typography` demo pages: Cards is now grouped into 12 labeled sections (headers, hover effects, images, footers, etc.), and Typography is now a single fake article ("Brewing better coffee at home") that shows headings, lists, a blockquote, a table, colored text, and other text styles used together in real content, instead of unrelated lorem ipsum blocks.
- Added a short description (`CardSubtitle`) under the title of each example on `progress`, `tables`, `form-layout`, `card-actions`, `colorpicker`, `datatables`, `patterns`, `dropzone`, `sortable`, and `payment-providers`, so it's clear what each variant is for.
- Added a `Docs` link in the page header on pages that were missing one, pointing to the matching documentation page.

## Preview

- **URL:** [tabler-git-better-preview-pages-tabler-io.vercel.app](https://tabler-git-better-preview-pages-tabler-io.vercel.app/)
- **How to test:** I'm attaching before/after screenshots for `/typography.html` and `/cards.html` — these two got the biggest rework, so the screenshots are the fastest way to review them. The other pages only got small additions (a description line and/or a Docs link), so a quick look at the diff is enough: `/progress.html`, `/tables.html`, `/form-layout.html`, `/card-actions.html`, `/colorpicker.html`, `/datatables.html`, `/patterns.html`, `/dropzone.html`, `/sortable.html`, `/payment-providers.html`.
<img width="2580" height="5417" alt="cards-before-after" src="https://github.com/user-attachments/assets/bf8ddae2-fe92-43d3-8d44-8079dd075e90" />
<img width="2580" height="3459" alt="typography-before-after" src="https://github.com/user-attachments/assets/6afde89e-21ca-4b49-b5a3-4a12d6927aac" />
