### PR TITLE
Drop `<lastmod>` from the preview sitemap

### DIFF
--- a/.changeset/sitemap-drop-lastmod.md
+++ b/.changeset/sitemap-drop-lastmod.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": patch
+---
+
+Removed the `<lastmod>` element from `sitemap.xml`, which carried the build time instead of a content date.

--- a/preview/pages/sitemap.xml.ts
+++ b/preview/pages/sitemap.xml.ts
@@ -25,13 +25,12 @@ const escapeXml = (value: string) => value.replace(/&/g, '&amp;').replace(/</g, 
 export const GET: APIRoute = () => {
   const environment = process.env.NODE_ENV || 'production'
   const baseUrl = environment !== 'development' ? site.previewUrl : ''
-  // ISO 8601 UTC timestamp (+00:00 suffix)
-  const lastModified = new Date().toISOString().replace(/\.\d{3}Z$/, '+00:00')
+  // No <lastmod>: it is optional, and stamping every url with the build time
+  // said nothing about the pages while making the file differ on every build.
   const entries = urls
     .map(
       (url) => `<url>
 	<loc>${escapeXml(`${baseUrl}${url}`)}</loc>
-	<lastmod>${lastModified}</lastmod>
 </url>`,
     )
     .join('\n')


### PR DESCRIPTION
## Summary

- Every `<url>` in `preview/pages/sitemap.xml.ts` carried the same `<lastmod>`, built from `new Date()` at build time. It described when the build ran, not when the page changed, so it gave crawlers nothing.
- `<lastmod>` is optional in the sitemap protocol, and a single identical value across all 128 urls is exactly the case crawlers ignore. Dropped it; `<loc>` stays.
- With this, `sitemap.xml` no longer changes on every build. It was the last file in `dist` that did.

## How to review

- `preview/pages/sitemap.xml.ts` — the `lastModified` constant and one line of the template are gone, nothing else.
- Built output: 128 `<url>` entries, 0 occurrences of `lastmod`.

## Notes / rollout

- If per-page dates are wanted later, they should come from the content (commit date of the page source), not from build time — that is the only version a crawler can act on.
