### PR TITLE
Set the browser baseline to what the CSS actually needs

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,10 +1,14 @@
->= 0.5%
-last 2 major versions
-not dead
-Chrome >= 120
-Firefox >= 121
-iOS >= 15.6
-Safari >= 15.6
-not Explorer <= 11
-Samsung >= 23
-not kaios <= 2.5
+# Tabler's CSS uses these four with no fallback, so the floor is the first
+# release that supports all of them:
+#   light-dark()  Chrome 123, Firefox 120, Safari 17.5
+#   @property     Chrome  85, Firefox 128, Safari 16.4
+#   :has()        Chrome 105, Firefox 121, Safari 15.4
+#   color-mix()   Chrome 111, Firefox 113, Safari 16.2
+# Opera 109 and Samsung Internet 27 are the first releases built on Chromium 123.
+Chrome >= 123
+Edge >= 123
+Firefox >= 128
+Safari >= 17.5
+iOS >= 17.5
+Opera >= 109
+Samsung >= 27

--- a/.changeset/browser-support-baseline.md
+++ b/.changeset/browser-support-baseline.md
@@ -1,0 +1,6 @@
+---
+"@tabler/core": patch
+"@tabler/docs": patch
+---
+
+Updated the supported browser baseline to what the CSS needs: Chrome 123, Firefox 128, Safari 17.5.

--- a/docs/content/ui/getting-started/browser-support.mdx
+++ b/docs/content/ui/getting-started/browser-support.mdx
@@ -5,32 +5,43 @@ summary: Learn about the supported browsers and compatibility guidelines for usi
 ---
 import Example from '@components/Example.astro';
 
-Tabler is fully optimized for all modern browsers, including the latest versions of Chrome, Firefox, Edge, Safari, and Opera. These browsers ensure a seamless and responsive experience, allowing users to enjoy Tabler's advanced UI components without compatibility issues.
+Tabler runs in every current browser: Chrome, Firefox, Edge, Safari, Opera and the Chromium browsers built on them.
 
-Tabler supports browsers with at least 0.5% global usage, the last 2 major versions of each browser, and excludes dead browsers. The framework introduces modern features like CSS Grid, object fit, and sticky positioning, which enhance design flexibility but may not be fully supported on older browsers.
-
-For the best experience, we recommend using one of the latest supported browsers to take full advantage of Tabler’s capabilities and design precision.
+The minimum versions below are not a policy, they are what the CSS needs. Tabler's colors and color modes are built on `light-dark()` and `color-mix()`, and the layout uses `:has()` and `@property`. None of them have a fallback, so a browser that misses one drops those declarations and the page renders wrong - usually as missing colors. See [what sets the floor](#what-sets-the-floor) for the exact features.
 
 ## Supported browsers
 
 Browser|Minimum Version
 ---|----------
-<img src="/img/browsers/chrome.svg" width="24" height="24" alt="Chrome Logo"/>|Chrome 120+
-<img src="/img/browsers/firefox.svg" width="24" height="24" alt="Firefox Logo"/>|Firefox 121+
-<img src="/img/browsers/safari.svg" width="24" height="24" alt="Safari Logo"/>|Safari 15.6+
-<img src="/img/browsers/edge.svg" width="24" height="24" alt="Edge Logo"/>|last 2 major versions
-<img src="/img/browsers/opera.svg" width="24" height="24" alt="Opera Logo"/>|last 2 major versions
-<img src="/img/browsers/electron.svg" width="24" height="24" alt="Electron Logo"/>|last 2 major versions
-<img src="/img/browsers/brave.svg" width="24" height="24" alt="Brave Logo"/>|last 2 major versions
-<img src="/img/browsers/vivaldi.svg" width="24" height="24" alt="Vivaldi Logo"/>|last 2 major versions
+<img src="/img/browsers/chrome.svg" width="24" height="24" alt="Chrome Logo"/>|Chrome 123+
+<img src="/img/browsers/firefox.svg" width="24" height="24" alt="Firefox Logo"/>|Firefox 128+
+<img src="/img/browsers/safari.svg" width="24" height="24" alt="Safari Logo"/>|Safari 17.5+
+<img src="/img/browsers/edge.svg" width="24" height="24" alt="Edge Logo"/>|Edge 123+
+<img src="/img/browsers/opera.svg" width="24" height="24" alt="Opera Logo"/>|Opera 109+
+<img src="/img/browsers/electron.svg" width="24" height="24" alt="Electron Logo"/>|Chromium 123+
+<img src="/img/browsers/brave.svg" width="24" height="24" alt="Brave Logo"/>|Chromium 123+
+<img src="/img/browsers/vivaldi.svg" width="24" height="24" alt="Vivaldi Logo"/>|Chromium 123+
 
 ## Mobile browsers
 
 Browser|Minimum Version
 ---|----------
-iOS Safari|iOS 15.6+
-Samsung Internet|Samsung 23+
+iOS Safari|iOS 17.5+
+Samsung Internet|Samsung 27+
+
+## What sets the floor
+
+Each row is the first version that supports the feature. The highest number in a column becomes the minimum for that browser.
+
+Feature|Used for|Chrome|Firefox|Safari
+---|---|---|---|---
+`light-dark()`|Every color that differs between light and dark mode|123|120|17.5
+`@property`|The animated gradient on cards|85|128|16.4
+`:has()`|State that depends on a child, for example a selected table row or the folded sidebar|105|121|15.4
+`color-mix()`|Tints, shades and translucent surfaces|111|113|16.2
+
+Opera 109 and Samsung Internet 27 are the first releases built on Chromium 123.
 
 ## Unsupported browsers
 
-Internet Explorer 11 and earlier versions are not supported. KaiOS 2.5 and earlier versions are also not supported.
+Internet Explorer is not supported, and neither is any browser released before the versions above. There is no polyfill to add: the features that set the floor are CSS, so a missing one cannot be patched with JavaScript.


### PR DESCRIPTION
## Summary

- `.browserslistrc` claimed Chrome 120 / Safari 15.6, but the CSS uses `light-dark()`, `color-mix()`, `:has()` and `@property` with no fallback. In a browser that misses one of them the whole declaration is dropped, so those versions render Tabler with missing colors. The floors are now derived from the features: Chrome 123, Edge 123, Firefox 128, Safari 17.5, iOS 17.5, Opera 109, Samsung Internet 27.
- The old config also mixed in `>= 0.5%`, `last 2 major versions` and `not dead`. Browserslist unions its queries, so those lines added browsers back rather than narrowing anything - the effective floor included Chrome 109, Safari 15.6, Samsung 23, KaiOS 3.0 and `op_mini all`. They are gone.
- The browser support page now lists the real versions and a table of which feature sets which floor, so the numbers can be checked instead of taken on trust.

## Preview

- **URL:** [browser support page](https://tabler-docs-4wb2qz96m-tabler-io.vercel.app/ui/getting-started/browser-support)
- **How to test:** Read the page - the two version tables and the new "What sets the floor" section should agree with `.browserslistrc`. `npx browserslist` in the repo root prints the resulting list; its lowest entries should be chrome 123, edge 123, firefox 128, ios_saf 17.5, opera 109, safari 17.5, samsung 27.

## Notes / rollout

- Versions come from MDN browser-compat-data: `light-dark()` (Chrome 123, Firefox 120, Safari 17.5), `@property` (85 / 128 / 16.4), `:has()` (105 / 121 / 15.4), `color-mix()` (111 / 113 / 16.2). Opera 109 and Samsung Internet 27 are the first releases whose `engine_version` is Chromium 123 or newer.
- Firefox is set to 128 because of `@property`. On 121 to 127 everything works except the animated card gradient, which stops animating - the gradient itself still renders. Setting 121 with a footnote would also be defensible.
- Autoprefixer follows this file, so the build changes: `tabler.css` drops from 793,836 to 788,569 bytes. The only prefixes removed are `-moz-column-*` (Firefox has been unprefixed since 52) and `-webkit-mask-*` (Safari since 15.4).
