### PR TITLE
Fix unreadable links in important alerts and the sign-in cover page

### DIFF
--- a/.changeset/alerts-important-action-example.md
+++ b/.changeset/alerts-important-action-example.md
@@ -1,0 +1,6 @@
+---
+"@tabler/preview": patch
+"@tabler/docs": patch
+---
+
+Added `action` and `link` examples to the important alerts in the alerts preview and docs pages.

--- a/.changeset/fix-alert-important-links.md
+++ b/.changeset/fix-alert-important-links.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed `.alert-action` and `.alert-link` colors inside `.alert-important` so links stay readable.

--- a/.changeset/fix-sign-in-cover-dark-mode.md
+++ b/.changeset/fix-sign-in-cover-dark-mode.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": patch
+---
+
+Fixed the sign-in cover page in dark mode by replacing `bg-white` with `bg-surface`.

--- a/core/scss/ui/_alerts.scss
+++ b/core/scss/ui/_alerts.scss
@@ -81,14 +81,13 @@
 }
 
 .alert-important {
-  color: var(--white);
+  // Set the shared color token so every child that reads it - text, icon,
+  // `.alert-action`, `.alert-link` - flips to white instead of the variant
+  // color, which is the background here.
+  --alert-color: var(--white);
   background-color: var(--alert-variant-color);
 
   .alert-description {
-    color: inherit;
-  }
-
-  .alert-icon {
     color: inherit;
   }
 }

--- a/docs/content/ui/components/alert.mdx
+++ b/docs/content/ui/components/alert.mdx
@@ -284,6 +284,12 @@ You can also use other elements, like icons and dismissible buttons, with this t
 </div>
 </Example>
 
+Links work here too. Both `alert-link` and `alert-action` follow the alert color, so they turn white on the solid background.
+
+<Example>
+<Alert variant="important" color="danger" title="An error occurred!" action="Try again" /> <Alert variant="important" color="info" title="Your plan renews next week." link="See the details" />
+</Example>
+
 ## Custom alert color
 
 You're not limited to the 4 default alert colors. You can use any [base color](/ui/base/colors) you want.

--- a/preview/pages/alerts.astro
+++ b/preview/pages/alerts.astro
@@ -69,6 +69,8 @@ import DocsLink from '@ui/DocsLink.astro'
           <Alert showClose variant="important" color="success" title="This is a custom alert box!" description="This is a custom alert box with a description." />
           <Alert showClose variant="important" color="warning" title="This is a custom alert box!" description="This is a custom alert box with a description." />
           <Alert showClose variant="important" color="info" title="This is a custom alert box!" description="This is a custom alert box with a description." />
+          <Alert showClose variant="important" action="Link" color="danger" title="An error occurred!" />
+          <Alert showClose variant="important" link="Link" color="info" title="Just a quick note!" />
         </CardBody>
       </Card>
     </div>

--- a/preview/pages/sign-in-cover.astro
+++ b/preview/pages/sign-in-cover.astro
@@ -8,7 +8,7 @@ import photos from '@data/photos.json'
 import { requireIndex } from '@shared/lib/array'
 ---
 
-<BaseLayout title="Sign in with cover" bodyClass="d-flex flex-column bg-white">
+<BaseLayout title="Sign in with cover" bodyClass="d-flex flex-column bg-surface">
   <main id="content" class="row g-0 flex-fill">
     <div class="col-12 col-lg-6 col-xl-4 border-top-wide border-primary d-flex flex-column justify-content-center">
       <div class="container container-tight my-5 px-lg-5">


### PR DESCRIPTION
## Summary

- `.alert-important` now overrides the `--tblr-alert-color` token instead of setting `color` directly, so `.alert-action` and `.alert-link` no longer render in the same color as the alert background. Fixes #2507.
- The sign-in cover page used `bg-white`, which forced a white background while the text stayed light in dark mode. It now uses `bg-surface`. Fixes #2696.
- Added examples of `action` and `link` on important alerts to the alerts preview page and the alerts docs page. Neither showed this combination, which is why the bug went unnoticed.

## Preview

- **URL:** [alerts preview](https://tabler-git-fix-alert-important-links-signin-cover-tabler-io.vercel.app/alerts.html) · [sign-in cover](https://tabler-git-fix-alert-important-links-signin-cover-tabler-io.vercel.app/sign-in-cover.html) · [alerts docs](https://tabler-docs-h2mdvdt8u-tabler-io.vercel.app/ui/components/alert)
- **How to test:** On the alerts preview page, open the "Important" card. The last two alerts have a link - both should be white and readable on the solid background. Then open the sign-in cover page and switch to dark mode; the form labels should stay readable, and light mode should look unchanged.

## Notes / rollout

- `.alert-important` no longer needs its own `.alert-icon` override, so the rule set is one declaration shorter. No class names or markup changed.
- Closes #2507, closes #2696.
