### PR TITLE
Trim changeset changelogs: drop dependency noise and private packages

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,0 +1,28 @@
+/**
+ * Changelog generator for Tabler.
+ *
+ * Same as `@changesets/cli/changelog`, except it drops the
+ * "Updated dependencies [...]" block. `@tabler/core`, `@tabler/preview` and
+ * `@tabler/docs` are a linked group, so they always share one version number —
+ * listing every core changeset commit in the preview and docs changelogs added
+ * a hundred lines that said nothing the version number does not already say.
+ */
+
+const getReleaseLine = async (changeset) => {
+  const [firstLine, ...futureLines] = changeset.summary.split('\n').map((line) => line.trimEnd())
+
+  let releaseLine = `- ${changeset.commit ? `${changeset.commit.slice(0, 7)}: ` : ''}${firstLine}`
+
+  if (futureLines.length > 0) {
+    releaseLine += `\n${futureLines.map((line) => `  ${line}`).join('\n')}`
+  }
+
+  return releaseLine
+}
+
+const getDependencyReleaseLine = async () => ''
+
+module.exports = {
+  getReleaseLine,
+  getDependencyReleaseLine,
+}

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "./changelog.cjs",
   "commit": false,
   "fixed": [],
   "linked": [
@@ -12,7 +12,10 @@
   ],
   "access": "public",
   "baseBranch": "dev",
-  "ignore": [],
+  "ignore": [
+    "@tabler/shared",
+    "@tabler/screenshots"
+  ],
   "privatePackages": {
     "version": true,
     "tag": false

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "shx": "^0.4.0"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.1",
     "@stylistic/stylelint-config": "^2.0.0",
     "adm-zip": "^0.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
     devDependencies:
-      '@changesets/changelog-github':
-        specifier: ^0.7.0
-        version: 0.7.0
       '@changesets/cli':
         specifier: ^2.31.1
         version: 2.31.1(@types/node@26.1.1)
@@ -688,9 +685,6 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/changelog-github@0.7.0':
-    resolution: {integrity: sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==}
-
   '@changesets/cli@2.31.1':
     resolution: {integrity: sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==}
     hasBin: true
@@ -703,9 +697,6 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.4':
     resolution: {integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==}
-
-  '@changesets/get-github-info@0.8.0':
-    resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
 
   '@changesets/get-release-plan@4.0.16':
     resolution: {integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==}
@@ -2636,9 +2627,6 @@ packages:
   custom-event-polyfill@1.0.7:
     resolution: {integrity: sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==}
 
-  dataloader@1.4.0:
-    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2709,10 +2697,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
-    engines: {node: '>=10'}
 
   driver.js@1.8.0:
     resolution: {integrity: sha512-+8/IO7h1v14IzWh2GP60N7T3PFZweXwdn5e5POuxRSBoCYUojsBxzqawPeXh3YZIibRy7EehYNEyxe7slwwtdg==}
@@ -5778,14 +5762,6 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/changelog-github@0.7.0':
-    dependencies:
-      '@changesets/get-github-info': 0.8.0
-      '@changesets/types': 6.1.0
-      dotenv: 8.6.0
-    transitivePeerDependencies:
-      - encoding
-
   '@changesets/cli@2.31.1(@types/node@26.1.1)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
@@ -5838,13 +5814,6 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.8.5
-
-  '@changesets/get-github-info@0.8.0':
-    dependencies:
-      dataloader: 1.4.0
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
 
   '@changesets/get-release-plan@4.0.16':
     dependencies:
@@ -7641,8 +7610,6 @@ snapshots:
 
   custom-event-polyfill@1.0.7: {}
 
-  dataloader@1.4.0: {}
-
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
@@ -7706,8 +7673,6 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-
-  dotenv@8.6.0: {}
 
   driver.js@1.8.0: {}
 


### PR DESCRIPTION
## Summary

- The default changeset changelog writes one `- Updated dependencies [hash]` line **per changeset**, not one per bump. With ~90 core changesets in the 1.5.0 release, the `@tabler/preview` and `@tabler/docs` changelogs each grew ~90 lines that only said `@tabler/core@1.5.0`. A new `.changeset/changelog.cjs` reuses the default release line and returns an empty dependency line, so the block is gone. The three packages are a `linked` group and always share one version number, so nothing is lost.
- `@tabler/shared` and `@tabler/screenshots` are private helper packages that are never published, but `changeset version` still generated a `CHANGELOG.md` and bumped their version. They are now in the `ignore` list.
- Removed `@changesets/changelog-github`. It was in `devDependencies` but nothing used it — the config always pointed at the default generator.

## How to review

- Read `.changeset/changelog.cjs` and the `.changeset/config.json` diff. `getReleaseLine` is inlined (about 10 lines) so the file needs no new dependency.
- Verified by running `changeset version` on a scratch tree: `docs/CHANGELOG.md` went from ~130 lines to 41, no `Updated dependencies` entries, and `shared` / `screenshots` got no changelog and stayed at `0.0.1`.

## Notes / rollout

- No changeset is included: this only touches release tooling in the repo root, not `core/`, `preview/` or `docs/`.
- `ignore` is safe here — changesets only errors when a released package depends on an ignored one, and nothing lists `@tabler/shared` or `@tabler/screenshots` in `dependencies` (`shared` is imported through the `@shared` vite alias).