### PR TITLE
Fix card status strips over the card border, build RTL css in dev

### DIFF
--- a/.changeset/dev-rtl-css.md
+++ b/.changeset/dev-rtl-css.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Updated the dev CSS build to also emit the `.rtl.css` files, so the RTL preview page is styled in dev.

--- a/.changeset/fix-card-status-border.md
+++ b/.changeset/fix-card-status-border.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed the `card-status-*` strips leaving a thin line over the card border and a mismatched corner radius.

--- a/core/package.json
+++ b/core/package.json
@@ -10,7 +10,7 @@
     "build-assets": "concurrently \"pnpm run css\" \"pnpm run js\"",
     "clean": "shx rm -rf dist demo",
     "css": "tsx ../.build/build-css.ts scss dist/css --rtl --minify --banner",
-    "css-build": "tsx ../.build/build-css.ts scss dist/css",
+    "css-build": "tsx ../.build/build-css.ts scss dist/css --rtl",
     "css-lint": "pnpm run lint:scss && pnpm run css-lint-variables",
     "lint:scss": "stylelint \"scss/**/*.scss\" --config ../stylelint.config.mjs",
     "lint:scss:fix": "pnpm run lint:scss --fix",

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -1247,6 +1247,8 @@ $card-img-overlay-padding: $spacer !default;
 $card-group-margin: 1.5rem !default;
 
 $card-status-size: 3px !default;
+// The strip sits on top of the card border, so it is pulled out by the border width
+$card-status-offset: calc(-1 * var(--card-border-width)) !default;
 
 $card-stamp-opacity: 0.2 !default;
 

--- a/core/scss/ui/_cards.scss
+++ b/core/scss/ui/_cards.scss
@@ -425,27 +425,29 @@ Card status
  */
 .card-status-top {
   position: absolute;
-  inset-inline-start: 0;
-  inset-inline-end: 0;
-  top: 0;
+  inset-inline-start: $card-status-offset;
+  inset-inline-end: $card-status-offset;
+  top: $card-status-offset;
   height: $card-status-size;
   @include border-radius(var(--card-border-radius) var(--card-border-radius) 0 0);
 }
 
 .card-status-start {
   position: absolute;
+  inset-inline-start: $card-status-offset;
   inset-inline-end: auto;
-  bottom: 0;
+  top: $card-status-offset;
+  bottom: $card-status-offset;
   width: $card-status-size;
-  height: 100%;
   @include border-radius(var(--card-border-radius) 0 0 var(--card-border-radius));
 }
 
 .card-status-bottom {
   position: absolute;
+  inset-inline-start: $card-status-offset;
+  inset-inline-end: $card-status-offset;
   top: initial;
-  bottom: 0;
-  width: 100%;
+  bottom: $card-status-offset;
   height: $card-status-size;
   @include border-radius(0 0 var(--card-border-radius) var(--card-border-radius));
 }


### PR DESCRIPTION
## Summary

- `card-status-top`, `card-status-bottom` and `card-status-start` sat inside the card border, so the border showed through above the strip as a thin line and the corner radius did not match. They are now pulled out by the card border width and cover it. Fixes #2703.
- The dev CSS build did not pass `--rtl`, so `tabler.rtl.css` and the other RTL stylesheets never existed in dev. The RTL preview page asks for them, so it rendered with no styles at all. `css-build` now passes `--rtl`. Fixes #2422.

## Preview

- **URL:** [cards](https://tabler-git-fix-card-status-border-and-dev-rtl-tabler-io.vercel.app/cards.html) · [navbar overlap layout](https://tabler-git-fix-card-status-border-and-dev-rtl-tabler-io.vercel.app/layout-navbar-overlap.html) · [RTL mode](https://tabler-git-fix-card-status-border-and-dev-rtl-tabler-io.vercel.app/layout-rtl.html)
- **How to test:** On the cards page, look at the cards with a colored status strip - the strip should reach the card edge on every side, with the same rounding as the card. The navbar overlap layout shows the old bug best: a card with `card-status-top` over the dark navbar had a light line above the strip.

## Notes / rollout

- Adding `--rtl` to the dev build costs about 10% (2.0s to 2.2s on a warm run). It does not re-run Sass; it only adds the rtlcss pass over the compiled result, so the watcher can keep it on.
- `$card-status-offset` is a new Sass variable. The strips no longer set `width: 100%` / `height: 100%`; their size comes from the insets.
