### PR TITLE
Fix Tom Select dropdown losing z-index and colors to the bootstrap5 preset CSS

### DIFF
--- a/.changeset/fix-tom-select-dropdown-z-index.md
+++ b/.changeset/fix-tom-select-dropdown-z-index.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed Tom Select's `.ts-dropdown` losing its z-index, background, and colors to the bootstrap5 preset CSS.

--- a/core/scss/vendor/_tom-select.scss
+++ b/core/scss/vendor/_tom-select.scss
@@ -54,29 +54,37 @@ $input-border-width: 1px;
   }
 }
 
+// Every declaration below is `!important`: the bootstrap5 preset CSS targets
+// these same selectors at equal specificity, and whichever stylesheet is
+// included last otherwise wins outright (not just for z-index — the preset's
+// `--bs-*` vars are undefined outside Bootstrap, so once it wins a property it
+// renders as transparent/unstyled rather than merely off-theme) (#2600).
 .ts-dropdown {
-  z-index: $zindex-dropdown;
-  color: var(--body-color);
-  background: var(--bg-surface);
-  box-shadow: var(--shadow-dropdown);
+  // Tabler inits Tom Select with dropdownParent: 'body', so the dropdown is a
+  // direct child of <body> rather than of whatever contains the <select>. A
+  // select inside a modal therefore needs a z-index above the modal's, not
+  // just above other in-flow content.
+  z-index: $zindex-popover !important;
+  color: var(--body-color) !important;
+  background: var(--bg-surface) !important;
+  box-shadow: var(--shadow-dropdown) !important;
 
   .option {
     padding: $dropdown-item-padding-y $dropdown-item-padding-x;
   }
 
-  // Override TomSelect's bootstrap5 preset which references --bs- vars not available in Tabler (#2600)
   .active {
-    color: var(--body-color);
-    background-color: var(--active-bg);
+    color: var(--body-color) !important;
+    background-color: var(--active-bg) !important;
   }
 
   .active.create {
-    color: var(--body-color);
+    color: var(--body-color) !important;
   }
 
   .optgroup-header {
-    color: var(--body-color);
-    background: var(--bg-surface);
+    color: var(--body-color) !important;
+    background: var(--bg-surface) !important;
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixed `.ts-dropdown` (the Tom Select dropdown) losing its `z-index`, `background`, `color`, `box-shadow`, and active-item highlight to `tom-select.bootstrap5.min.css`.
- Root cause: that vendor stylesheet targets the same selectors at equal specificity, so whichever stylesheet loads last wins outright. When it wins, its `--bs-*` variables are undefined outside Bootstrap, so the properties fall back to transparent/unstyled instead of just being off-theme — the dropdown renders behind modals and see-through over whatever comes after it on the page.
- Fixed by adding `!important` to every override in `.ts-dropdown`, matching the convention already used across `core/scss/vendor/*.scss` for pinning down third-party CSS.

## Preview

- **URL:** [modals.html](https://tabler-git-fix-tom-select-z-index-tabler-io.vercel.app/modals.html) (open "Modal with form" — its assignee select uses Tom Select) · [all-elements.html](https://tabler-git-fix-tom-select-z-index-tabler-io.vercel.app/all-elements.html)
- **How to test:** On `modals.html`, open the "Modal with form" modal and click the "Assigned to" select — the dropdown should render with a solid background above the modal, not behind it or see-through. On `all-elements.html`, open any Tom Select dropdown and confirm the list has a solid white background and the highlighted/active option shows the theme's active color, not a hardcoded Bootstrap gray.

## Notes / rollout

- Based on `datepicker-and-tom-select-docs` (#2880), not `dev` — that branch adds the two docs pages this fix references; merge #2880 first, or merge this into it directly.