### PR TITLE
Fix missing focus ring on all buttons and button groups

### DIFF
--- a/.changeset/fix-button-focus-ring.md
+++ b/.changeset/fix-button-focus-ring.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed the missing focus ring on buttons and `btn-check` button groups by using the shared focus ring token.

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -1118,14 +1118,13 @@ $btn-border-width: $input-btn-border-width !default;
 
 $btn-font-weight: var(--font-weight-medium) !default;
 $btn-box-shadow: var(--shadow-input) !default;
-$btn-focus-width: $input-btn-focus-width !default;
+$btn-focus-box-shadow: $focus-ring-box-shadow !default;
 $btn-disabled-opacity: 0.4 !default;
 $btn-active-box-shadow: inset 0 3px 5px rgba($black, 0.125) !default;
 
 $btn-link-color: var(--link-color) !default;
 $btn-link-hover-color: var(--link-hover-color) !default;
 $btn-link-disabled-color: $gray-600 !default;
-$btn-link-focus-shadow-rgb: to-rgb(color.mix(color-contrast($link-color), $link-color, 15%)) !default;
 
 $btn-border-radius: var(--border-radius) !default;
 $btn-border-radius-sm: var(--border-radius-sm) !default;

--- a/core/scss/bootstrap/_buttons.scss
+++ b/core/scss/bootstrap/_buttons.scss
@@ -20,7 +20,10 @@
   --btn-hover-border-color: transparent;
   --btn-box-shadow: #{$btn-box-shadow};
   --btn-disabled-opacity: #{$btn-disabled-opacity};
-  --btn-focus-box-shadow: 0 0 0 #{$btn-focus-width} rgba(var(--btn-focus-shadow-rgb), 0.5);
+  // Zero-size shadow, not `none`: the active state is combined with the focus
+  // ring in one `box-shadow` list, where `none` would negate every other shadow
+  --btn-active-shadow: 0 0 0 #000;
+  --btn-focus-box-shadow: #{$btn-focus-box-shadow};
   // scss-docs-end btn-css-vars
 
   display: inline-block;
@@ -172,7 +175,6 @@
   --btn-disabled-color: #{$btn-link-disabled-color};
   --btn-disabled-border-color: transparent;
   --btn-box-shadow: 0 0 0 #000; // Can't use `none` as keyword negates all values when used with multiple shadows
-  --btn-focus-shadow-rgb: #{$btn-link-focus-shadow-rgb};
 
   text-decoration: $link-decoration;
   @if $enable-gradients {


### PR DESCRIPTION
## Summary

- `--tblr-btn-focus-box-shadow` was built from `--tblr-btn-focus-shadow-rgb`, which is only defined for `.btn-link`. Everywhere else the `rgba()` call was invalid, so the browser dropped the whole `box-shadow` declaration and no button had a visible focus ring. It now uses the shared `$focus-ring-box-shadow`, the same token as inputs, nav links, pagination and form checks.
- `--tblr-btn-active-shadow` was only set by `.btn-ghost-*`. The checked-and-focused rule combines it with the focus ring in one shadow list, so a checked `.btn-check` in a button group lost the ring as well. The base `.btn` now defines it as a zero-size shadow. Fixes #2662.
- Dropped `$btn-focus-width` and `$btn-link-focus-shadow-rgb`, which no longer have a consumer.

## Preview

- **URL:** [buttons](https://tabler-git-fix-button-focus-ring-tabler-io.vercel.app/buttons.html) · [form elements](https://tabler-git-fix-button-focus-ring-tabler-io.vercel.app/form-elements.html)
- **How to test:** Tab through the buttons page - every button should show a blue ring, in light and dark mode. On the form elements page, tab into the "Buttons group" radio group; the focused option should be clearly marked, including the one that is already selected.

## Notes / rollout

- The ring now follows `--tblr-primary` at runtime, so it tracks the theme color picker. The old value was compiled from the Sass `$link-color` and could not.
- `$btn-focus-width` and `$btn-link-focus-shadow-rgb` are gone. Anyone overriding those two Sass variables should switch to `$focus-ring-width` and `$btn-focus-box-shadow`.
