### PR TITLE
Raise bundlewatch limits for `tabler-payments` CSS

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -132,19 +132,19 @@
       },
       {
         "path": "./dist/css/tabler-payments.css",
-        "maxSize": "2.4 kB"
+        "maxSize": "3.5 kB"
       },
       {
         "path": "./dist/css/tabler-payments.min.css",
-        "maxSize": "2.1 kB"
+        "maxSize": "3.25 kB"
       },
       {
         "path": "./dist/css/tabler-payments.rtl.css",
-        "maxSize": "2.4 kB"
+        "maxSize": "3.5 kB"
       },
       {
         "path": "./dist/css/tabler-payments.rtl.min.css",
-        "maxSize": "2.1 kB"
+        "maxSize": "3.25 kB"
       },
       {
         "path": "./dist/css/tabler-props.css",


### PR DESCRIPTION
## Summary

- Raise the bundlewatch `maxSize` for the four `tabler-payments` CSS bundles from 2.4 kB / 2.1 kB to 3.5 kB / 3.25 kB (gzip).
- The bundles grew to 3.08 kB / 2.8 kB after #2909 synced the full icon set from `tabler/tabler-payments`, so the Bundlewatch check now fails on every push to `dev`.
- No changeset: this only changes a CI size limit, not the published package.

## Preview

- No visual changes. Review the four `maxSize` values in `core/package.json`; `pnpm --filter @tabler/core bundlewatch` passes locally with the new limits.