### PR TITLE
Load the sponsors image from GitHub instead of jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A premium and open source dashboard template with a responsive and high-quality 
 
 <p align="center">
 	<a href="https://github.com/sponsors/codecalm">
-		<img src="https://cdn.jsdelivr.net/gh/tabler/sponsors@latest/sponsors.svg" alt="Tabler sponsors">
+		<img src="https://raw.githubusercontent.com/tabler/sponsors/main/sponsors.svg" alt="Tabler sponsors">
 	</a>
 </p>
 


### PR DESCRIPTION
## Summary

- The sponsors banner in the README now loads from `raw.githubusercontent.com/tabler/sponsors/main/sponsors.svg` instead of the jsDelivr mirror.
- jsDelivr's `@latest` tag pins to the last tagged release of `tabler/sponsors` and caches it, so new sponsors could take a long time to show up. The raw URL always serves the current file from the default branch.
- GitHub serves the file as `image/svg+xml`, so it still renders inside `<img>`.

**How to review:** open the README on this branch and check that the sponsors image loads.
