### PR TITLE
Make the marketing hero, browser and shapes read tokens that exist

### DIFF
--- a/.build/css-vars-baseline.txt
+++ b/.build/css-vars-baseline.txt
@@ -4,14 +4,5 @@
 # also on a listed name that no longer dangles, so fixing one means deleting
 # its line.
 #
-# Everything below is a real bug waiting to be fixed, not an accepted exception.
-
-# tabler-marketing.css: `.shape-*` backgrounds, borders and headings reach for
-# tokens that only ever existed in the marketing prototype.
---tblr-black-lt
---tblr-border-color-dark
---tblr-border-color-light
---tblr-border-radius-circle
---tblr-font-weight-black
---tblr-gray-dark-lt
---tblr-gray-lt
+# The list is empty: every var() in the css resolves. An entry added here is a
+# bug waiting to be fixed, not an accepted exception.

--- a/.changeset/fix-marketing-dangling-tokens.md
+++ b/.changeset/fix-marketing-dangling-tokens.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed the marketing hero, browser and shape components reading custom properties nothing defined.

--- a/core/scss/_props.scss
+++ b/core/scss/_props.scss
@@ -28,6 +28,11 @@
   --white: #{$white};
   --white-lt: color-mix(in oklab, var(--white) 10%, transparent);
   --black: #{$black};
+  // `.shape-*` runs over `$colors`, which carries these three on top of the
+  // theme colors; the `-lt` tint below is generated for the theme colors only.
+  --black-lt: color-mix(in oklab, var(--black) 10%, transparent);
+  --gray-lt: color-mix(in oklab, var(--gray) 10%, transparent);
+  --gray-dark-lt: color-mix(in oklab, var(--gray-dark) 10%, transparent);
   --dark: #{$dark};
   --light: #{$light};
 

--- a/core/scss/marketing/_browser.scss
+++ b/core/scss/marketing/_browser.scss
@@ -12,7 +12,7 @@
 
 .browser-header {
   padding: 0.25rem 1rem;
-  background: var(--border-color-light) linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.03));
+  background: var(--bg-surface-tertiary) linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.03));
   border-bottom: 1px solid var(--border-color);
   @include border-radius(calc(var(--border-radius-lg) - 1px) calc(var(--border-radius-lg) - 1px) 0 0);
 }
@@ -44,8 +44,8 @@
   height: 0.75rem;
   margin-inline-end: 0.5rem;
   background: var(--border-color);
-  border: 1px solid var(--border-color-dark);
-  @include border-radius(var(--border-radius-circle));
+  border: 1px solid var(--border-active-color);
+  @include border-radius(var(--border-radius-pill));
 }
 
 .browser-input {

--- a/core/scss/marketing/_hero.scss
+++ b/core/scss/marketing/_hero.scss
@@ -10,7 +10,7 @@
 
 .hero-title {
   font-size: 3rem;
-  font-weight: var(--font-weight-black);
+  font-weight: var(--font-weight-bold);
   line-height: $headings-line-height;
   letter-spacing: $spacing-tight;
 


### PR DESCRIPTION
## Summary

- The marketing stylesheet reached for seven custom properties that nothing declares, so every declaration reading them was dropped. `.hero-title` rendered at the inherited weight instead of a heavy one, `.browser-header` had no background, `.browser-dot` had no border and square corners, and `.shape-black`, `.shape-gray` and `.shape-gray-dark` had no background at all.
- The three shape colors now get the same `-lt` tint every theme color has. `.shape-*` runs over `$colors`, which carries `black`, `gray` and `gray-dark` on top of the theme colors, while the tint was only generated for the latter.
- The browser chrome and the hero title now use tokens that exist: `--tblr-bg-surface-tertiary` for the header, `--tblr-border-active-color` for the dot border, `--tblr-border-radius-pill` for its corners, and `--tblr-font-weight-bold` for the title.

## Preview

- **URL:** [marketing](https://tabler-git-fix-marketing-dangling-tokens-tabler-io.vercel.app/marketing.html) · [hero](https://tabler-git-fix-marketing-dangling-tokens-tabler-io.vercel.app/marketing/hero.html)
- **How to test:** On the marketing page the browser mockup under the hero should have a tinted title bar and three dots with a visible ring; the headline should be bold. Shapes appear in the feature sections - the gray and black ones had no fill before.

## Notes / rollout

- `--tblr-font-weight-black` is not restored as a token. The weight scale stops at bold, and the shipped Geist faces are Regular, Medium and SemiBold, so a 900 token would only ever be synthesised. Bold is the heaviest weight the scale actually names.
- `--tblr-border-radius-circle` is replaced with the pill radius rather than reintroduced: on a 12px dot both are a circle, and the pill token already exists.
- Measured after the change: hero title `font-weight: 700` (was the inherited 400), header background `rgb(249, 250, 251)` (was transparent), dot border `rgb(156, 163, 175)` with a 1600px radius, and all three shapes with a 10% tint.
- This is the last of the four dangling-property fixes, so `.build/css-vars-baseline.txt` ends up empty: every `var()` in the css now resolves, and the check in #2926 fails on the first one that does not.
