### PR TITLE
Use the renamed changesets/action inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,9 @@ jobs:
       - name: Create release Pull Request or publish to NPM
         uses: changesets/action@v2
         with:
-          version: pnpm run version
-          publish: pnpm run publish
-          commit: "chore: update versions"
-          title: "chore: update versions"
+          version-script: pnpm run version
+          publish-script: pnpm run publish
+          commit-message: "chore: update versions"
+          pr-title: "chore: update versions"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- The release workflow fails on every push to `dev` with `The following inputs have been renamed`. `changesets/action` renamed four inputs in v2, and the bump in #2910 moved the tag from v1 to v2 without touching the `with:` block, so the action now rejects the run.
- Renamed them: `version` to `version-script`, `publish` to `publish-script`, `commit` to `commit-message`, `title` to `pr-title`. The values are unchanged.

## Notes / rollout

- The failure was not only a warning. With the old keys the action never received the publish and version commands, and the release PR would have been titled "Version Packages" rather than "chore: update versions" - the defaults visible in the failing run's input dump.
- Only the four names changed; `github-token` still comes from the action's own default and `GITHUB_TOKEN` stays in `env`.
- No changeset: this is CI configuration and changes nothing in the published packages.
