### PR TITLE
Add SRI `integrity` hashes to CDN snippets in docs

### DIFF
--- a/.changeset/cdn-sri-hashes.md
+++ b/.changeset/cdn-sri-hashes.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": minor
+---
+
+Added `integrity` and `crossorigin` to the CDN snippets in `CdnImportPackage` and `CdnImportPlugin`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history, so the SRI commit below can be pushed back to dev
 
       - name: Install PNPM
         uses: pnpm/action-setup@v6
@@ -39,6 +41,7 @@ jobs:
         run: pnpm run build
 
       - name: Create release Pull Request or publish to NPM
+        id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm run version
@@ -49,3 +52,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # The docs pin their CDN snippets to the files the CDN serves, so the hashes can only be
+      # taken once the release is on npm. `--wait` polls jsDelivr until it picks the version up.
+      - name: Update SRI hashes
+        if: steps.changesets.outputs.published == 'true'
+        run: pnpm --filter @tabler/core run generate-sri --wait
+
+      - name: Commit SRI hashes
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          if git diff --quiet -- shared/data/sri.json; then
+            echo "shared/data/sri.json is already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add shared/data/sri.json
+          git commit -m "chore: update SRI hashes [skip ci]"
+          git pull --rebase --autostash origin dev
+          git push origin HEAD:dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,8 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # core/dist here is the build that was just published, so hashing it pins the docs to the
-      # exact files the CDN will serve — no waiting for npm and jsDelivr to catch up.
+      # core/dist here is the build changesets just published, so hashing it pins the docs to the
+      # exact files users will load from the CDN.
       - name: Update SRI hashes
         if: steps.changesets.outputs.published == 'true'
         run: pnpm --filter @tabler/core run generate-sri

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,11 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # The docs pin their CDN snippets to the files the CDN serves, so the hashes can only be
-      # taken once the release is on npm. `--wait` polls jsDelivr until it picks the version up.
+      # core/dist here is the build that was just published, so hashing it pins the docs to the
+      # exact files the CDN will serve — no waiting for npm and jsDelivr to catch up.
       - name: Update SRI hashes
         if: steps.changesets.outputs.published == 'true'
-        run: pnpm --filter @tabler/core run generate-sri --wait
+        run: pnpm --filter @tabler/core run generate-sri
 
       - name: Commit SRI hashes
         if: steps.changesets.outputs.published == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,11 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # core/dist here is the build changesets just published, so hashing it pins the docs to the
-      # exact files users will load from the CDN.
+      # exact files users will load from the CDN. Called directly, with no package.json script
+      # behind it, so there is nothing to run by accident mid-cycle.
       - name: Update SRI hashes
         if: steps.changesets.outputs.published == 'true'
-        run: pnpm --filter @tabler/core run generate-sri
+        run: pnpm exec tsx core/.build/generate-sri.ts
 
       - name: Commit SRI hashes
         if: steps.changesets.outputs.published == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ package-lock.json
 dist/
 packages-zip/
 .env
-sri.json
 
 # TypeScript
 *.tsbuildinfo

--- a/core/.build/generate-sri.ts
+++ b/core/.build/generate-sri.ts
@@ -7,6 +7,9 @@
 //
 // The result is committed to shared/data/sri.json, so a docs build needs no prior core build. The
 // version stored next to the hashes is what the docs check before rendering them.
+//
+// There is deliberately no package.json script for this: .github/workflows/release.yml calls it as
+// `pnpm exec tsx core/.build/generate-sri.ts`, and that release is the only place it belongs.
 import * as crypto from 'node:crypto'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'

--- a/core/.build/generate-sri.ts
+++ b/core/.build/generate-sri.ts
@@ -1,29 +1,25 @@
 // Writes the SRI hashes the docs render into their CDN snippets.
 //
-// The hashes are taken from the files jsDelivr actually serves for the published release, not
-// from the local core/dist: the snippets link to @tabler/core@<version>, while dev is usually
-// ahead of that release, so hashing the local build would ship an `integrity` value the browser
-// rejects — worse for users than no `integrity` at all.
+// Hashes describe the published release the snippets link to (@tabler/core@<version>), so this
+// only runs at release time: the release workflow builds core, publishes that build to npm, and
+// then hashes the same core/dist it just published. Running it mid-cycle would pin hashes of an
+// unreleased build — an `integrity` value the browser rejects, which is worse for users than no
+// `integrity` at all.
 //
 // The result is committed to shared/data/sri.json, so a docs build needs neither the network nor
-// a prior core build. Run this after publishing a release (`pnpm --filter @tabler/core
-// generate-sri`). Two flags exist for CI: `--check` verifies the committed file still matches the
-// CDN, and `--wait` polls until the just-published release is there, which the release workflow
-// uses right after `changesets publish`.
+// a prior core build. `--check` verifies the committed file against what jsDelivr actually serves,
+// which is the independent way to catch hashes generated at the wrong moment.
 import * as crypto from 'node:crypto'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
-import { setTimeout } from 'node:timers/promises'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const configFile = path.join(__dirname, '../../shared/data/sri.json')
+const distDir = path.join(__dirname, '../dist')
 const { version } = JSON.parse(readFileSync(path.join(__dirname, '../package.json'), 'utf8')) as { version: string }
 const cdnUrl = `https://cdn.jsdelivr.net/npm/@tabler/core@${version}/dist`
-
-const waitAttempts = 10
-const waitDelay = 30_000
 
 interface FileConfig {
   file: string
@@ -113,6 +109,23 @@ const files: FileConfig[] = [
 /** Thrown when the version is not on the CDN yet, which is expected between a bump and a publish. */
 class UnpublishedVersionError extends Error {}
 
+const integrityOf = (data: Buffer): string => `sha384-${crypto.createHash('sha384').update(data).digest('base64')}`
+
+/** Hashes of the local build — the files the release workflow is about to publish, or just did. */
+function hashDist(): Record<string, string> {
+  const entries = files.map(({ file, configPropertyName }) => {
+    const filePath = path.join(distDir, file)
+
+    if (!existsSync(filePath)) {
+      throw new Error(`${filePath} is missing. Run \`pnpm --filter @tabler/core build\` first.`)
+    }
+
+    return [configPropertyName, integrityOf(readFileSync(filePath))] as const
+  })
+
+  return Object.fromEntries(entries)
+}
+
 async function fetchIntegrity(file: string): Promise<string> {
   const response = await fetch(`${cdnUrl}/${file}`)
 
@@ -124,37 +137,14 @@ async function fetchIntegrity(file: string): Promise<string> {
     throw new Error(`${cdnUrl}/${file} returned ${response.status} ${response.statusText}`)
   }
 
-  const hash = crypto
-    .createHash('sha384')
-    .update(Buffer.from(await response.arrayBuffer()))
-    .digest('base64')
-
-  return `sha384-${hash}`
+  return integrityOf(Buffer.from(await response.arrayBuffer()))
 }
 
+/** Hashes of what the CDN serves, used by `--check` to verify the committed file. */
 async function fetchHashes(): Promise<Record<string, string>> {
   const entries = await Promise.all(files.map(async ({ file, configPropertyName }) => [configPropertyName, await fetchIntegrity(file)] as const))
 
   return Object.fromEntries(entries)
-}
-
-/**
- * With `--wait`, keep polling until the release shows up on the CDN. Used right after a publish,
- * where npm and jsDelivr are a few moments behind the workflow that published them.
- */
-async function fetchHashesWaiting(): Promise<Record<string, string>> {
-  for (let attempt = 1; attempt <= waitAttempts; attempt++) {
-    try {
-      return await fetchHashes()
-    } catch (error) {
-      if (!(error instanceof UnpublishedVersionError) || attempt === waitAttempts) throw error
-
-      console.log(`@tabler/core@${version} is not on the CDN yet — retrying in ${waitDelay / 1000}s (${attempt}/${waitAttempts - 1})`)
-      await setTimeout(waitDelay)
-    }
-  }
-
-  throw new UnpublishedVersionError(`@tabler/core@${version} did not appear on the CDN`)
 }
 
 function readConfig(): SriData | null {
@@ -163,16 +153,16 @@ function readConfig(): SriData | null {
   return JSON.parse(readFileSync(configFile, 'utf8')) as SriData
 }
 
-async function generateSRI(check: boolean, wait: boolean): Promise<void> {
-  let hashes: Record<string, string>
+async function check(): Promise<void> {
+  let published: Record<string, string>
 
   try {
-    hashes = wait ? await fetchHashesWaiting() : await fetchHashes()
+    published = await fetchHashes()
   } catch (error) {
-    if (error instanceof UnpublishedVersionError && !wait) {
-      // Nothing to pin yet. The docs render their snippets without `integrity` until the release
-      // is on npm and this script is run again.
-      console.warn(`@tabler/core@${version} is not published yet — shared/data/sri.json left unchanged.`)
+    if (error instanceof UnpublishedVersionError) {
+      // Between a version bump and the publish there is nothing to compare against. The docs
+      // render their snippets without `integrity` in that window, which is safe.
+      console.warn(`@tabler/core@${version} is not published yet — nothing to check.`)
       return
     }
 
@@ -180,17 +170,17 @@ async function generateSRI(check: boolean, wait: boolean): Promise<void> {
   }
 
   const current = readConfig()
+  const matches = current?.version === version && files.every(({ configPropertyName }) => current?.hashes[configPropertyName] === published[configPropertyName])
 
-  if (check) {
-    const matches = current?.version === version && files.every(({ configPropertyName }) => current?.hashes[configPropertyName] === hashes[configPropertyName])
-
-    if (!matches) {
-      throw new Error(`shared/data/sri.json does not match what the CDN serves for @tabler/core@${version}. Run \`pnpm --filter @tabler/core generate-sri\`.`)
-    }
-
-    console.log(`shared/data/sri.json matches @tabler/core@${version}.`)
-    return
+  if (!matches) {
+    throw new Error(`shared/data/sri.json does not match what the CDN serves for @tabler/core@${version}. It was generated from a build that was never published.`)
   }
+
+  console.log(`shared/data/sri.json matches @tabler/core@${version}.`)
+}
+
+function generate(): void {
+  const hashes = hashDist()
 
   for (const { configPropertyName } of files) {
     console.log(`${configPropertyName}: ${hashes[configPropertyName]}`)
@@ -199,7 +189,9 @@ async function generateSRI(check: boolean, wait: boolean): Promise<void> {
   writeFileSync(configFile, JSON.stringify({ version, hashes } satisfies SriData, null, 2) + '\n', 'utf8')
 }
 
-generateSRI(process.argv.includes('--check'), process.argv.includes('--wait')).catch((error: unknown) => {
+const run = process.argv.includes('--check') ? check() : Promise.resolve(generate())
+
+run.catch((error: unknown) => {
   console.error('Failed to generate SRI:', error)
   process.exit(1)
 })

--- a/core/.build/generate-sri.ts
+++ b/core/.build/generate-sri.ts
@@ -7,10 +7,13 @@
 //
 // The result is committed to shared/data/sri.json, so a docs build needs neither the network nor
 // a prior core build. Run this after publishing a release (`pnpm --filter @tabler/core
-// generate-sri`), or with `--check` to verify the committed file still matches the CDN.
+// generate-sri`). Two flags exist for CI: `--check` verifies the committed file still matches the
+// CDN, and `--wait` polls until the just-published release is there, which the release workflow
+// uses right after `changesets publish`.
 import * as crypto from 'node:crypto'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
+import { setTimeout } from 'node:timers/promises'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -18,6 +21,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const configFile = path.join(__dirname, '../../shared/data/sri.json')
 const { version } = JSON.parse(readFileSync(path.join(__dirname, '../package.json'), 'utf8')) as { version: string }
 const cdnUrl = `https://cdn.jsdelivr.net/npm/@tabler/core@${version}/dist`
+
+const waitAttempts = 10
+const waitDelay = 30_000
 
 interface FileConfig {
   file: string
@@ -132,19 +138,38 @@ async function fetchHashes(): Promise<Record<string, string>> {
   return Object.fromEntries(entries)
 }
 
+/**
+ * With `--wait`, keep polling until the release shows up on the CDN. Used right after a publish,
+ * where npm and jsDelivr are a few moments behind the workflow that published them.
+ */
+async function fetchHashesWaiting(): Promise<Record<string, string>> {
+  for (let attempt = 1; attempt <= waitAttempts; attempt++) {
+    try {
+      return await fetchHashes()
+    } catch (error) {
+      if (!(error instanceof UnpublishedVersionError) || attempt === waitAttempts) throw error
+
+      console.log(`@tabler/core@${version} is not on the CDN yet — retrying in ${waitDelay / 1000}s (${attempt}/${waitAttempts - 1})`)
+      await setTimeout(waitDelay)
+    }
+  }
+
+  throw new UnpublishedVersionError(`@tabler/core@${version} did not appear on the CDN`)
+}
+
 function readConfig(): SriData | null {
   if (!existsSync(configFile)) return null
 
   return JSON.parse(readFileSync(configFile, 'utf8')) as SriData
 }
 
-async function generateSRI(check: boolean): Promise<void> {
+async function generateSRI(check: boolean, wait: boolean): Promise<void> {
   let hashes: Record<string, string>
 
   try {
-    hashes = await fetchHashes()
+    hashes = wait ? await fetchHashesWaiting() : await fetchHashes()
   } catch (error) {
-    if (error instanceof UnpublishedVersionError) {
+    if (error instanceof UnpublishedVersionError && !wait) {
       // Nothing to pin yet. The docs render their snippets without `integrity` until the release
       // is on npm and this script is run again.
       console.warn(`@tabler/core@${version} is not published yet — shared/data/sri.json left unchanged.`)
@@ -174,7 +199,7 @@ async function generateSRI(check: boolean): Promise<void> {
   writeFileSync(configFile, JSON.stringify({ version, hashes } satisfies SriData, null, 2) + '\n', 'utf8')
 }
 
-generateSRI(process.argv.includes('--check')).catch((error: unknown) => {
+generateSRI(process.argv.includes('--check'), process.argv.includes('--wait')).catch((error: unknown) => {
   console.error('Failed to generate SRI:', error)
   process.exit(1)
 })

--- a/core/.build/generate-sri.ts
+++ b/core/.build/generate-sri.ts
@@ -1,14 +1,12 @@
 // Writes the SRI hashes the docs render into their CDN snippets.
 //
-// Hashes describe the published release the snippets link to (@tabler/core@<version>), so this
-// only runs at release time: the release workflow builds core, publishes that build to npm, and
-// then hashes the same core/dist it just published. Running it mid-cycle would pin hashes of an
-// unreleased build — an `integrity` value the browser rejects, which is worse for users than no
-// `integrity` at all.
+// Hashes describe the release the snippets link to (@tabler/core@<version>), so this only runs at
+// release time: the release workflow builds core, publishes that build to npm, and then hashes the
+// same core/dist it just published. Running it mid-cycle would pin hashes of an unreleased build —
+// an `integrity` value the browser rejects, which is worse for users than no `integrity` at all.
 //
-// The result is committed to shared/data/sri.json, so a docs build needs neither the network nor
-// a prior core build. `--check` verifies the committed file against what jsDelivr actually serves,
-// which is the independent way to catch hashes generated at the wrong moment.
+// The result is committed to shared/data/sri.json, so a docs build needs no prior core build. The
+// version stored next to the hashes is what the docs check before rendering them.
 import * as crypto from 'node:crypto'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
@@ -19,7 +17,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const configFile = path.join(__dirname, '../../shared/data/sri.json')
 const distDir = path.join(__dirname, '../dist')
 const { version } = JSON.parse(readFileSync(path.join(__dirname, '../package.json'), 'utf8')) as { version: string }
-const cdnUrl = `https://cdn.jsdelivr.net/npm/@tabler/core@${version}/dist`
 
 interface FileConfig {
   file: string
@@ -106,92 +103,29 @@ const files: FileConfig[] = [
   },
 ]
 
-/** Thrown when the version is not on the CDN yet, which is expected between a bump and a publish. */
-class UnpublishedVersionError extends Error {}
+function generateSRI(): void {
+  const hashes: Record<string, string> = {}
 
-const integrityOf = (data: Buffer): string => `sha384-${crypto.createHash('sha384').update(data).digest('base64')}`
-
-/** Hashes of the local build — the files the release workflow is about to publish, or just did. */
-function hashDist(): Record<string, string> {
-  const entries = files.map(({ file, configPropertyName }) => {
+  for (const { file, configPropertyName } of files) {
     const filePath = path.join(distDir, file)
 
     if (!existsSync(filePath)) {
       throw new Error(`${filePath} is missing. Run \`pnpm --filter @tabler/core build\` first.`)
     }
 
-    return [configPropertyName, integrityOf(readFileSync(filePath))] as const
-  })
+    const integrity = `sha384-${crypto.createHash('sha384').update(readFileSync(filePath)).digest('base64')}`
 
-  return Object.fromEntries(entries)
-}
+    console.log(`${configPropertyName}: ${integrity}`)
 
-async function fetchIntegrity(file: string): Promise<string> {
-  const response = await fetch(`${cdnUrl}/${file}`)
-
-  if (response.status === 404) {
-    throw new UnpublishedVersionError(`${cdnUrl}/${file} returned 404`)
-  }
-
-  if (!response.ok) {
-    throw new Error(`${cdnUrl}/${file} returned ${response.status} ${response.statusText}`)
-  }
-
-  return integrityOf(Buffer.from(await response.arrayBuffer()))
-}
-
-/** Hashes of what the CDN serves, used by `--check` to verify the committed file. */
-async function fetchHashes(): Promise<Record<string, string>> {
-  const entries = await Promise.all(files.map(async ({ file, configPropertyName }) => [configPropertyName, await fetchIntegrity(file)] as const))
-
-  return Object.fromEntries(entries)
-}
-
-function readConfig(): SriData | null {
-  if (!existsSync(configFile)) return null
-
-  return JSON.parse(readFileSync(configFile, 'utf8')) as SriData
-}
-
-async function check(): Promise<void> {
-  let published: Record<string, string>
-
-  try {
-    published = await fetchHashes()
-  } catch (error) {
-    if (error instanceof UnpublishedVersionError) {
-      // Between a version bump and the publish there is nothing to compare against. The docs
-      // render their snippets without `integrity` in that window, which is safe.
-      console.warn(`@tabler/core@${version} is not published yet — nothing to check.`)
-      return
-    }
-
-    throw error
-  }
-
-  const current = readConfig()
-  const matches = current?.version === version && files.every(({ configPropertyName }) => current?.hashes[configPropertyName] === published[configPropertyName])
-
-  if (!matches) {
-    throw new Error(`shared/data/sri.json does not match what the CDN serves for @tabler/core@${version}. It was generated from a build that was never published.`)
-  }
-
-  console.log(`shared/data/sri.json matches @tabler/core@${version}.`)
-}
-
-function generate(): void {
-  const hashes = hashDist()
-
-  for (const { configPropertyName } of files) {
-    console.log(`${configPropertyName}: ${hashes[configPropertyName]}`)
+    hashes[configPropertyName] = integrity
   }
 
   writeFileSync(configFile, JSON.stringify({ version, hashes } satisfies SriData, null, 2) + '\n', 'utf8')
 }
 
-const run = process.argv.includes('--check') ? check() : Promise.resolve(generate())
-
-run.catch((error: unknown) => {
+try {
+  generateSRI()
+} catch (error) {
   console.error('Failed to generate SRI:', error)
   process.exit(1)
-})
+}

--- a/core/.build/generate-sri.ts
+++ b/core/.build/generate-sri.ts
@@ -1,120 +1,180 @@
+// Writes the SRI hashes the docs render into their CDN snippets.
+//
+// The hashes are taken from the files jsDelivr actually serves for the published release, not
+// from the local core/dist: the snippets link to @tabler/core@<version>, while dev is usually
+// ahead of that release, so hashing the local build would ship an `integrity` value the browser
+// rejects — worse for users than no `integrity` at all.
+//
+// The result is committed to shared/data/sri.json, so a docs build needs neither the network nor
+// a prior core build. Run this after publishing a release (`pnpm --filter @tabler/core
+// generate-sri`), or with `--check` to verify the committed file still matches the CDN.
 import * as crypto from 'node:crypto'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const configFile = path.join(__dirname, '../../shared/data/sri.json')
+const { version } = JSON.parse(readFileSync(path.join(__dirname, '../package.json'), 'utf8')) as { version: string }
+const cdnUrl = `https://cdn.jsdelivr.net/npm/@tabler/core@${version}/dist`
 
 interface FileConfig {
   file: string
   configPropertyName: string
 }
 
+interface SriData {
+  version: string
+  hashes: Record<string, string>
+}
+
 const files: FileConfig[] = [
   {
-    file: 'dist/css/tabler.min.css',
+    file: 'css/tabler.min.css',
     configPropertyName: 'css',
   },
   {
-    file: 'dist/css/tabler.rtl.min.css',
+    file: 'css/tabler.rtl.min.css',
     configPropertyName: 'css-rtl',
   },
   {
-    file: 'dist/css/tabler-flags.min.css',
+    file: 'css/tabler-flags.min.css',
     configPropertyName: 'css-flags',
   },
   {
-    file: 'dist/css/tabler-flags.rtl.min.css',
+    file: 'css/tabler-flags.rtl.min.css',
     configPropertyName: 'css-flags-rtl',
   },
   {
-    file: 'dist/css/tabler-marketing.min.css',
+    file: 'css/tabler-marketing.min.css',
     configPropertyName: 'css-marketing',
   },
   {
-    file: 'dist/css/tabler-marketing.rtl.min.css',
+    file: 'css/tabler-marketing.rtl.min.css',
     configPropertyName: 'css-marketing-rtl',
   },
   {
-    file: 'dist/css/tabler-payments.min.css',
+    file: 'css/tabler-payments.min.css',
     configPropertyName: 'css-payments',
   },
   {
-    file: 'dist/css/tabler-payments.rtl.min.css',
+    file: 'css/tabler-payments.rtl.min.css',
     configPropertyName: 'css-payments-rtl',
   },
   {
-    file: 'dist/css/tabler-props.min.css',
+    file: 'css/tabler-props.min.css',
     configPropertyName: 'css-props',
   },
   {
-    file: 'dist/css/tabler-props.rtl.min.css',
+    file: 'css/tabler-props.rtl.min.css',
     configPropertyName: 'css-props-rtl',
   },
   {
-    file: 'dist/css/tabler-themes.min.css',
+    file: 'css/tabler-themes.min.css',
     configPropertyName: 'css-themes',
   },
   {
-    file: 'dist/css/tabler-themes.rtl.min.css',
+    file: 'css/tabler-themes.rtl.min.css',
     configPropertyName: 'css-themes-rtl',
   },
   {
-    file: 'dist/css/tabler-socials.min.css',
+    file: 'css/tabler-socials.min.css',
     configPropertyName: 'css-socials',
   },
   {
-    file: 'dist/css/tabler-socials.rtl.min.css',
+    file: 'css/tabler-socials.rtl.min.css',
     configPropertyName: 'css-socials-rtl',
   },
   {
-    file: 'dist/css/tabler-vendors.min.css',
+    file: 'css/tabler-vendors.min.css',
     configPropertyName: 'css-vendors',
   },
   {
-    file: 'dist/css/tabler-vendors.rtl.min.css',
+    file: 'css/tabler-vendors.rtl.min.css',
     configPropertyName: 'css-vendors-rtl',
   },
   {
-    file: 'dist/js/tabler.min.js',
+    file: 'js/tabler.min.js',
     configPropertyName: 'js',
   },
   {
-    file: 'dist/js/tabler-theme.min.js',
+    file: 'js/tabler-theme.min.js',
     configPropertyName: 'js-theme',
   },
 ]
 
-function generateSRI(): void {
-  const sriData: Record<string, string> = {}
+/** Thrown when the version is not on the CDN yet, which is expected between a bump and a publish. */
+class UnpublishedVersionError extends Error {}
 
-  for (const { file, configPropertyName } of files) {
-    try {
-      const filePath = path.join(__dirname, '..', file)
-      const data = readFileSync(filePath, 'utf8')
+async function fetchIntegrity(file: string): Promise<string> {
+  const response = await fetch(`${cdnUrl}/${file}`)
 
-      const algorithm = 'sha384'
-      const hash = crypto.createHash(algorithm).update(data, 'utf8').digest('base64')
-      const integrity = `${algorithm}-${hash}`
-
-      console.log(`${configPropertyName}: ${integrity}`)
-
-      sriData[configPropertyName] = integrity
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      console.error(`Error processing ${file}:`, errorMessage)
-      throw error
-    }
+  if (response.status === 404) {
+    throw new UnpublishedVersionError(`${cdnUrl}/${file} returned 404`)
   }
 
-  writeFileSync(configFile, JSON.stringify(sriData, null, 2) + '\n', 'utf8')
+  if (!response.ok) {
+    throw new Error(`${cdnUrl}/${file} returned ${response.status} ${response.statusText}`)
+  }
+
+  const hash = crypto
+    .createHash('sha384')
+    .update(Buffer.from(await response.arrayBuffer()))
+    .digest('base64')
+
+  return `sha384-${hash}`
 }
 
-try {
-  generateSRI()
-} catch (error) {
+async function fetchHashes(): Promise<Record<string, string>> {
+  const entries = await Promise.all(files.map(async ({ file, configPropertyName }) => [configPropertyName, await fetchIntegrity(file)] as const))
+
+  return Object.fromEntries(entries)
+}
+
+function readConfig(): SriData | null {
+  if (!existsSync(configFile)) return null
+
+  return JSON.parse(readFileSync(configFile, 'utf8')) as SriData
+}
+
+async function generateSRI(check: boolean): Promise<void> {
+  let hashes: Record<string, string>
+
+  try {
+    hashes = await fetchHashes()
+  } catch (error) {
+    if (error instanceof UnpublishedVersionError) {
+      // Nothing to pin yet. The docs render their snippets without `integrity` until the release
+      // is on npm and this script is run again.
+      console.warn(`@tabler/core@${version} is not published yet — shared/data/sri.json left unchanged.`)
+      return
+    }
+
+    throw error
+  }
+
+  const current = readConfig()
+
+  if (check) {
+    const matches = current?.version === version && files.every(({ configPropertyName }) => current?.hashes[configPropertyName] === hashes[configPropertyName])
+
+    if (!matches) {
+      throw new Error(`shared/data/sri.json does not match what the CDN serves for @tabler/core@${version}. Run \`pnpm --filter @tabler/core generate-sri\`.`)
+    }
+
+    console.log(`shared/data/sri.json matches @tabler/core@${version}.`)
+    return
+  }
+
+  for (const { configPropertyName } of files) {
+    console.log(`${configPropertyName}: ${hashes[configPropertyName]}`)
+  }
+
+  writeFileSync(configFile, JSON.stringify({ version, hashes } satisfies SriData, null, 2) + '\n', 'utf8')
+}
+
+generateSRI(process.argv.includes('--check')).catch((error: unknown) => {
   console.error('Failed to generate SRI:', error)
   process.exit(1)
-}
+})

--- a/core/package.json
+++ b/core/package.json
@@ -31,7 +31,6 @@
     "watch-css": "nodemon --watch scss/ --ext scss --exec \"pnpm run css-build\"",
     "watch-js": "nodemon --watch js/ --ext ts,js --exec \"pnpm run js-build\"",
     "bundlewatch": "bundlewatch",
-    "generate-sri": "tsx .build/generate-sri.ts",
     "type-check": "tsc --noEmit",
     "test": "concurrently \"pnpm run test:js\" \"pnpm run test:scss\"",
     "test:js": "vitest run",

--- a/core/package.json
+++ b/core/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "pnpm run watch",
     "dev-prepare": "pnpm run clean && pnpm run copy && concurrently \"pnpm run css-build\" \"pnpm run js-build\"",
-    "build": "pnpm run clean && pnpm run build-assets && pnpm run copy && pnpm run generate-sri",
+    "build": "pnpm run clean && pnpm run build-assets && pnpm run copy",
     "build-assets": "concurrently \"pnpm run css\" \"pnpm run js\"",
     "clean": "shx rm -rf dist demo",
     "css": "tsx ../.build/build-css.ts scss dist/css --rtl --minify --banner",
@@ -32,6 +32,7 @@
     "watch-js": "nodemon --watch js/ --ext ts,js --exec \"pnpm run js-build\"",
     "bundlewatch": "bundlewatch",
     "generate-sri": "tsx .build/generate-sri.ts",
+    "generate-sri:check": "tsx .build/generate-sri.ts --check",
     "type-check": "tsc --noEmit",
     "test": "concurrently \"pnpm run test:js\" \"pnpm run test:scss\"",
     "test:js": "vitest run",

--- a/core/package.json
+++ b/core/package.json
@@ -32,7 +32,6 @@
     "watch-js": "nodemon --watch js/ --ext ts,js --exec \"pnpm run js-build\"",
     "bundlewatch": "bundlewatch",
     "generate-sri": "tsx .build/generate-sri.ts",
-    "generate-sri:check": "tsx .build/generate-sri.ts --check",
     "type-check": "tsc --noEmit",
     "test": "concurrently \"pnpm run test:js\" \"pnpm run test:scss\"",
     "test:js": "vitest run",

--- a/docs/components/CdnImportPackage.astro
+++ b/docs/components/CdnImportPackage.astro
@@ -1,11 +1,6 @@
 ---
 import { Code } from 'astro:components'
-import { site } from '@shared/lib/site.ts'
-import { sriAttributes } from '@shared/lib/sri.ts'
+import { cdnPackageSnippet } from '@lib/cdn-snippets.ts'
 ---
 
-<Code
-  lang="html"
-  code={`<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler.min.css"${sriAttributes('css')} />
-<script src="${site.cdnUrl}/dist/js/tabler.min.js"${sriAttributes('js')}></script>`}
-/>
+<Code lang="html" code={cdnPackageSnippet()} />

--- a/docs/components/CdnImportPackage.astro
+++ b/docs/components/CdnImportPackage.astro
@@ -1,10 +1,11 @@
 ---
 import { Code } from 'astro:components'
 import { site } from '@shared/lib/site.ts'
+import { sri } from '@shared/lib/sri.ts'
 ---
 
 <Code
   lang="html"
-  code={`<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler.min.css" />
-<script src="${site.cdnUrl}/dist/js/tabler.min.js"></script>`}
+  code={`<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler.min.css" integrity="${sri['css']}" crossorigin="anonymous" />
+<script src="${site.cdnUrl}/dist/js/tabler.min.js" integrity="${sri['js']}" crossorigin="anonymous"></script>`}
 />

--- a/docs/components/CdnImportPackage.astro
+++ b/docs/components/CdnImportPackage.astro
@@ -1,11 +1,11 @@
 ---
 import { Code } from 'astro:components'
 import { site } from '@shared/lib/site.ts'
-import { sri } from '@shared/lib/sri.ts'
+import { sriAttributes } from '@shared/lib/sri.ts'
 ---
 
 <Code
   lang="html"
-  code={`<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler.min.css" integrity="${sri['css']}" crossorigin="anonymous" />
-<script src="${site.cdnUrl}/dist/js/tabler.min.js" integrity="${sri['js']}" crossorigin="anonymous"></script>`}
+  code={`<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler.min.css"${sriAttributes('css')} />
+<script src="${site.cdnUrl}/dist/js/tabler.min.js"${sriAttributes('js')}></script>`}
 />

--- a/docs/components/CdnImportPlugin.astro
+++ b/docs/components/CdnImportPlugin.astro
@@ -1,6 +1,7 @@
 ---
 import { Code } from 'astro:components'
 import { site } from '@shared/lib/site.ts'
+import { sri } from '@shared/lib/sri.ts'
 
 interface Props {
   plugins: string[]
@@ -13,7 +14,7 @@ const { plugins }: Props = Astro.props
   lang="html"
   code={plugins
     .map((plugin) => {
-      return `<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler-${plugin}.min.css" />`
+      return `<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler-${plugin}.min.css" integrity="${sri[`css-${plugin}`]}" crossorigin="anonymous" />`
     })
     .join('\n')}
 />

--- a/docs/components/CdnImportPlugin.astro
+++ b/docs/components/CdnImportPlugin.astro
@@ -1,7 +1,7 @@
 ---
 import { Code } from 'astro:components'
 import { site } from '@shared/lib/site.ts'
-import { sri } from '@shared/lib/sri.ts'
+import { sriAttributes } from '@shared/lib/sri.ts'
 
 interface Props {
   plugins: string[]
@@ -14,7 +14,7 @@ const { plugins }: Props = Astro.props
   lang="html"
   code={plugins
     .map((plugin) => {
-      return `<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler-${plugin}.min.css" integrity="${sri[`css-${plugin}`]}" crossorigin="anonymous" />`
+      return `<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler-${plugin}.min.css"${sriAttributes(`css-${plugin}`)} />`
     })
     .join('\n')}
 />

--- a/docs/components/CdnImportPlugin.astro
+++ b/docs/components/CdnImportPlugin.astro
@@ -1,7 +1,6 @@
 ---
 import { Code } from 'astro:components'
-import { site } from '@shared/lib/site.ts'
-import { sriAttributes } from '@shared/lib/sri.ts'
+import { cdnPluginSnippet } from '@lib/cdn-snippets.ts'
 
 interface Props {
   plugins: string[]
@@ -10,11 +9,4 @@ interface Props {
 const { plugins }: Props = Astro.props
 ---
 
-<Code
-  lang="html"
-  code={plugins
-    .map((plugin) => {
-      return `<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler-${plugin}.min.css"${sriAttributes(`css-${plugin}`)} />`
-    })
-    .join('\n')}
-/>
+<Code lang="html" code={cdnPluginSnippet(plugins)} />

--- a/docs/content/ui/getting-started/installation.mdx
+++ b/docs/content/ui/getting-started/installation.mdx
@@ -64,7 +64,8 @@ Update your HTML file to include these resources:
 
 This setup includes the Tabler CSS and JavaScript via a CDN, providing a responsive and functional base for your project.
 
-Each CDN snippet includes an `integrity` attribute with a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (SRI) hash and `crossorigin="anonymous"`. The browser verifies the downloaded file against this hash before running it, so the page fails safely instead of loading tampered or corrupted code if the CDN response doesn't match.
+Each CDN snippet includes an `integrity` attribute with a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (SRI) hash and `crossorigin="anonymous"`. The browser verifies the downloaded file against this hash before running it, so the page fails safely instead of
+loading tampered or corrupted code if the CDN response doesn't match.
 
 You can also download the files and include them locally in your project. For more information, see the [Download](/ui/getting-started/download) page.
 

--- a/docs/content/ui/getting-started/installation.mdx
+++ b/docs/content/ui/getting-started/installation.mdx
@@ -64,6 +64,8 @@ Update your HTML file to include these resources:
 
 This setup includes the Tabler CSS and JavaScript via a CDN, providing a responsive and functional base for your project.
 
+Each CDN snippet includes an `integrity` attribute with a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (SRI) hash and `crossorigin="anonymous"`. The browser verifies the downloaded file against this hash before running it, so the page fails safely instead of loading tampered or corrupted code if the CDN response doesn't match.
+
 You can also download the files and include them locally in your project. For more information, see the [Download](/ui/getting-started/download) page.
 
 ### Open in your browser

--- a/docs/content/ui/getting-started/installation.mdx
+++ b/docs/content/ui/getting-started/installation.mdx
@@ -8,7 +8,7 @@ description: 'Set up Tabler: HTML, CSS, JS, and build stunning UIs.'
 import Example from '@components/Example.astro'
 import CdnImportPackage from '@components/CdnImportPackage.astro'
 import { Code } from 'astro:components'
-import { site } from '@shared/lib/site.ts'
+import { cdnCssTag, cdnJsTag } from '@lib/cdn-snippets.ts'
 import Steps from '@components/Steps.astro'
 
 Using a framework? See [Tabler framework integration guides](/ui/getting-started/frameworks).
@@ -53,11 +53,11 @@ Update your HTML file to include these resources:
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Tabler Demo</title>
-    <link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler.min.css" />
+    ${cdnCssTag()}
   </head>
   <body>
     <h1>Hello, Tabler!</h1>
-    <script src="${site.cdnUrl}/dist/js/tabler.min.js"></script>
+    ${cdnJsTag()}
   </body>
 </html>`}
 />

--- a/docs/lib/cdn-snippets.ts
+++ b/docs/lib/cdn-snippets.ts
@@ -1,0 +1,17 @@
+// The CDN snippets the docs hand out, in one place: the page components render them, llms.ts
+// re-renders them into the /llms.txt endpoints, and the installation page drops the two tags into
+// a full HTML example. Building them anywhere else is how one copy silently loses its `integrity`.
+import { site } from '@shared/lib/site.ts'
+import { sriAttributes } from '@shared/lib/sri.ts'
+
+/** `<link>` for the core stylesheet. */
+export const cdnCssTag = (): string => `<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler.min.css"${sriAttributes('css')} />`
+
+/** `<script>` for the core bundle. */
+export const cdnJsTag = (): string => `<script src="${site.cdnUrl}/dist/js/tabler.min.js"${sriAttributes('js')}></script>`
+
+/** Both core tags, as shown by `<CdnImportPackage />`. */
+export const cdnPackageSnippet = (): string => `${cdnCssTag()}\n${cdnJsTag()}`
+
+/** `<link>` per plugin stylesheet, as shown by `<CdnImportPlugin />`. */
+export const cdnPluginSnippet = (plugins: string[]): string => plugins.map((plugin) => `<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler-${plugin}.min.css"${sriAttributes(`css-${plugin}`)} />`).join('\n')

--- a/docs/lib/llms.ts
+++ b/docs/lib/llms.ts
@@ -9,6 +9,7 @@ import type { CollectionEntry } from 'astro:content'
 import { extractMarkedSnippet } from '@shared/lib/code-example'
 import { site } from '@shared/lib/site'
 import packageManagers from '@data/package-managers.json'
+import { cdnCssTag, cdnJsTag, cdnPackageSnippet, cdnPluginSnippet } from './cdn-snippets.ts'
 
 // Lazy raw imports, same as CodeDocs.astro — node:fs paths break once this is
 // bundled into dist/.prerender.
@@ -16,6 +17,20 @@ const scssSources = import.meta.glob('../../core/scss/**/*.scss', { query: '?raw
 const jsSources = import.meta.glob('../../core/js/**/*.{js,ts}', { query: '?raw', import: 'default' })
 
 const fence = (code: string, lang = 'html') => `\`\`\`${lang}\n${code.trim()}\n\`\`\``
+
+/**
+ * `<Code code={`…`} />` blocks are read as source text, never evaluated, so the few interpolations
+ * the docs use inside them are resolved by hand. Anything not listed here is left as written.
+ */
+function resolveCodeTokens(snippet: string): string {
+  const tokens: Record<string, () => string> = {
+    '${site.cdnUrl}': () => site.cdnUrl,
+    '${cdnCssTag()}': cdnCssTag,
+    '${cdnJsTag()}': cdnJsTag,
+  }
+
+  return Object.entries(tokens).reduce((text, [token, resolve]) => text.replaceAll(token, resolve()), snippet)
+}
 
 /** Strip the common leading indentation from a block and trim blank edges. */
 const dedent = (text: string) => {
@@ -101,7 +116,7 @@ export async function mdxToMarkdown(body: string): Promise<string> {
   // would otherwise be mistaken for markdown code spans by protectCode() below.
   let text = body.replace(/<Code\b[^>]*?code=\{`([\s\S]*?)`\}[\s\S]*?\/>/g, (match, snippet: string) => {
     const lang = attr(match, 'lang') ?? 'html'
-    return `\n${fence(snippet.replaceAll('${site.cdnUrl}', site.cdnUrl), lang)}\n`
+    return `\n${fence(resolveCodeTokens(snippet), lang)}\n`
   })
 
   const code: string[] = []
@@ -127,13 +142,12 @@ export async function mdxToMarkdown(body: string): Promise<string> {
     return `\n${fence(commands.join('\n'), 'shell')}\n`
   })
 
-  text = text.replace(/<CdnImportPackage\b[^>]*\/>/g, () => `\n${fence(`<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler.min.css" />\n<script src="${site.cdnUrl}/dist/js/tabler.min.js"></script>`)}\n`)
+  text = text.replace(/<CdnImportPackage\b[^>]*\/>/g, () => `\n${fence(cdnPackageSnippet())}\n`)
 
   text = text.replace(/<CdnImportPlugin\b[^>]*\/>/g, (match: string) => {
-    const plugins = [...match.matchAll(/'([^']+)'/g)].map((plugin) => plugin[1])
+    const plugins = [...match.matchAll(/'([^']+)'/g)].map((plugin) => plugin[1]).filter((plugin): plugin is string => Boolean(plugin))
     if (!plugins.length) return ''
-    const links = plugins.map((plugin) => `<link rel="stylesheet" href="${site.cdnUrl}/dist/css/tabler-${plugin}.min.css" />`)
-    return `\n${fence(links.join('\n'))}\n`
+    return `\n${fence(cdnPluginSnippet(plugins))}\n`
   })
 
   // the blocks just produced must be protected too, for the same reason

--- a/shared/data/sri.json
+++ b/shared/data/sri.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.4.0",
+  "hashes": {
+    "css": "sha384-kz+I4+mczbNiZfLAJMxOlJaZmnbRYhARHNkR2k6tal4gz7OL33/0puDD3SvkiNX9",
+    "css-rtl": "sha384-oBsMN4t4hqHp2yPeHCvYqwzbzTIQj7tW4JvGHxhmk14iAV8n8UWc8nl5PjfN0Cmp",
+    "css-flags": "sha384-kmvP0hkBXZ2hMSZlbvE1Q2HIXzPCQRL3ijUeqNiwaPd2nl2Aks+s3gW+V5fAHOX9",
+    "css-flags-rtl": "sha384-Q/h6koANGclsGnwB8rvF8h84H54NKHDeNWFj6yiE4WLLEXyHcz+Zu6Afkh2ssYTC",
+    "css-marketing": "sha384-4dAlYnPzCom9yeC/5++PFq2FG/szJRlUPsDSrjZ3EWP8IAzK7g7rrsnSfqrS67Se",
+    "css-marketing-rtl": "sha384-c6gNhuNYjp+lqluSdArbL8ciLEBq7IVU00XnPM2Eogj8RAjMapccvOM/pGhk3vV6",
+    "css-payments": "sha384-xWIXbKxPLGG/ZEGUKxDjJn3xmUgd2PC2CSZUKJ4PyTse49DiuvJx2WT5wSNJRyw9",
+    "css-payments-rtl": "sha384-69CxgA+uEPtM07SLA8MMAdnBmwtVGndDJf8nIPdfvNrDayBfPqOK3wS3nvV5yyk+",
+    "css-props": "sha384-yctdHmQqHsVGkRviR41l44mMU+tmJq7aIvUiRG05pnl2kIjaX1e9yuT6SdYTVMg/",
+    "css-props-rtl": "sha384-xMuKYM+iQpCesX0ZyyH7tW8KJgLkUOyHlPwNjEY8ZepdiAXhT9+psV8ohJ4xqlkg",
+    "css-themes": "sha384-jTe/MdN6BlY4S3eYe6Qw++yTjuezmVnxWp/l7GAG1qXGC+jttphHqsAN/bGPvJOk",
+    "css-themes-rtl": "sha384-WTp4aZ+OGqnkNR6Xe0sJwwfd0JHGq3dZTLU2ITKxTK2zjcJTBUMY/+Z4eXgm8ipF",
+    "css-socials": "sha384-eWmz8gyiLzrDw3JcT/PJxjGyKizQjvByfHqocjrMMkIrbKFCnOuP/qMwAz3bHmsC",
+    "css-socials-rtl": "sha384-yobKDIyTOxB1z7t/uZ2ImuXrcKWF24vDYg2vR1n7x2msF09iWnvyIxQtfEl9+OFl",
+    "css-vendors": "sha384-+X7+c/noY2B9ieq9daEaVStkUhIFyJTO5T6Occ6jZisx57sbECetvloLqcvGahUv",
+    "css-vendors-rtl": "sha384-V555LUGE2xyN4wNbzdVMgsajsKmJdlLFm20Ws72jEyPiSsTXXITV0PebNzVeBjnb",
+    "js": "sha384-pku3birjgGovaJ9ngF7SaxKkF/eYUvBjiMJ+jTtWbNesIj2Rud2K63+4JD7EF4gk",
+    "js-theme": "sha384-SoDJmj40r6f9Rfxi6Fq+bNS8ofhlZMyxHk9dq9Y8e1M17PZGkBRN/XUpx8swn0i5"
+  }
+}

--- a/shared/lib/sri.ts
+++ b/shared/lib/sri.ts
@@ -7,9 +7,7 @@ import path from 'node:path'
 const sriPath = path.resolve(process.cwd(), '../shared/data/sri.json')
 
 if (!existsSync(sriPath)) {
-  throw new Error(
-    'shared/data/sri.json is missing. Run `pnpm --filter @tabler/core build` before building the docs so SRI hashes are generated.',
-  )
+  throw new Error('shared/data/sri.json is missing. Run `pnpm --filter @tabler/core build` before building the docs so SRI hashes are generated.')
 }
 
 export const sri: Record<string, string> = JSON.parse(readFileSync(sriPath, 'utf8'))

--- a/shared/lib/sri.ts
+++ b/shared/lib/sri.ts
@@ -1,0 +1,12 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const sriPath = fileURLToPath(new URL('../data/sri.json', import.meta.url))
+
+if (!existsSync(sriPath)) {
+  throw new Error(
+    'shared/data/sri.json is missing. Run `pnpm --filter @tabler/core build` before building the docs so SRI hashes are generated.',
+  )
+}
+
+export const sri: Record<string, string> = JSON.parse(readFileSync(sriPath, 'utf8'))

--- a/shared/lib/sri.ts
+++ b/shared/lib/sri.ts
@@ -25,8 +25,8 @@ function loadData(): SriData | null {
 
 /**
  * Returns the `integrity` and `crossorigin` attributes for a CDN file, ready to be interpolated
- * into a code snippet. Keys match `shared/data/sri.json`, written by `core generate-sri`: `css`,
- * `js`, `css-flags`, and so on.
+ * into a code snippet. Keys match `shared/data/sri.json`, written by the release workflow from
+ * the build it publishes: `css`, `js`, `css-flags`, and so on.
  *
  * The hashes only describe the published release the snippets link to, so between a version bump
  * and the npm publish there is nothing to pin: the snippet then goes out without `integrity`
@@ -40,7 +40,7 @@ export function sriAttributes(key: string): string {
   if (sri?.version !== site.version) {
     if (!warned) {
       warned = true
-      console.warn(`[sri] No SRI hashes for @tabler/core@${site.version} in shared/data/sri.json — CDN snippets are shown without \`integrity\`. Run \`pnpm --filter @tabler/core generate-sri\` once the release is published.`)
+      console.warn(`[sri] No SRI hashes for @tabler/core@${site.version} in shared/data/sri.json — CDN snippets are shown without \`integrity\`. The release workflow writes them when this version is published.`)
     }
 
     return ''
@@ -49,7 +49,7 @@ export function sriAttributes(key: string): string {
   const hash = sri.hashes[key]
 
   if (!hash) {
-    throw new Error(`Missing SRI hash "${key}" in shared/data/sri.json. Add the file to core/.build/generate-sri.ts and run \`pnpm --filter @tabler/core generate-sri\`.`)
+    throw new Error(`Missing SRI hash "${key}" in shared/data/sri.json. Add the file to the list in core/.build/generate-sri.ts; the hash lands there with the next release.`)
   }
 
   return ` integrity="${hash}" crossorigin="anonymous"`

--- a/shared/lib/sri.ts
+++ b/shared/lib/sri.ts
@@ -6,8 +6,43 @@ import path from 'node:path'
 // directory (e.g. dist/.prerender/chunks/), which would break a file-relative path.
 const sriPath = path.resolve(process.cwd(), '../shared/data/sri.json')
 
-if (!existsSync(sriPath)) {
-  throw new Error('shared/data/sri.json is missing. Run `pnpm --filter @tabler/core build` before building the docs so SRI hashes are generated.')
+let hashes: Record<string, string> | null = null
+let warned = false
+
+function loadHashes(): Record<string, string> {
+  // Read lazily and keep re-checking until the file shows up: in dev it may be written by a
+  // `core build` running after the docs server started.
+  if (!hashes && existsSync(sriPath)) {
+    hashes = JSON.parse(readFileSync(sriPath, 'utf8')) as Record<string, string>
+  }
+
+  return hashes ?? {}
 }
 
-export const sri: Record<string, string> = JSON.parse(readFileSync(sriPath, 'utf8'))
+/**
+ * Returns the `integrity` and `crossorigin` attributes for a CDN file, ready to be interpolated
+ * into a code snippet. Keys match `shared/data/sri.json`, written by `core build`: `css`, `js`,
+ * `css-flags`, and so on.
+ *
+ * A missing file or key fails the build instead of emitting `integrity="undefined"`. In dev the
+ * attributes are dropped instead, because `dev-prepare` only builds unminified files, so there is
+ * nothing to hash yet.
+ */
+export function sriAttributes(key: string): string {
+  const hash = loadHashes()[key]
+
+  if (!hash) {
+    if (import.meta.env.PROD) {
+      throw new Error(`Missing SRI hash "${key}" in shared/data/sri.json. Run \`pnpm --filter @tabler/core build\` before building the docs so SRI hashes are generated.`)
+    }
+
+    if (!warned) {
+      warned = true
+      console.warn('[sri] No SRI hashes found in shared/data/sri.json — CDN snippets are shown without `integrity`. Run `pnpm --filter @tabler/core build` to generate them.')
+    }
+
+    return ''
+  }
+
+  return ` integrity="${hash}" crossorigin="anonymous"`
+}

--- a/shared/lib/sri.ts
+++ b/shared/lib/sri.ts
@@ -1,7 +1,10 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import path from 'node:path'
 
-const sriPath = fileURLToPath(new URL('../data/sri.json', import.meta.url))
+// Resolved from process.cwd() (the calling package's directory, e.g. docs/ or preview/),
+// not import.meta.url: Vite/Rollup emit this module's compiled output into a different
+// directory (e.g. dist/.prerender/chunks/), which would break a file-relative path.
+const sriPath = path.resolve(process.cwd(), '../shared/data/sri.json')
 
 if (!existsSync(sriPath)) {
   throw new Error(

--- a/shared/lib/sri.ts
+++ b/shared/lib/sri.ts
@@ -1,47 +1,55 @@
 import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
+import { site } from './site.ts'
+
+interface SriData {
+  version: string
+  hashes: Record<string, string>
+}
 
 // Resolved from process.cwd() (the calling package's directory, e.g. docs/ or preview/),
 // not import.meta.url: Vite/Rollup emit this module's compiled output into a different
 // directory (e.g. dist/.prerender/chunks/), which would break a file-relative path.
 const sriPath = path.resolve(process.cwd(), '../shared/data/sri.json')
 
-let hashes: Record<string, string> | null = null
+let data: SriData | null = null
 let warned = false
 
-function loadHashes(): Record<string, string> {
-  // Read lazily and keep re-checking until the file shows up: in dev it may be written by a
-  // `core build` running after the docs server started.
-  if (!hashes && existsSync(sriPath)) {
-    hashes = JSON.parse(readFileSync(sriPath, 'utf8')) as Record<string, string>
+function loadData(): SriData | null {
+  if (!data && existsSync(sriPath)) {
+    data = JSON.parse(readFileSync(sriPath, 'utf8')) as SriData
   }
 
-  return hashes ?? {}
+  return data
 }
 
 /**
  * Returns the `integrity` and `crossorigin` attributes for a CDN file, ready to be interpolated
- * into a code snippet. Keys match `shared/data/sri.json`, written by `core build`: `css`, `js`,
- * `css-flags`, and so on.
+ * into a code snippet. Keys match `shared/data/sri.json`, written by `core generate-sri`: `css`,
+ * `js`, `css-flags`, and so on.
  *
- * A missing file or key fails the build instead of emitting `integrity="undefined"`. In dev the
- * attributes are dropped instead, because `dev-prepare` only builds unminified files, so there is
- * nothing to hash yet.
+ * The hashes only describe the published release the snippets link to, so between a version bump
+ * and the npm publish there is nothing to pin: the snippet then goes out without `integrity`
+ * rather than with a hash the browser would reject. A key missing from a file that does match the
+ * current version means the file list in `generate-sri.ts` drifted from what the docs render, so
+ * that one fails the build instead of emitting `integrity="undefined"`.
  */
 export function sriAttributes(key: string): string {
-  const hash = loadHashes()[key]
+  const sri = loadData()
 
-  if (!hash) {
-    if (import.meta.env.PROD) {
-      throw new Error(`Missing SRI hash "${key}" in shared/data/sri.json. Run \`pnpm --filter @tabler/core build\` before building the docs so SRI hashes are generated.`)
-    }
-
+  if (sri?.version !== site.version) {
     if (!warned) {
       warned = true
-      console.warn('[sri] No SRI hashes found in shared/data/sri.json — CDN snippets are shown without `integrity`. Run `pnpm --filter @tabler/core build` to generate them.')
+      console.warn(`[sri] No SRI hashes for @tabler/core@${site.version} in shared/data/sri.json — CDN snippets are shown without \`integrity\`. Run \`pnpm --filter @tabler/core generate-sri\` once the release is published.`)
     }
 
     return ''
+  }
+
+  const hash = sri.hashes[key]
+
+  if (!hash) {
+    throw new Error(`Missing SRI hash "${key}" in shared/data/sri.json. Add the file to core/.build/generate-sri.ts and run \`pnpm --filter @tabler/core generate-sri\`.`)
   }
 
   return ` integrity="${hash}" crossorigin="anonymous"`

--- a/turbo.json
+++ b/turbo.json
@@ -19,17 +19,6 @@
       ],
       "cache": true
     },
-    "@tabler/core#build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "dist/**",
-        "demo/**",
-        "../shared/data/sri.json"
-      ],
-      "cache": true
-    },
     "@tabler/preview#build": {
       "dependsOn": [
         "^build"

--- a/turbo.json
+++ b/turbo.json
@@ -19,6 +19,17 @@
       ],
       "cache": true
     },
+    "@tabler/core#build": {
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        "demo/**",
+        "../shared/data/sri.json"
+      ],
+      "cache": true
+    },
     "@tabler/preview#build": {
       "dependsOn": [
         "^build"


### PR DESCRIPTION
## Summary

- CDN snippets in the docs now carry `integrity` and `crossorigin="anonymous"`, so a browser stops a tampered or corrupted file instead of running it.
- Hashes describe the published release the snippets link to. `generate-sri` no longer runs on every `core build` — it runs once per release, in the release workflow, right after `changesets` publishes that exact `core/dist`. Hashing a mid-cycle build would pin a value the browser rejects, because `dev` moves on while the snippets still link to the last released version.
- `shared/data/sri.json` is now committed and carries the release it belongs to (`{ "version": "1.4.0", "hashes": { … } }`). The docs render the hashes only when that version matches `@tabler/core`, so a stale file drops `integrity` instead of shipping a wrong one. A docs build no longer needs a prior core build.
- Every CDN snippet is built in one place (`docs/lib/cdn-snippets.ts`): the doc pages, the `/llms.txt` endpoints, and the full HTML example on the installation page. Before, the last two were separate copies with no `integrity`.

## Preview

- **URL:** [Installation](https://tabler-docs-git-fix-2876-tabler-io.vercel.app/ui/getting-started/installation), [Flags plugin](https://tabler-docs-git-fix-2876-tabler-io.vercel.app/ui/plugins/flags), [installation.md](https://tabler-docs-git-fix-2876-tabler-io.vercel.app/ui/getting-started/installation.md)
- **How to test:** Open the installation page. Both code blocks — the short CDN snippet and the full HTML example — should show `integrity="sha384-…"` and `crossorigin="anonymous"`. The `.md` version of the page (what `/llms.txt` serves) should show the same. Copy the snippet into an empty HTML file and open it: the styles must apply, which is what proves the hash matches the file users get from the CDN.

## Notes / rollout

- `release.yml` gains two steps, both behind `if: steps.changesets.outputs.published == 'true'`: run `generate-sri`, then commit `shared/data/sri.json` back to `dev` as `chore: update SRI hashes [skip ci]`. The checkout now uses `fetch-depth: 0` so that push works. If `dev` is protected against direct pushes, this step needs a token that may bypass it.
- Until that commit lands, the version in `sri.json` does not match `package.json` and the snippets render without `integrity` — safe, just unprotected.
- A hash missing while the version does match fails the docs build. That case means the file list in `core/.build/generate-sri.ts` drifted from what the docs render.
- Closes #2876
