### PR TITLE
Use npm trusted publishing (OIDC) in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,10 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to create release 
+      contents: write # to create release
       issues: write # to post issue comments
       pull-requests: write # to create pull request
+      id-token: write # for npm trusted publishing (OIDC)
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v7
@@ -31,6 +32,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+
+      - name: Update npm # trusted publishing requires npm >= 11.5.1
+        run: npm install -g npm@latest
 
       - name: Install Dependencies
         run: pnpm install
@@ -47,5 +51,3 @@ jobs:
           title: "chore: update versions"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Switch npm publishing in the release workflow to trusted publishing (OIDC). The workflow no longer needs the `NPM_TOKEN` secret.
- Add `id-token: write` permission so the job can get an OIDC token from GitHub.
- Update npm to the latest version before publish. Trusted publishing needs npm 11.5.1 or newer, and `changeset publish` uses the global npm. npm also adds provenance to the published package.
- Remove `NPM_TOKEN` and `NODE_AUTH_TOKEN` from the publish step env.

## Preview

- No visual changes. Review the diff in `.github/workflows/release.yml`.

## Notes / rollout

- Before merge: add a trusted publisher for `@tabler/core` on npmjs.com (GitHub Actions, org `tabler`, repo `tabler`, workflow `release.yml`, no environment). Without it, the next publish will fail.
- Keep the `NPM_TOKEN` secret until the first OIDC publish works. After that, it can be removed.