### PR TITLE
Remove leftover `squircle-radius()` dead code from border-radius mixin

### DIFF
--- a/.changeset/fix-squircle-multi-value-border-radius.md
+++ b/.changeset/fix-squircle-multi-value-border-radius.md
@@ -1,5 +1,0 @@
----
-"@tabler/core": patch
----
-
-Fixed multi-value `border-radius` squircle scaling in `border-radius()` by scaling each corner value separately.

--- a/core/scss/mixins/bootstrap/_border-radius.scss
+++ b/core/scss/mixins/bootstrap/_border-radius.scss
@@ -22,28 +22,9 @@
   @return $return;
 }
 
-@function squircle-radius($radius) {
-  $return: ();
-  @each $value in valid-radius($radius) {
-    @if $value == 0 {
-      $return: list.append($return, 0);
-    } @else {
-      $return: list.append($return, calc(#{$value} * 2.5));
-    }
-  }
-  @return $return;
-}
-
 @mixin border-radius($radius: $border-radius, $fallback-border-radius: false) {
   @if $enable-rounded {
     border-radius: valid-radius($radius);
-
-    // @if $radius != 0 {
-    //   @supports (corner-shape: squircle) {
-    //     corner-shape: squircle;
-    //     border-radius: squircle-radius($radius) !important;
-    //   }
-    // }
   } @else if $fallback-border-radius != false {
     border-radius: $fallback-border-radius;
   }

--- a/core/scss/tests/_border-radius.test.scss
+++ b/core/scss/tests/_border-radius.test.scss
@@ -21,13 +21,3 @@
     @include assert-equal(meta.inspect(valid-radius(4px -2px 6px)), '4px 0 6px');
   }
 }
-
-@include describe('squircle-radius') {
-  @include it('keeps 0 as 0') {
-    @include assert-equal(meta.inspect(squircle-radius(0)), '0');
-  }
-
-  @include it('scales a non-zero radius by 2.5 via calc()') {
-    @include assert-equal(meta.inspect(squircle-radius(4px)), 'calc(4px * 2.5)');
-  }
-}


### PR DESCRIPTION
## Summary

- Removed the unused `squircle-radius()` Sass function from `_border-radius.scss`. It was never wired into a shipped feature.
- Removed the commented-out `@supports (corner-shape: squircle)` block that referenced it.
- Removed the squircle unit tests in `_border-radius.test.scss`.
- Removed the orphaned changeset `fix-squircle-multi-value-border-radius.md`, which described a fix for code that was never released.

## Preview

- **How to test:** Read the diff in `core/scss/mixins/bootstrap/_border-radius.scss` and `core/scss/tests/_border-radius.test.scss`. Run `pnpm test` (or `pnpm run test:scss`) and confirm the remaining `border-radius` tests still pass. Run `grep -ri squircle -r .` and confirm no code references remain.

## Notes / rollout

- Dead code removal only, no public API was ever shipped for squircle corners, so no changeset is needed.
- Closes #2889