### PR TITLE
Show the ApexCharts license note as a callout

### DIFF
--- a/docs/content/ui/plugins/chart.mdx
+++ b/docs/content/ui/plugins/chart.mdx
@@ -37,7 +37,9 @@ ApexCharts draws with its own default colors, grid and tooltip. Tabler restyles 
 
 ### License
 
-Tabler is MIT licensed, but ApexCharts is not. From version 5 on it is dual-licensed: free under its Community license for organizations under $2 million in annual revenue, paid above that, with a separate OEM license for redistributing it inside a product you ship to others.
+<Warning title="Tabler is MIT licensed, ApexCharts is not">
+  From version 5 on ApexCharts is dual-licensed: free under its Community license for organizations under $2 million in annual revenue, paid above that, with a separate OEM license for redistributing it inside a product you ship to others.
+</Warning>
 
 Tabler bundles the built file in `dist/libs` so the examples work out of the box, but the license stays with ApexCharts. Read the [ApexCharts license options](https://apexcharts.com/license/) before you use charts in a commercial product.
 


### PR DESCRIPTION
## Summary

- Turns the ApexCharts license note on the chart page into a `Warning` callout. The note is the one thing on that page a reader must not miss, and it read as an ordinary paragraph between two install steps.

Follow-up to #2915, which added the License section, and #2916, which added the callouts. Both are merged, so this is now a one-paragraph change.

## Preview

- **URL:** [chart plugin page](https://tabler-docs-git-chart-license-callout-tabler-io.vercel.app/ui/plugins/chart)
- **How to test:** open the Installation section. The license note renders as a yellow callout with the warning icon, and the sentence about `dist/libs` stays as prose under it.

## Notes / rollout

- No changeset: both features are still unreleased, and their own changesets already describe them.
