### PR TITLE
Fix print styles for navbar, dark mode, cards and tables; document printing

### DIFF
--- a/.changeset/add-printing-docs.md
+++ b/.changeset/add-printing-docs.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": minor
+---
+
+Added a Printing docs page covering `d-print-*` utilities and the `media-print` mixin.

--- a/.changeset/fix-print-styles.md
+++ b/.changeset/fix-print-styles.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed print styles: hidden navbar/sidebar, forced light `color-scheme`, and avoided breaking `.card`/table rows.

--- a/core/scss/layout/_dark.scss
+++ b/core/scss/layout/_dark.scss
@@ -48,4 +48,15 @@
   // The global `@extend [data-bs-theme='dark']` for light-scoped subtrees
   // inside a dark body lives in `_extends.scss` — with the module system it
   // must have every dark-styling module upstream.
+
+  // Printing a dark page wastes ink/toner and can leave near-white text on
+  // paper, since browsers skip background colors in print by default. Force
+  // every light-dark() token back to its light value regardless of theme.
+  @include media-print() {
+    :root,
+    [data-bs-theme='dark'],
+    [data-theme='dark'] {
+      color-scheme: light !important;
+    }
+  }
 }

--- a/core/scss/layout/_navbar.scss
+++ b/core/scss/layout/_navbar.scss
@@ -97,6 +97,10 @@ Navbar
   background: var(--navbar-bg);
   box-shadow: inset 0 calc(-1 * var(--navbar-border-width)) 0 0 var(--navbar-border-color);
 
+  @include media-print() {
+    display: none;
+  }
+
   .navbar-collapse & {
     flex-grow: 1;
   }
@@ -389,6 +393,13 @@ Navbar vertical
           }
         }
       }
+    }
+  }
+
+  @include media-print() {
+    .navbar-vertical ~ .page {
+      padding-inline-start: 0;
+      padding-inline-end: 0;
     }
   }
 }

--- a/core/scss/ui/_cards.scss
+++ b/core/scss/ui/_cards.scss
@@ -24,6 +24,7 @@
   @include media-print() {
     border: none;
     box-shadow: none;
+    break-inside: avoid;
   }
 
   @at-root a#{&} {

--- a/core/scss/ui/_tables.scss
+++ b/core/scss/ui/_tables.scss
@@ -3,6 +3,16 @@
 .table {
   font: inherit;
 
+  @include media-print() {
+    thead {
+      display: table-header-group;
+    }
+
+    tr {
+      break-inside: avoid;
+    }
+  }
+
   thead {
     th {
       padding-top: $table-th-padding-y;

--- a/docs/content/ui/utilities/printing.mdx
+++ b/docs/content/ui/utilities/printing.mdx
@@ -1,0 +1,102 @@
+---
+title: Printing
+summary: Print-friendly styles that hide navigation, keep pages in light colors, and control page breaks.
+description: Learn what Tabler hides when a page is printed, the d-print-* utilities, and the media-print mixin for custom print styles.
+related: [/ui/layout/page-layouts, /ui/layout/navbars]
+---
+import Example from '@components/Example.astro';
+
+Tabler adjusts its styles automatically when a page is printed, so you don't get a printout full of navigation bars, buttons, and dark backgrounds. This page explains what changes on print, and how to write your own print-only styles.
+
+## What gets hidden on print
+
+Elements that only make sense on screen are hidden with `display: none` when the page is printed. This includes:
+
+- The navbar, both the top navbar and the vertical (sidebar) navbar
+- The footer
+- Page header actions, such as buttons and dropdowns next to the page title
+- Dropdowns, popovers, and toasts
+- Modals and offcanvas panels
+- Pagination
+- Close buttons
+- The floating action toolbar
+
+You don't need to add anything for these to work — they're built into the component styles. For example, the navbar in a default layout already has this rule, so it disappears on print without any extra class:
+
+```html
+<header class="navbar navbar-expand-md">...</header>
+```
+
+If you build your own layout elements and want them hidden on print too, add the [`.d-print-none`](#print-utilities) utility class, or use the [`media-print` mixin](#the-media-print-mixin) in your own SCSS.
+
+## Dark mode on print
+
+If dark mode is active, Tabler still prints the page in light colors. Dark backgrounds waste ink and toner, and browsers skip background colors by default when printing, which can leave low-contrast, near-white text on a white page. Forcing light colors keeps printed pages readable no matter which theme a visitor had selected.
+
+## Tables and cards
+
+Tables and cards get a few adjustments so they print well over multiple pages:
+
+- A table's `<thead>` repeats at the top of every printed page.
+- A table row never splits across a page break.
+- A card never splits across a page break — it either fits fully on one page or starts on the next one.
+- Cards lose their border and shadow when printed, since these don't add anything on paper.
+
+## Print utilities
+
+Tabler generates `d-print-*` classes to show or hide any element only when the page is printed, the same way [display utilities](/ui/utilities) work on screen.
+
+Class|`display` value used on print
+-|-
+`d-print-none`|`none`
+`d-print-inline`|`inline`
+`d-print-inline-block`|`inline-block`
+`d-print-block`|`block`
+`d-print-grid`|`grid`
+`d-print-inline-grid`|`inline-grid`
+`d-print-table`|`table`
+`d-print-table-row`|`table-row`
+`d-print-table-cell`|`table-cell`
+`d-print-flex`|`flex`
+`d-print-inline-flex`|`inline-flex`
+
+`.d-print-none` is the one you'll use most — add it to anything that shouldn't appear on a printout, like a "Search" box or an "Edit" button:
+
+<Example>
+<div class="d-print-none"> <span class="badge bg-blue-lt">Hidden on print</span> </div>
+</Example>
+
+The other `d-print-*` classes work the other way around: pair them with a screen-only display utility (such as `.d-none`) to show something only when the page is printed:
+
+```html
+<div class="d-none d-print-block">This text only shows up when the page is printed.</div>
+```
+
+## The `media-print` mixin
+
+When customizing Tabler's SCSS, use the `media-print` mixin instead of writing `@media print` by hand. It lives in `core/scss/mixins/_mixins.scss`:
+
+```scss
+@mixin media-print {
+  @media print {
+    @content;
+  }
+}
+```
+
+Use it inside a component or layout rule to add print-only styles next to the rest of the component's SCSS:
+
+```scss
+.my-widget {
+  border: var(--border-width) var(--border-style) var(--border-color);
+
+  @include media-print() {
+    border: none;
+    box-shadow: none;
+  }
+}
+```
+
+## Accessibility
+
+Hiding navigation and interactive controls on print doesn't affect screen readers or keyboard users — it only applies inside the `print` media type, so the page works exactly as before on screen. Keep enough contrast in any custom print styles you add: printed pages can't rely on color alone, since some printers output in black and white.

--- a/docs/content/ui/utilities/printing.mdx
+++ b/docs/content/ui/utilities/printing.mdx
@@ -72,7 +72,7 @@ The other `d-print-*` classes work the other way around: pair them with a screen
 <div class="d-none d-print-block">This text only shows up when the page is printed.</div>
 ```
 
-## The `media-print` mixin
+## The media-print mixin
 
 When customizing Tabler's SCSS, use the `media-print` mixin instead of writing `@media print` by hand. It lives in `core/scss/mixins/_mixins.scss`:
 

--- a/shared/data/docs.json
+++ b/shared/data/docs.json
@@ -441,6 +441,10 @@
 							"url": "/ui/utilities/margins"
 						},
 						{
+							"title": "Printing",
+							"url": "/ui/utilities/printing"
+						},
+						{
 							"title": "Vertical align",
 							"url": "/ui/utilities/vertical-align"
 						},


### PR DESCRIPTION
## Summary

- Hid the top navbar and the vertical/side navbar (`.navbar`) on print — the second nav-links bar had no `d-print-none` and used to print on every page, and the fixed sidebar overlapped content.
- Reset the `.page` padding left for the vertical navbar so content fills the page once the sidebar is hidden on print.
- Forced `color-scheme: light` on print in `layout/_dark.scss`, so dark mode pages print with light, readable colors instead of near-white text on white paper.
- Kept `.table` `<thead>` repeating on every printed page and stopped table rows and `.card` elements from breaking across a page boundary.
- Added a "Printing" docs page under Utilities, covering hidden elements, the `d-print-*` classes, and the `media-print` mixin.

## Preview

- **URL:** [invoice.html](https://tabler-git-fix-print-styles-and-documentation-tabler-io.vercel.app/invoice.html), [layout-vertical.html](https://tabler-git-fix-print-styles-and-documentation-tabler-io.vercel.app/layout-vertical.html), [tables.html](https://tabler-git-fix-print-styles-and-documentation-tabler-io.vercel.app/tables.html), [docs: Printing](https://tabler-docs-git-fix-print-styles-and-documentation-tabler-io.vercel.app/ui/utilities/printing)
- **How to test:** Open any of the pages above, then use the browser's print preview (`Cmd+P` / `Ctrl+P`). Check that the navbar/sidebar is gone, colors stay light even with dark mode toggled on, and long tables repeat their header on later pages. On `layout-vertical.html`, confirm the content isn't shifted right after the sidebar disappears.

## Notes / rollout

Closes #2890