### PR TITLE
Keep the docs header sticky and the table of contents clear of it

### DIFF
--- a/.changeset/docs-sticky-header.md
+++ b/.changeset/docs-sticky-header.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Fixed the docs header not staying sticky, and the table of contents sliding under it.

--- a/docs/components/DocsNavbar.astro
+++ b/docs/components/DocsNavbar.astro
@@ -13,7 +13,7 @@ const changelogUrl = 'https://tabler.io/changelog'
 ---
 
 <!-- BEGIN DOCS NAVBAR -->
-<nav class="navbar navbar-expand sticky-top" aria-label="Docs">
+<nav class="navbar navbar-expand" aria-label="Docs">
   <div class="container-lg">
     <div class="d-flex align-items-center flex-fill gap-2">
       <button type="button" class="btn btn-icon btn-ghost-secondary d-lg-none" data-bs-toggle="offcanvas" data-bs-target="#docs-menu-offcanvas" aria-controls="docs-menu-offcanvas" aria-label="Open documentation menu">

--- a/docs/layouts/DocsLayout.astro
+++ b/docs/layouts/DocsLayout.astro
@@ -318,7 +318,7 @@ const relatedPages = await Promise.all(
 		</script>
 		<!-- END GLOBAL THEME SCRIPT -->
 		<!-- BEGIN NAVBAR  -->
-		<header role="banner">
+		<header role="banner" class="sticky-top">
 			<DocsNavbar />
 		</header>
 		<!-- END NAVBAR  -->
@@ -476,7 +476,7 @@ const relatedPages = await Promise.all(
 					</div>
 					<!-- BEGIN DOCS TOC -->
 					<div class="col-2 d-none d-xxl-block">
-						<div class="py-5 sticky-top">
+						<div class="py-5 sticky-top docs-toc-sticky">
 							<DocsToc toc={toc} editUrl={`${site.githubUrl}/edit/dev/${editFilePath}`} sourceUrl={sourcePath ? `${site.githubUrl}/blob/dev/${sourcePath}` : undefined} markdownUrl={markdownUrl} />
 						</div>
 					</div>

--- a/docs/scss/docs.scss
+++ b/docs/scss/docs.scss
@@ -579,3 +579,31 @@ header > .navbar {
     }
   }
 }
+
+//
+// Sticky header
+//
+// `position: sticky` only travels inside its containing block. The docs shell
+// has no `.page` wrapper - the header is a child of `body` - and core's
+// `body { height: 100% }` makes that block exactly one viewport tall, so the
+// header would unstick after the first screen (#2332). Let the docs body grow
+// with its content instead; `.page` does the same thing for the app layouts.
+body {
+  height: auto;
+  min-height: 100%;
+}
+
+:root {
+  // Matches `$navbar-height` in core - the height of the docs navbar.
+  --docs-header-height: 3.5rem;
+}
+
+// Anchors from the table of contents would otherwise land under the header.
+html {
+  scroll-padding-top: var(--docs-header-height);
+}
+
+// The table of contents sticks too, so it has to clear the header (#2421).
+.docs-toc-sticky {
+  top: var(--docs-header-height);
+}


### PR DESCRIPTION
## Summary

- The docs navbar carried `sticky-top`, but it sat inside a `<header>` exactly as tall as itself, so it had nowhere to travel and scrolled away with the page. `sticky-top` moves to the `<header>`, and the docs body is allowed to grow with its content - core's `body { height: 100% }` otherwise caps every sticky child at one viewport. Fixes #2332.
- With the header actually sticking, the table of contents parked under it. It now offsets by the header height, and `scroll-padding-top` keeps anchor links from landing behind the header too. Fixes #2421.

## Preview

- **URL:** [installation page](https://tabler-docs-ezehkzzy9-tabler-io.vercel.app/ui/getting-started/installation)
- **How to test:** Scroll a long docs page past the first screen - the header should stay at the top the whole way. On a screen wide enough for the "On this page" rail (1400px and up), the rail should sit under the header, not behind it. Click a link in it: the heading should land just below the header, not under it.

## Notes / rollout

- This is docs-only. Core is untouched: the app layouts put their sticky navbar inside `.page`, which already grows with the content, so `sticky-top` works there. The docs shell has no `.page` wrapper, which is why only the docs header was affected.
- Measured on the branch, viewport 1440x900: the header stays at `top: 0` at scroll 0, 600, 1200 and 1800, with no overlap on the table of contents. Anchor targets land 56px from the top instead of 0. Verified at 375px too, with no horizontal scroll.
