### PR TITLE
Format built HTML in worker threads to halve the preview build

### DIFF
--- a/preview/.build/prettify-html-worker.mjs
+++ b/preview/.build/prettify-html-worker.mjs
@@ -1,0 +1,21 @@
+// Worker half of the prettify-html integration in astro.config.mjs: formats one
+// batch of built pages while the sibling workers format theirs. Prettier is
+// single-threaded and the built HTML is ~18 MB, so one pass over it is by far
+// the slowest part of the build when it runs on a single thread.
+import { readFileSync, writeFileSync } from 'node:fs'
+import { workerData } from 'node:worker_threads'
+import prettier from 'prettier'
+
+const { files, options } = workerData
+
+for (const file of files) {
+  const source = readFileSync(file, 'utf8')
+  // Astro appends "overflow-x: auto" to the shiki <pre> style — the Eleventy
+  // pipeline doesn't have it and HTML is the product: restore 1:1.
+  const cleaned = source.replaceAll('; overflow-x: auto;', '')
+  // filepath is not redundant next to parser: "html" — prettier's printer keys
+  // some output off it, and without it the doctype comes out as <!DOCTYPE html>
+  // instead of the <!doctype html> the prettier CLI writes.
+  const formatted = await prettier.format(cleaned, { ...options, filepath: file })
+  if (formatted !== source) writeFileSync(file, formatted)
+}

--- a/preview/astro.config.mjs
+++ b/preview/astro.config.mjs
@@ -38,10 +38,11 @@ function prettifyHtml() {
         if (firstFile === undefined) return
 
         // Resolved once for the whole run: every page sits in the same directory
-        // tree and no .prettierrc override matches *.html. Passing the options on
-        // also keeps the workers off the ignore files — .gitignore and
+        // tree and no .prettierrc override matches *.html. The CLI pass this
+        // replaced also needed --ignore-path devNull, because .gitignore and
         // .prettierignore both list "dist" (so normal lint/format passes skip build
-        // output), which would silently no-op this deliberate pass.
+        // output) and the CLI would have skipped the very directory it targeted.
+        // format() reads no ignore files, so the workers need no such opt-out.
         const options = { ...(await prettier.resolveConfig(firstFile)), parser: 'html' }
 
         // Page sizes span two orders of magnitude, so an even split by file count

--- a/preview/astro.config.mjs
+++ b/preview/astro.config.mjs
@@ -3,10 +3,14 @@ import { defineConfig } from 'astro/config'
 import mdx from '@astrojs/mdx'
 import { satteri } from '@astrojs/markdown-satteri'
 import beautify from 'js-beautify'
-import { execFileSync } from 'node:child_process'
-import { globSync, readFileSync, writeFileSync } from 'node:fs'
-import { devNull } from 'node:os'
+import { globSync, statSync } from 'node:fs'
+import { availableParallelism } from 'node:os'
 import { fileURLToPath } from 'node:url'
+import { Worker } from 'node:worker_threads'
+// Imported statically: a dynamic import() inside the hook below would go through
+// Vite's module runner, which is already closed by the time astro:build:done runs
+// (the config is bundled by vite-node because it imports a .ts module).
+import prettier from 'prettier'
 import { copyAssets } from '../.build/copy-assets'
 
 /** @param {string} p */
@@ -14,6 +18,8 @@ const path = (p) => fileURLToPath(new URL(p, import.meta.url))
 
 /**
  * After build, format page HTML with prettier (users copy it 1:1).
+ * The formatting itself happens in .build/prettify-html-worker.mjs — see there
+ * for why it is worth spreading over threads.
  * @returns {import('astro').AstroIntegration}
  */
 function prettifyHtml() {
@@ -27,37 +33,38 @@ function prettifyHtml() {
         // some vendored libs ship their own malformed docs/*.html that trips the parser below.
         /** @param {string} file */
         const isVendorCopy = (file) => file.includes(`${outDir}preview/`) || file.includes(`${outDir}dist/`)
-        // Astro appends "overflow-x: auto" to the shiki <pre> style — the
-        // Eleventy pipeline doesn't have it and HTML is the product: restore 1:1.
-        // node:fs is imported statically — a dynamic import() here would go
-        // through Vite's module runner, which is already closed by the time
-        // the astro:build:done hook runs (the config is bundled by vite-node
-        // because it imports a .ts module).
-        for (const file of globSync(`${outDir}**/*.html`, { exclude: isVendorCopy })) {
-          const content = readFileSync(file, 'utf8')
-          const cleaned = content.replaceAll('; overflow-x: auto;', '')
-          if (cleaned !== content) writeFileSync(file, cleaned)
-        }
-        execFileSync(
-          'npx',
-          [
-            'prettier',
-            '--write',
-            '--parser',
-            'html',
-            // Prettier's default ignore-path is [.gitignore, .prettierignore], and both
-            // list "dist" (needed elsewhere so normal lint/format passes skip build
-            // output) — that silently no-ops this pass on the very directory it targets.
-            // Point at devNull to opt this one deliberate pass out of those ignores.
-            '--ignore-path',
-            devNull,
-            `${outDir}**/*.html`,
-            `!${outDir}preview/**`,
-            `!${outDir}dist/**`,
-          ],
-          { stdio: 'inherit' },
+        const files = globSync(`${outDir}**/*.html`, { exclude: isVendorCopy })
+        const firstFile = files[0]
+        if (firstFile === undefined) return
+
+        // Resolved once for the whole run: every page sits in the same directory
+        // tree and no .prettierrc override matches *.html. Passing the options on
+        // also keeps the workers off the ignore files — .gitignore and
+        // .prettierignore both list "dist" (so normal lint/format passes skip build
+        // output), which would silently no-op this deliberate pass.
+        const options = { ...(await prettier.resolveConfig(firstFile)), parser: 'html' }
+
+        // Page sizes span two orders of magnitude, so an even split by file count
+        // leaves one worker alone with the biggest page long after the others are
+        // done. Dealing the size-ordered list round-robin evens the batches out.
+        const workerCount = Math.min(availableParallelism(), 8, files.length)
+        const ordered = files
+          .map((file) => ({ file, size: statSync(file).size }))
+          .sort((a, b) => b.size - a.size)
+          .map(({ file }) => file)
+        const batches = Array.from({ length: workerCount }, (_, worker) => ordered.filter((_, index) => index % workerCount === worker))
+
+        await Promise.all(
+          batches.map(
+            (batch) =>
+              new Promise((resolve, reject) => {
+                const worker = new Worker(path('./.build/prettify-html-worker.mjs'), { workerData: { files: batch, options } })
+                worker.on('error', reject)
+                worker.on('exit', (code) => (code === 0 ? resolve(undefined) : reject(new Error(`prettify-html worker exited with code ${code}`))))
+              }),
+          ),
         )
-        logger.info('HTML formatted with prettier')
+        logger.info(`HTML formatted with prettier (${files.length} pages, ${workerCount} workers)`)
       },
     },
   }


### PR DESCRIPTION
## Summary

- The `prettify-html` step formatted all 128 built pages (~18 MB of HTML) in one `npx prettier` call. That single-threaded pass took 6.8s of a 9.5s build.
- It now runs prettier through its Node API in worker threads, and folds the `overflow-x: auto` cleanup into the same pass instead of reading and writing every file twice.
- Pages are sorted by size and dealt to the workers round-robin. An even split by file count left one worker alone with `navigation.html` (576 KB) long after the others were done — that alone was 2.5s vs 1.9s.
- The preview build drops from 8.8s to 3.7s (`real` 9.5s to 4.5s). The formatting step itself: 6.8s to 2.1s.

## How to review

- `preview/.build/prettify-html-worker.mjs` is the new worker: read, strip `; overflow-x: auto;`, format, write.
- `preview/astro.config.mjs` holds the rest: resolve `.prettierrc` once, split the pages, wait for the workers.
- `filepath` is passed to `prettier.format()` next to `parser: "html"` on purpose. Without it the doctype comes out as `<!DOCTYPE html>` instead of the `<!doctype html>` the CLI writes. There is a comment on it in the worker.
- prettier is imported statically. A dynamic `import()` inside `astro:build:done` fails because Vite's module runner is closed by then (the config is bundled by vite-node).

## Notes / rollout

- Output is byte-identical. Verified by building once with the step disabled, snapshotting the raw HTML, then running the old and new pass over that same input: 0 of 128 files differ.
- Two consecutive builds of `preview` differ in 101 of 128 pages on their own, so `dist` cannot be compared byte-for-byte across builds. That is why verification had to go through shared input. The only cause is the build-time `new Date()` in `shared/components/layout/Footer.astro` — normalize that stamp and the two builds match exactly. The 101 pages are the ones that render the footer.
- Worker count is `min(availableParallelism(), 8, pages)`, so it scales down on small CI runners.
- No changeset: this only changes build tooling, not the published HTML.
