### PR TITLE
Let docs build without waiting for the preview pages

### DIFF
--- a/preview/astro.config.mjs
+++ b/preview/astro.config.mjs
@@ -121,6 +121,9 @@ export default defineConfig({
           from: path('./tmp-assets'),
           to: path('./public/preview'),
           label: '@tabler/preview',
+          // Built by the separate "assets" script (its own turbo task), so this
+          // build can start with a half-written tmp-assets from an aborted run.
+          requiredFile: path('./tmp-assets/css/demo.css'),
         },
         {
           // static assets (photos, avatars, tracks, brand svgs...). The real source,

--- a/preview/package.json
+++ b/preview/package.json
@@ -15,7 +15,7 @@
     "watch": "concurrently \"pnpm run watch-css\" \"pnpm run watch-js\"",
     "dev": "concurrently -n astro,css,js -c blue,magenta,cyan \"astro dev\" \"pnpm run watch-css\" \"pnpm run watch-js\"",
     "dev-prepare": "pnpm run assets",
-    "build": "pnpm run assets && astro build",
+    "build": "astro build",
     "preview": "astro preview",
     "clean": "shx rm -rf dist public/dist public/preview public/css .astro tmp-assets",
     "import-icons": "pnpm up @tabler/icons@latest && node .build/import-icons.mjs",

--- a/turbo.json
+++ b/turbo.json
@@ -19,9 +19,23 @@
       ],
       "cache": true
     },
+    "@tabler/preview#assets": {
+      "inputs": [
+        "scss/**",
+        "js/**",
+        ".build/vite.config.mts",
+        "$TURBO_ROOT$/.build/build-css.ts",
+        "$TURBO_ROOT$/.build/vite.config.helper.ts"
+      ],
+      "outputs": [
+        "tmp-assets/**"
+      ],
+      "cache": true
+    },
     "@tabler/preview#build": {
       "dependsOn": [
-        "^build"
+        "^build",
+        "@tabler/preview#assets"
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
@@ -29,14 +43,14 @@
       ],
       "outputs": [
         "dist/**",
-        "demo/**",
-        "tmp-assets/**"
+        "demo/**"
       ],
       "cache": true
     },
     "@tabler/docs#build": {
       "dependsOn": [
-        "^build"
+        "@tabler/core#build",
+        "@tabler/preview#assets"
       ],
       "inputs": [
         "$TURBO_DEFAULT$",


### PR DESCRIPTION
## Summary

- `@tabler/docs#build` depended on `^build`, so it waited for the **whole** preview build — 128 pages plus the prettier pass — when all it needs from preview is `preview/tmp-assets` (the demo css/js it copies into its own `public/`). Nothing in docs reads `preview/dist`.
- Preview's asset build is now its own turbo task, `@tabler/preview#assets`, with `tmp-assets/**` as its output. `preview#build` and `docs#build` both depend on that task instead of on each other's page builds.
- `preview`'s `build` script drops the `pnpm run assets &&` prefix — turbo runs the assets task first now. The `dev` graph is untouched: `dev-prepare` still runs the same script.
- The assets task declares its own inputs (`scss/**`, `js/**`, the two build scripts), so editing a page no longer invalidates the cached demo css/js, and editing the demo scss no longer invalidates the pages.

## Timings

Measured back to back on the same machine, `turbo build --force`:

| | before | after |
| --- | --- | --- |
| full build | 17.0s | **13.4s** |

The task timeline shows why: `core` (5.3s) is still the head, but `docs`, `preview` and `screenshots` now all start the moment core finishes, instead of docs queueing behind preview.

## How to review

- `turbo.json` is the whole change; the other two files follow from it.
- Worth checking that the new `inputs` list for `@tabler/preview#assets` covers everything the `assets` script reads. It runs `.build/build-css.ts` over `preview/scss` and vite over `preview/js` — neither imports anything from `core`, which is why the task has no `dependsOn`.

## Notes / rollout

- `astro build` run directly in `preview/` without assets now fails with `copy-assets: missing …/tmp-assets/css/demo.css — build @tabler/preview first` instead of silently shipping pages with no demo css. Added `requiredFile` for that. Going through `turbo build` from the root, as before, is unaffected.
- `astro check` still runs on a clean checkout — the copy hook skips itself on `command === 'sync'`, verified with `tmp-assets` deleted.
- Verified a full `turbo clean && turbo build --force`: both `preview/dist` and `docs/dist` come out with the demo css/js in place.
- No changeset: build orchestration only, the published output is unchanged.
