### PR TITLE
Give disabled buttons the colors of their own enabled state

### DIFF
--- a/.changeset/fix-button-disabled-tokens.md
+++ b/.changeset/fix-button-disabled-tokens.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed disabled buttons falling back to `currentColor` for the border and to a transparent background.

--- a/core/scss/bootstrap/_buttons.scss
+++ b/core/scss/bootstrap/_buttons.scss
@@ -20,6 +20,12 @@
   --btn-hover-border-color: transparent;
   --btn-box-shadow: #{$btn-box-shadow};
   --btn-disabled-opacity: #{$btn-disabled-opacity};
+  // Disabled reuses the button's own colors, dimmed by the opacity above.
+  // Without these the `:disabled` rule reads tokens only the color variants
+  // set, so a plain button fell back to `currentColor` for the border.
+  --btn-disabled-color: var(--btn-color);
+  --btn-disabled-bg: var(--btn-bg);
+  --btn-disabled-border-color: var(--btn-border-color);
   // Zero-size shadow, not `none`: the active state is combined with the focus
   // ring in one `box-shadow` list, where `none` would negate every other shadow
   --btn-active-shadow: 0 0 0 #000;

--- a/core/scss/ui/_buttons.scss
+++ b/core/scss/ui/_buttons.scss
@@ -62,6 +62,11 @@
 }
 
 .btn-link {
+  // Tokens, not just the plain properties below: the disabled state reads
+  // `--btn-bg` and `--btn-border-color`, so setting only `background-color`
+  // here would leave a disabled link button with the default surface and border.
+  --btn-bg: transparent;
+  --btn-border-color: transparent;
   color: #{color.adjust($primary, $lightness: 5%)};
   background-color: transparent;
   border-color: transparent;
@@ -269,6 +274,8 @@
 //
 .btn-action {
   --border-color: transparent;
+  --btn-bg: transparent;
+  --btn-disabled-color: var(--secondary);
   color: var(--secondary);
   @include border-radius(var(--border-radius));
   background: transparent;


### PR DESCRIPTION
## Summary

- `.btn:disabled` reads `--tblr-btn-disabled-color`, `--tblr-btn-disabled-bg` and `--tblr-btn-disabled-border-color`, but only the color variants ever set them. On a plain `.btn` all three were undefined, so the declarations were dropped: the border fell back to `currentColor` and the background to transparent. A disabled button showed a dark border in light mode and a light one in dark mode - the opposite of the border it has when enabled - and lost its surface fill.
- The base `.btn` now defines the three tokens as the button's own colors, so the disabled state is the enabled state at `--tblr-btn-disabled-opacity`. Variants that already set their own keep them.
- `.btn-link` and `.btn-action` expressed their transparency only as plain `background-color` / `border-color`, which the disabled rule does not read. They now set `--tblr-btn-bg` and `--tblr-btn-border-color` as well, so a disabled link or action button stays transparent.

This is the same defect as #2662: a `var()` on a token nobody defines makes the whole declaration invalid and the browser silently drops it.

## Preview

- **URL:** [buttons](https://tabler-git-fix-button-disabled-tokens-tabler-io.vercel.app/buttons.html) · [form elements](https://tabler-git-fix-button-disabled-tokens-tabler-io.vercel.app/form-elements.html)
- **How to test:** On the buttons page compare the "Disabled" button with the ones next to it - the border and the white fill should now match, just faded. Switch to dark mode and check the same: before this change the disabled border was lighter than the enabled one.

## Notes / rollout

- I measured border, background and text color for 11 button variants, enabled and disabled, in both color modes, before and after. 16 of the 44 cells changed and every one of them is a disabled state; no enabled state moved. Each changed cell now equals its own enabled value.
- Two of those cells are worth calling out. `.btn-primary` and the other solid variants had a near-white 1px ring when disabled (`currentColor` again); it is now transparent, like the enabled button. `.btn-action` had a dark border and dark text when disabled; it is now borderless with its usual muted gray.
- `.btn-link`, `.btn-outline-*` and `.btn-ghost-*` are unchanged - they already set the tokens they need.
- The bug predates the release: the same values reproduce with `@tabler/core@1.4.0` loaded from a CDN.
