### PR TITLE
Tidy the 1.5 changesets before the release

### DIFF
--- a/.changeset/browser-support-baseline.md
+++ b/.changeset/browser-support-baseline.md
@@ -1,5 +1,5 @@
 ---
-"@tabler/core": patch
+"@tabler/core": minor
 "@tabler/docs": patch
 ---
 

--- a/.changeset/card-header-footer-bg-vars.md
+++ b/.changeset/card-header-footer-bg-vars.md
@@ -2,4 +2,4 @@
 "@tabler/core": minor
 ---
 
-Added `--card-header-bg` and `--card-footer-bg` variables so both backgrounds can be overridden independently.
+Added `--tblr-card-header-bg` and `--tblr-card-footer-bg` variables so both backgrounds can be overridden independently.

--- a/.changeset/data-tblr-attributes.md
+++ b/.changeset/data-tblr-attributes.md
@@ -1,5 +1,5 @@
 ---
-"@tabler/core": patch
+"@tabler/core": minor
 ---
 
 Added support for `data-tblr-*` attributes alongside `data-bs-*` for dropdown and other components.

--- a/.changeset/docs-fix-invalid-example-classes.md
+++ b/.changeset/docs-fix-invalid-example-classes.md
@@ -2,4 +2,4 @@
 "@tabler/docs": patch
 ---
 
-Fixed docs examples using classes that do not exist, such as `alert-facebook`, `btn-close-white`, `bg-gray` and `btn-xs`.
+Fixed docs examples using classes that do not exist, such as `alert-facebook`, `btn-close-white`, `bg-gray`, `btn-xs`, `alert-title` and `hr-text-center`.

--- a/.changeset/docs-stale-class-names.md
+++ b/.changeset/docs-stale-class-names.md
@@ -1,5 +1,0 @@
----
-"@tabler/docs": patch
----
-
-Fixed docs examples using class names that no longer exist, such as `alert-title` and `hr-text-center`.

--- a/.changeset/fix-card-table-radius.md
+++ b/.changeset/fix-card-table-radius.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed the corner radius and the double bottom border on the first and last rows of a table inside a `.card`.

--- a/.changeset/fix-dark-mode-selection-contrast.md
+++ b/.changeset/fix-dark-mode-selection-contrast.md
@@ -2,4 +2,4 @@
 "@tabler/core": patch
 ---
 
-Fixed dark mode text selection contrast with a `--tblr-selection-bg` variable.
+Fixed dark mode text selection contrast with a new `$selection-bg` Sass variable.

--- a/.changeset/flags-avatars-updates.md
+++ b/.changeset/flags-avatars-updates.md
@@ -1,5 +1,0 @@
----
-"@tabler/core": patch
----
-
-Added bottom corner radius to the last row of a table inside a `.card`.

--- a/.changeset/funny-kings-double.md
+++ b/.changeset/funny-kings-double.md
@@ -1,5 +1,0 @@
----
-"@tabler/core": patch
----
-
-Updated core SCSS to logical properties such as `margin-inline-start` and `margin-inline-end`.

--- a/.changeset/import-icons-scripts.md
+++ b/.changeset/import-icons-scripts.md
@@ -2,4 +2,4 @@
 "@tabler/preview": patch
 ---
 
-Updated Tabler Icons to v3.45.0 and restored the `import-icons` and `import-illustrations` scripts.
+Restored the `import-icons` and `import-illustrations` scripts.

--- a/.changeset/late-pugs-breathe2.md
+++ b/.changeset/late-pugs-breathe2.md
@@ -1,5 +1,5 @@
 ---
-"@tabler/core": patch
+"@tabler/core": minor
 "@tabler/preview": patch
 ---
 

--- a/.changeset/many-dogs-rest.md
+++ b/.changeset/many-dogs-rest.md
@@ -1,5 +1,0 @@
----
-"@tabler/core": patch
----
-
-Added top corner radius to the first and last child elements in `.card-table`.

--- a/.changeset/media-print-mixin.md
+++ b/.changeset/media-print-mixin.md
@@ -1,5 +1,5 @@
 ---
-"@tabler/core": patch
+"@tabler/core": minor
 ---
 
 Added `media-print` mixin and print styles to hide interactive components during printing.

--- a/.changeset/pattern-opacity-css.md
+++ b/.changeset/pattern-opacity-css.md
@@ -1,7 +1,7 @@
 ---
 "@tabler/core": minor
-"@tabler/docs": patch
 "@tabler/preview": patch
+"@tabler/docs": patch
 ---
 
-Added `--pattern-opacity-factor` and `.bg-pattern-opacity-*` utilities for background patterns.
+Added `--tblr-pattern-opacity-factor` and `.bg-pattern-opacity-*` utilities for background patterns.

--- a/.changeset/pretty-chefs-design.md
+++ b/.changeset/pretty-chefs-design.md
@@ -1,5 +1,0 @@
----
-"@tabler/core": patch
----
-
-Fixed the double bottom border on the last table row inside a `.card`.

--- a/.changeset/silly-crabs-walk.md
+++ b/.changeset/silly-crabs-walk.md
@@ -1,6 +1,6 @@
 ---
-"@tabler/core": patch
-"@tabler/preview": patch
+"@tabler/core": minor
+"@tabler/preview": minor
 ---
 
 Added Driver.js library integration and Tour demo page for interactive product tours and onboarding guides.

--- a/.changeset/system-fonts.md
+++ b/.changeset/system-fonts.md
@@ -4,4 +4,4 @@
 "@tabler/docs": patch
 ---
 
-Use the system fonts as the default `$font-family-sans-serif` and `$font-family-monospace`. Tabler no longer bundles a web font, so no font files are downloaded.
+Updated the default `$font-family-sans-serif` and `$font-family-monospace` to the system font stacks. Tabler no longer bundles a web font, so no font files are downloaded.

--- a/.changeset/tricky-moons-laugh.md
+++ b/.changeset/tricky-moons-laugh.md
@@ -1,5 +1,0 @@
----
-"@tabler/docs": patch
----
-
-Fixed the DocSearch search box and dropdown colors in dark mode.


### PR DESCRIPTION
## Summary

- Merged five sets of duplicate changesets, so the 1.5 changelog does not repeat itself: the three entries about the card table corner radius, the two about invalid classes in docs examples, the two about logical properties, the two about DocSearch colors in dark mode, and the two that bumped Tabler Icons to different versions.
- Fixed variable names that would have shipped wrong in the changelog: `--tblr-card-header-bg` / `--tblr-card-footer-bg` and `--tblr-pattern-opacity-factor` were missing the prefix, and the dark mode selection fix promised a `--tblr-selection-bg` custom property that does not exist — it is the Sass variable `$selection-bg`.
- Raised five entries from `patch` to `minor` for `@tabler/core`, so new features follow the same rule as the rest: the `bg-blur` utility, the `media-print` mixin, the Driver.js integration, the `data-tblr-*` attribute support, and the new browser support baseline.
- Reworded the system fonts entry to past tense, like every other changeset.

No source code changes — only files under `.changeset/`. The release still bumps `@tabler/core`, `@tabler/preview` and `@tabler/docs` by `minor`.

## Preview

- **How to test:** read the diff in `.changeset/`, and run `npx changeset status` — it reports a `minor` bump for the three packages, same as before.
