### PR TITLE
Add high-contrast color mode via `data-bs-theme-contrast`

### DIFF
--- a/.build/check-contrast.ts
+++ b/.build/check-contrast.ts
@@ -1,0 +1,318 @@
+// Verifies WCAG contrast ratios of Tabler's semantic color tokens.
+//
+// Compiles scss/tabler.scss in-memory (no dist build needed), collects the
+// custom-property declarations of the base (:root), dark-mode and
+// high-contrast blocks, resolves var() / light-dark() / color-mix() chains the
+// way a browser would, and checks a fixed list of foreground/background token
+// pairs in every color-mode × contrast-mode combination.
+//
+// Thresholds: the default theme ("normal" profile) is reported as warnings
+// only — pre-existing shortfalls must not break the build. The high-contrast
+// profile is a hard gate: any required pair below its ratio exits non-zero.
+//
+// Usage: tsx ../.build/check-contrast.ts   (cwd = the package, e.g. core)
+import { compile as compileSass } from 'sass'
+import postcss, { type Container, type Rule } from 'postcss'
+
+type Rgba = { r: number; g: number; b: number; a: number } // channels 0..1
+
+type State = { dark: boolean; high: boolean }
+
+type Pair = { fg: string; bg: string; normal: number | null; high: number | null; note: string }
+
+// Ratios follow WCAG 2.2: 4.5 = AA text, 7 = AAA text, 3 = non-text UI
+// (1.4.11). `null` = report-only (no requirement at that profile).
+const PAIRS: Pair[] = [
+  { fg: '--body-color', bg: '--bg-surface', normal: 4.5, high: 7, note: 'body text on cards' },
+  { fg: '--body-color', bg: '--body-bg', normal: 4.5, high: 7, note: 'body text on page' },
+  { fg: '--secondary', bg: '--bg-surface', normal: 4.5, high: 7, note: 'muted text on cards' },
+  { fg: '--secondary', bg: '--body-bg', normal: 4.5, high: 7, note: 'muted text on page' },
+  { fg: '--tertiary', bg: '--bg-forms', normal: null, high: 4.5, note: 'placeholder text' },
+  { fg: '--link-color', bg: '--bg-surface', normal: 4.5, high: 7, note: 'links on cards' },
+  { fg: '--link-color', bg: '--body-bg', normal: 4.5, high: 7, note: 'links on page' },
+  { fg: '--link-hover-color', bg: '--bg-surface', normal: 4.5, high: 7, note: 'hovered links' },
+  { fg: '--icon-color', bg: '--bg-surface', normal: null, high: 3, note: 'decorative icons' },
+  { fg: '--border-color', bg: '--bg-surface', normal: null, high: 3, note: 'borders on cards' },
+  { fg: '--border-color', bg: '--body-bg', normal: null, high: 3, note: 'borders on page' },
+  { fg: '--border-active-color', bg: '--bg-forms', normal: null, high: 3, note: 'active control borders' },
+  { fg: '--focus-ring-color', bg: '--body-bg', normal: null, high: 3, note: 'focus ring' },
+  { fg: '--primary', bg: '--bg-surface', normal: 3, high: 3, note: 'primary UI (buttons)' },
+  { fg: '--primary-fg', bg: '--primary', normal: 4.5, high: 4.5, note: 'text on primary buttons' },
+  { fg: '--disabled-color', bg: '--bg-surface', normal: null, high: null, note: 'disabled text (WCAG-exempt)' },
+]
+
+// ---------------------------------------------------------------------------
+// Collect custom properties from the compiled css
+
+const compiled = compileSass('scss/tabler.scss', {
+  loadPaths: ['node_modules'],
+  style: 'expanded',
+  logger: { warn: () => {}, debug: () => {} },
+})
+
+const baseProps = new Map<string, string>()
+const darkProps = new Map<string, string>()
+const highProps = new Map<string, string>()
+
+function mediaChain(node: Container | undefined): string {
+  let params = ''
+  for (let cur = node; cur; cur = cur.parent as Container | undefined) {
+    if (cur.type === 'atrule') params += ` ${(cur as postcss.AtRule).name} ${(cur as postcss.AtRule).params}`
+  }
+  return params
+}
+
+postcss.parse(compiled.css).walkRules((rule: Rule) => {
+  const media = mediaChain(rule.parent as Container | undefined)
+  const inPrefersContrast = media.includes('prefers-contrast')
+  // Ignore breakpoint/print/supports blocks — only the contrast media query
+  // carries color tokens we track.
+  if (media.trim() && !inPrefersContrast) return
+
+  const selector = rule.selector
+  let target: Map<string, string> | undefined
+  if (inPrefersContrast || /theme-contrast=['"]?high/.test(selector)) {
+    target = highProps
+  } else if (/data-(?:bs-)?theme=['"]?dark|\.theme-dark/.test(selector)) {
+    target = darkProps
+  } else if (rule.selectors.some((s) => [':root', ':host'].includes(s.trim()) || /^\[data-(?:bs-)?theme=['"]?light/.test(s.trim()))) {
+    target = baseProps
+  }
+  if (!target) return
+
+  rule.walkDecls((decl) => {
+    if (decl.prop.startsWith('--')) target!.set(decl.prop, decl.value.trim())
+  })
+})
+
+if (baseProps.size === 0 || highProps.size === 0) {
+  console.error(`check-contrast: token collection failed (base: ${baseProps.size}, high-contrast: ${highProps.size})`)
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Value resolution: var() substitution + color evaluation
+
+function lookupProp(name: string, state: State): string | undefined {
+  const key = baseProps.has(name) || darkProps.has(name) || highProps.has(name) ? name : name.replace(/^--tblr-/, '--')
+  if (state.high && highProps.has(key)) return highProps.get(key)
+  if (state.dark && darkProps.has(key)) return darkProps.get(key)
+  return baseProps.get(key)
+}
+
+// Split on top-level commas (ignores commas inside nested parens)
+function splitArgs(str: string): string[] {
+  const parts: string[] = []
+  let depth = 0
+  let cur = ''
+  for (const ch of str) {
+    if (ch === '(') depth++
+    if (ch === ')') depth--
+    if (ch === ',' && depth === 0) {
+      parts.push(cur.trim())
+      cur = ''
+    } else {
+      cur += ch
+    }
+  }
+  if (cur.trim()) parts.push(cur.trim())
+  return parts
+}
+
+// Find `fn(` in str and return the span of its balanced argument list
+function findCall(str: string, fn: string): { start: number; end: number; inner: string } | null {
+  const start = str.indexOf(`${fn}(`)
+  if (start === -1) return null
+  let depth = 0
+  for (let i = start + fn.length; i < str.length; i++) {
+    if (str[i] === '(') depth++
+    if (str[i] === ')') {
+      depth--
+      if (depth === 0) return { start, end: i + 1, inner: str.slice(start + fn.length + 1, i) }
+    }
+  }
+  throw new Error(`unbalanced parens in: ${str}`)
+}
+
+function substituteVars(value: string, state: State, seen: string[] = []): string {
+  let out = value
+  for (let call = findCall(out, 'var'); call; call = findCall(out, 'var')) {
+    const [name, ...fallback] = splitArgs(call.inner)
+    if (seen.includes(name)) throw new Error(`var() cycle: ${[...seen, name].join(' → ')}`)
+    const raw = lookupProp(name, state)
+    const replacement = raw !== undefined ? substituteVars(raw, state, [...seen, name]) : fallback.length ? substituteVars(fallback.join(','), state, seen) : undefined
+    if (replacement === undefined) throw new Error(`unresolvable ${name}`)
+    out = out.slice(0, call.start) + replacement + out.slice(call.end)
+  }
+  return out
+}
+
+const NAMED: Record<string, Rgba> = {
+  transparent: { r: 0, g: 0, b: 0, a: 0 },
+  white: { r: 1, g: 1, b: 1, a: 1 },
+  black: { r: 0, g: 0, b: 0, a: 1 },
+}
+
+function parseLiteral(str: string): Rgba {
+  const s = str.trim().toLowerCase()
+  if (NAMED[s]) return NAMED[s]
+  const hex = s.match(/^#([0-9a-f]{3,8})$/)
+  if (hex) {
+    let h = hex[1]
+    if (h.length <= 4) h = [...h].map((c) => c + c).join('')
+    const n = (i: number) => parseInt(h.slice(i, i + 2), 16) / 255
+    return { r: n(0), g: n(2), b: n(4), a: h.length === 8 ? n(6) : 1 }
+  }
+  const fn = s.match(/^rgba?\((.*)\)$/)
+  if (fn) {
+    const body = fn[1].replace('/', ' ')
+    const parts = body.split(/[\s,]+/).filter(Boolean)
+    const chan = (p: string, scale: number) => (p.endsWith('%') ? parseFloat(p) / 100 : parseFloat(p) / scale)
+    return {
+      r: chan(parts[0], 255),
+      g: chan(parts[1], 255),
+      b: chan(parts[2], 255),
+      a: parts[3] !== undefined ? chan(parts[3], 1) : 1,
+    }
+  }
+  throw new Error(`cannot parse color: ${str}`)
+}
+
+// -- oklab <-> srgb (standard matrices), needed for `color-mix(in oklab, …)`
+const linear = (c: number) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4)
+const unlinear = (c: number) => (c <= 0.0031308 ? c * 12.92 : 1.055 * c ** (1 / 2.4) - 0.055)
+
+function toOklab({ r, g, b }: Rgba): [number, number, number] {
+  const [lr, lg, lb] = [linear(r), linear(g), linear(b)]
+  const l = Math.cbrt(0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb)
+  const m = Math.cbrt(0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb)
+  const s = Math.cbrt(0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb)
+  return [0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s, 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s, 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s]
+}
+
+function fromOklab([L, A, B]: [number, number, number]): Omit<Rgba, 'a'> {
+  const l = (L + 0.3963377774 * A + 0.2158037573 * B) ** 3
+  const m = (L - 0.1055613458 * A - 0.0638541728 * B) ** 3
+  const s = (L - 0.0894841775 * A - 1.291485548 * B) ** 3
+  const clamp = (c: number) => Math.min(1, Math.max(0, c))
+  return {
+    r: clamp(unlinear(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s)),
+    g: clamp(unlinear(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s)),
+    b: clamp(unlinear(-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s)),
+  }
+}
+
+function colorMix(space: string, c1: Rgba, w1: number, c2: Rgba, w2: number): Rgba {
+  // css-color-5 §3: normalize weights; a sum below 100% multiplies the alpha
+  const sum = w1 + w2
+  const alphaScale = sum < 1 ? sum : 1
+  const [n1, n2] = [w1 / sum, w2 / sum]
+  const a = c1.a * n1 + c2.a * n2
+  const mixPre = (v1: number, v2: number) => (a === 0 ? v1 * n1 + v2 * n2 : (v1 * c1.a * n1 + v2 * c2.a * n2) / a)
+  if (space === 'srgb') {
+    return { r: mixPre(c1.r, c2.r), g: mixPre(c1.g, c2.g), b: mixPre(c1.b, c2.b), a: a * alphaScale }
+  }
+  if (space === 'oklab') {
+    const [l1, l2] = [toOklab(c1), toOklab(c2)]
+    const lab: [number, number, number] = [mixPre(l1[0], l2[0]), mixPre(l1[1], l2[1]), mixPre(l1[2], l2[2])]
+    return { ...fromOklab(lab), a: a * alphaScale }
+  }
+  throw new Error(`unsupported color-mix space: ${space}`)
+}
+
+function evalColor(expr: string, state: State): Rgba {
+  const s = expr.trim()
+  if (s.startsWith('light-dark(')) {
+    const [light, dark] = splitArgs(findCall(s, 'light-dark')!.inner)
+    return evalColor(state.dark ? dark : light, state)
+  }
+  if (s.startsWith('color-mix(')) {
+    const args = splitArgs(findCall(s, 'color-mix')!.inner)
+    const space = args[0].replace(/^in\s+/, '').trim()
+    const parseComponent = (arg: string): { color: string; pct: number | null } => {
+      const m = arg.match(/^(.*?)\s+([\d.]+)%$/s) ?? arg.match(/^([\d.]+)%\s+(.*)$/s)
+      if (!m) return { color: arg, pct: null }
+      return /%$/.test(arg) ? { color: m[1], pct: parseFloat(m[2]) } : { color: m[2], pct: parseFloat(m[1]) }
+    }
+    const [p1, p2] = [parseComponent(args[1]), parseComponent(args[2])]
+    let [w1, w2] = [p1.pct, p2.pct]
+    if (w1 === null && w2 === null) [w1, w2] = [50, 50]
+    else if (w1 === null) w1 = 100 - w2!
+    else if (w2 === null) w2 = 100 - w1
+    return colorMix(space, evalColor(p1.color, state), w1! / 100, evalColor(p2.color, state), w2! / 100)
+  }
+  return parseLiteral(s)
+}
+
+function resolveToken(name: string, state: State): Rgba {
+  const raw = lookupProp(name, state)
+  if (raw === undefined) throw new Error(`token not found: ${name}`)
+  return evalColor(substituteVars(raw, state), state)
+}
+
+// ---------------------------------------------------------------------------
+// WCAG math
+
+function flatten(fg: Rgba, bg: Rgba): Rgba {
+  if (fg.a >= 1) return fg
+  const over = (f: number, b: number) => f * fg.a + b * (1 - fg.a)
+  return { r: over(fg.r, bg.r), g: over(fg.g, bg.g), b: over(fg.b, bg.b), a: 1 }
+}
+
+function luminance({ r, g, b }: Rgba): number {
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b)
+}
+
+function contrast(fg: Rgba, bg: Rgba): number {
+  const [l1, l2] = [luminance(fg), luminance(bg)]
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05)
+}
+
+const toHex = ({ r, g, b }: Rgba) =>
+  '#' +
+  [r, g, b]
+    .map((c) =>
+      Math.round(c * 255)
+        .toString(16)
+        .padStart(2, '0'),
+    )
+    .join('')
+
+// ---------------------------------------------------------------------------
+// Run every color-mode × contrast-mode combination
+
+const STATES: { label: string; state: State }[] = [
+  { label: 'light · normal', state: { dark: false, high: false } },
+  { label: 'light · high-contrast', state: { dark: false, high: true } },
+  { label: 'dark · normal', state: { dark: true, high: false } },
+  { label: 'dark · high-contrast', state: { dark: true, high: true } },
+]
+
+let errors = 0
+let warnings = 0
+
+for (const { label, state } of STATES) {
+  console.log(`\n${label}`)
+  for (const pair of PAIRS) {
+    const required = state.high ? pair.high : pair.normal
+    let line: string
+    try {
+      const bgToken = resolveToken(pair.bg, state)
+      const pageBg = flatten(resolveToken('--body-bg', state), NAMED.white)
+      const bg = flatten(bgToken, pageBg)
+      const fg = flatten(resolveToken(pair.fg, state), bg)
+      const ratio = contrast(fg, bg)
+      const ok = required === null || ratio >= required
+      if (!ok) state.high ? errors++ : warnings++
+      const mark = required === null ? '·' : ok ? '✓' : state.high ? '✗' : '!'
+      line = `  ${mark} ${pair.fg} on ${pair.bg}`.padEnd(50) + `${ratio.toFixed(2).padStart(6)}${required === null ? '   (report)' : `   (>= ${required})`}  ${toHex(fg)} on ${toHex(bg)}  ${pair.note}`
+    } catch (err) {
+      errors++
+      line = `  ✗ ${pair.fg} on ${pair.bg}`.padEnd(50) + `  ${err instanceof Error ? err.message : err}`
+    }
+    console.log(line)
+  }
+}
+
+console.log(`\n${errors} error(s), ${warnings} warning(s) — high-contrast failures are errors, default-theme failures are warnings`)
+process.exit(errors > 0 ? 1 : 0)

--- a/.changeset/high-contrast-mode.md
+++ b/.changeset/high-contrast-mode.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": minor
+---
+
+Added a high-contrast color mode, enabled with `data-bs-theme-contrast="high"` or the `prefers-contrast` media query.

--- a/.changeset/theme-settings-contrast.md
+++ b/.changeset/theme-settings-contrast.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": minor
+---
+
+Added a Contrast setting (`auto`/`normal`/`high`) to the Theme Settings panel.

--- a/core/js/tabler-theme.ts
+++ b/core/js/tabler-theme.ts
@@ -6,6 +6,7 @@
 interface ThemeConfig {
   'theme': string
   'theme-base': string
+  'theme-contrast': string
   'theme-font': string
   'theme-primary': string
   'theme-radius': string
@@ -14,6 +15,8 @@ interface ThemeConfig {
 const themeConfig: ThemeConfig = {
   'theme': 'light',
   'theme-base': 'gray',
+  // 'auto' = no attribute: the css then follows `prefers-contrast: more`
+  'theme-contrast': 'auto',
   'theme-font': 'sans-serif',
   'theme-primary': 'blue',
   'theme-radius': '1',

--- a/core/package.json
+++ b/core/package.json
@@ -15,6 +15,7 @@
     "lint:scss": "stylelint \"scss/**/*.scss\" --config ../stylelint.config.mjs",
     "lint:scss:fix": "pnpm run lint:scss --fix",
     "css-lint-variables": "find-unused-sass-variables scss/",
+    "css-check-contrast": "tsx ../.build/check-contrast.ts",
     "js": "pnpm run js-build && pnpm run js-build-min",
     "js-build": "concurrently \"pnpm run js-build-standalone\" \"pnpm run js-build-theme\"",
     "js-build-theme": "cross-env BASE_NAME=tabler-theme vite build --config .build/vite.config.mts",

--- a/core/scss/_core.scss
+++ b/core/scss/_core.scss
@@ -41,6 +41,7 @@
 @forward 'layout/page';
 @forward 'layout/footer';
 @forward 'layout/dark';
+@forward 'layout/contrast';
 @forward 'layout/accessibility';
 
 @forward 'ui/accordion';

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -14,6 +14,7 @@ $enable-gradients: false !default;
 $enable-shadows: true !default;
 $enable-navbar-vertical: true !default;
 $enable-dark-mode: true !default;
+$enable-contrast-mode: true !default;
 $enable-negative-margins: true !default;
 // $enable-rfs is declared in `_mixins.scss` (forwarded from rfs with `false !default`)
 $enable-cssgrid: true !default;

--- a/core/scss/layout/_contrast.scss
+++ b/core/scss/layout/_contrast.scss
@@ -1,0 +1,63 @@
+@use '../config' as *;
+
+// High-contrast color mode.
+//
+// Overrides the semantic tokens from `layout/_root.scss` so text reaches
+// WCAG AAA (7:1) and non-text UI (borders, icons, focus) reaches 3:1
+// (WCAG 1.4.11), in both light and dark color modes.
+//
+// Enabled explicitly with `data-bs-theme-contrast="high"`, or automatically
+// when the OS asks for more contrast (`prefers-contrast: more`). Setting
+// `data-bs-theme-contrast="normal"` opts out of the automatic behavior.
+//
+// The resulting token pairs are verified by `.build/check-contrast.ts`
+// (`pnpm run css-check-contrast`).
+@mixin theme-contrast-high() {
+  --body-color: light-dark(var(--gray-900), var(--gray-50));
+  --secondary: light-dark(var(--gray-700), var(--gray-300));
+  --tertiary: light-dark(var(--gray-600), var(--gray-300));
+
+  // Decorative gray-400 icons don't reach 3:1 — tie them to secondary text
+  --icon-color: var(--secondary);
+
+  // Translucent borders composite below 3:1 on tinted surfaces, so every
+  // border token becomes an opaque gray here.
+  --border-color: light-dark(var(--gray-500), var(--gray-400));
+  --border-color-translucent: var(--border-color);
+  --border-dark-color: light-dark(var(--gray-600), var(--gray-300));
+  --border-dark-color-translucent: var(--border-dark-color);
+  --border-active-color: light-dark(var(--gray-700), var(--gray-200));
+  --border-active-color-translucent: var(--border-active-color);
+
+  // Links keep the primary hue, pushed towards the mode's text color until
+  // they clear AAA on every surface.
+  --link-color: light-dark(color-mix(in srgb, var(--primary), #000 35%), color-mix(in srgb, var(--primary), #fff 60%));
+  --link-hover-color: light-dark(color-mix(in srgb, var(--primary), #000 50%), color-mix(in srgb, var(--primary), #fff 75%));
+
+  // Disabled content is exempt from WCAG, but the default 40% alpha is
+  // illegible; keep it visibly dimmed yet readable.
+  --disabled-color: #{color-transparent(var(--body-color), 0.6)};
+
+  // Full-opacity focus ring instead of the default 25% glow
+  --focus-ring-color: light-dark(var(--primary), color-mix(in srgb, var(--primary), #fff 40%));
+
+  // Raw primary sits below 3:1 on dark surfaces, so primary UI gets a tinted
+  // variant there — with dark text to keep 4.5:1 on buttons. Compile-time
+  // values: a runtime `data-bs-theme-primary` accent still overrides these
+  // (accessible variants of the accent palette are a follow-up).
+  --primary: light-dark(#{$primary}, #{tint-color($primary, 40%)});
+  --primary-fg: light-dark(var(--light), var(--gray-950));
+}
+
+@if $enable-contrast-mode {
+  [data-bs-theme-contrast='high'],
+  [data-theme-contrast='high'] {
+    @include theme-contrast-high();
+  }
+
+  @media (prefers-contrast: more) {
+    :root:not([data-bs-theme-contrast]):not([data-theme-contrast]) {
+      @include theme-contrast-high();
+    }
+  }
+}

--- a/shared/components/demo/ThemeSettings.astro
+++ b/shared/components/demo/ThemeSettings.astro
@@ -7,6 +7,7 @@ import { site } from '@shared/lib/site'
 const defaults = {
   'theme': 'light',
   'theme-base': 'gray',
+  'theme-contrast': 'auto',
   'theme-font': 'sans-serif',
   'theme-primary': 'blue',
   'theme-radius': '1',
@@ -35,6 +36,21 @@ const defaults = {
                 <div class="form-selectgroup-item">
                   <input type="radio" name="theme" value={mode} class="form-check-input" checked={mode === defaults.theme} />
                   <div class="form-check-label">{mode.charAt(0).toUpperCase() + mode.slice(1)}</div>
+                </div>
+              </label>
+            ))
+          }
+        </fieldset>
+
+        <fieldset class="border-0 p-0 mb-4">
+          <legend class="form-label float-none mb-0" style="font-size: inherit;">Contrast</legend>
+          <FormHint as="p">Increase contrast for better readability. Auto follows your system setting.</FormHint>
+          {
+            ['auto', 'normal', 'high'].map((contrast) => (
+              <label class="form-check">
+                <div class="form-selectgroup-item">
+                  <input type="radio" name="theme-contrast" value={contrast} class="form-check-input" checked={contrast === defaults['theme-contrast']} />
+                  <div class="form-check-label">{contrast.charAt(0).toUpperCase() + contrast.slice(1)}</div>
                 </div>
               </label>
             ))

--- a/shared/layouts/BaseLayout.astro
+++ b/shared/layouts/BaseLayout.astro
@@ -145,6 +145,7 @@ const libJsFiles = (head: boolean) => pageLibEntries.filter(([, lib]) => Boolean
         var themeConfig = {
           'theme': 'light',
           'theme-base': 'gray',
+          'theme-contrast': 'auto',
           'theme-font': 'sans-serif',
           'theme-primary': 'blue',
           'theme-radius': '1',


### PR DESCRIPTION
## Summary

- Adds a new theme axis: `data-bs-theme-contrast="high"` (alias `data-theme-contrast`) raises text contrast to WCAG AAA (7:1) and borders, icons and focus to 3:1, in both light and dark color modes.
- The mode also turns on by itself when the OS asks for more contrast (`prefers-contrast: more`). Setting the attribute opts out of the automatic behavior. A new `$enable-contrast-mode` Sass flag can disable the feature.
- Adds a **Contrast** setting (Auto / Normal / High) to the Theme Settings panel, wired through `tabler-theme.js` and the offcanvas script, so it persists in `localStorage` and works as a `?theme-contrast=…` URL param.
- Adds `.build/check-contrast.ts` (`pnpm run css-check-contrast` in `core`): it compiles `tabler.scss`, resolves `var()` / `light-dark()` / `color-mix()` chains like a browser, and checks the contrast of token pairs in all four color-mode × contrast combinations. High-contrast failures exit non-zero; default-theme shortfalls are warnings only.

## Preview

- **URL:** [preview link](https://tabler-git-high-contrast-mode-tabler-io.vercel.app/)
- **How to test:** open any page, open **Theme Settings** and set **Contrast** to *High* — text gets darker (lighter in dark mode) and borders get stronger; combine it with the dark color mode. `?theme-contrast=high` in the URL does the same. *Auto* follows the OS "Increase contrast" setting, *Normal* opts out of it. You can also run `pnpm --dir core run css-check-contrast` and check that the high-contrast profiles report no errors.

## Notes / rollout

- The default theme is untouched. The check script surfaces an existing issue as warnings: links in the default dark mode are below AA (2.9–3.6:1); a separate fix is planned.
- A runtime `data-bs-theme-primary` accent still overrides the high-contrast primary; accessible accent variants and a docs page are follow-ups.
