### PR TITLE
Show the `Generated` stamp only on preview builds

### DIFF
--- a/.changeset/footer-generated-preview-only.md
+++ b/.changeset/footer-generated-preview-only.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": patch
+---
+
+Updated the footer to show the version link everywhere and the `Generated` timestamp only on preview builds.

--- a/shared/components/layout/Footer.astro
+++ b/shared/components/layout/Footer.astro
@@ -3,11 +3,10 @@ import Icon from '@ui/Icon.astro'
 import { site } from '@shared/lib/site'
 import { formatUtcTimestamp } from '@shared/lib/date-format'
 
-// Development build (unminified assets), same as BaseLayout.
-const environment: string = 'development'
+// Set to "preview" on the branch deploys, same as robots.txt and sitemap.xml.
+const environment = process.env.NODE_ENV || 'production'
 
 const now = new Date()
-const generatedAt = formatUtcTimestamp(now)
 ---
 
 <!--  BEGIN FOOTER  -->
@@ -44,12 +43,12 @@ const generatedAt = formatUtcTimestamp(now)
           </li>
           <li class="list-inline-item">
             {
-              environment === 'production' || environment === 'preview' ? (
+              environment === 'preview' ? (
+                `Generated ${formatUtcTimestamp(now)}`
+              ) : (
                 <a href="./changelog.html" class="link-secondary" rel="noopener">
                   v{site.version}
                 </a>
-              ) : (
-                `Generated ${generatedAt}`
               )
             }
           </li>


### PR DESCRIPTION
## Summary

- `Footer.astro` had `environment` hardcoded to `"development"`, so every build shipped the `Generated <date>` stamp — including the packaged HTML users download. The version link in the other branch of that condition was unreachable.
- The footer now reads `NODE_ENV` the same way `preview/pages/robots.txt.ts` and `preview/pages/sitemap.xml.ts` already do. Only `NODE_ENV=preview` renders the stamp; every other environment renders the link to `changelog.html`.
- Side effect worth having: local and production builds are now byte-stable across runs. That timestamp was the single reason two builds of the same commit differed (101 of 128 pages).

## Preview

- **URL:** [preview build](https://tabler-git-footer-generated-preview-only-tabler-io.vercel.app/)
- **How to test:** look at the footer, right-hand column. On the Vercel preview it should read `Generated <date>`, because that project runs with `NODE_ENV=preview`. Build locally (`pnpm run build` in `preview/`) and the same spot should show the version link instead.

## Notes / rollout

- This depends on `NODE_ENV=preview` being set in the Vercel project settings. Nothing in the repo sets it — `turbo.json` only passes it through. If it is not set there, the preview deploy shows the version link, and `robots.txt` is already behaving the same way today.
- Verified both paths: default build gives 0 pages with the stamp and 101 with the version link; `NODE_ENV=preview` gives the reverse.
