### PR TITLE
Type the illustration name in Illustration and Empty

### DIFF
--- a/.changeset/typed-illustration-names.md
+++ b/.changeset/typed-illustration-names.md
@@ -1,0 +1,6 @@
+---
+"@tabler/preview": patch
+"@tabler/docs": patch
+---
+
+Updated the `Illustration` and `Empty` components to accept only the bundled illustration names, checked at build time.

--- a/shared/layouts/ErrorLayout.astro
+++ b/shared/layouts/ErrorLayout.astro
@@ -3,6 +3,7 @@
 import BaseLayout from './BaseLayout.astro'
 import Empty from '@ui/Empty.astro'
 import errors from '@data/errors.json'
+import type { IllustrationImage } from '@shared/lib/svg'
 
 interface Props {
   title?: string
@@ -13,7 +14,7 @@ interface Props {
 const { title, pageError } = Astro.props
 
 type ErrorEntry = {
-  illustration?: string
+  illustration?: IllustrationImage
   title?: string | number
   header?: string
   description?: string

--- a/shared/lib/svg.test.ts
+++ b/shared/lib/svg.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { iconSvg, iconSourceComment, illustrationSvg } from './svg'
+import { freeIllustrationSource, iconSvg, iconSourceComment, illustrationSvg } from './svg'
 
 describe('iconSvg', () => {
   it('returns the processed outline svg with a11y attributes and the given classes', () => {
@@ -31,6 +31,16 @@ describe('iconSvg', () => {
 describe('iconSourceComment', () => {
   it('links the tabler.io icon page', () => {
     expect(iconSourceComment('heart')).toBe('<!-- Download SVG icon from http://tabler.io/icons/icon/heart -->')
+  })
+})
+
+describe('freeIllustrationSource', () => {
+  it('returns the same svg with and without the ".svg" suffix', () => {
+    expect(freeIllustrationSource('boy-girl.svg')).toBe(freeIllustrationSource('boy-girl'))
+  })
+
+  it('returns the auto-dark source of a bundled illustration', () => {
+    expect(freeIllustrationSource('not-found')).toContain('<svg ')
   })
 })
 

--- a/shared/lib/svg.ts
+++ b/shared/lib/svg.ts
@@ -1,6 +1,18 @@
 // Inline-SVG preparation helpers: filler-path strip, a11y attribute/class swap
 // and the illustration attribute rewrites.
 import icons from '../data/icons.json'
+import freeIllustrations from '../data/free-illustrations.json'
+
+/** Names of the illustrations bundled in @data/free-illustrations.json. */
+export type FreeIllustration = keyof typeof freeIllustrations.autodark
+
+/** How an illustration is named in markup — with or without the ".svg" suffix. */
+export type IllustrationImage = FreeIllustration | `${FreeIllustration}.svg`
+
+/** Source SVG of a bundled illustration, in its auto-dark variant. */
+export function freeIllustrationSource(image: IllustrationImage): string {
+  return freeIllustrations.autodark[image.replaceAll('.svg', '') as FreeIllustration] ?? ''
+}
 
 type IconRecord = { svg: Record<string, string | null | undefined> }
 

--- a/shared/ui/Empty.astro
+++ b/shared/ui/Empty.astro
@@ -2,6 +2,7 @@
 import Icon from './Icon.astro'
 import Button from './Button.astro'
 import Illustration from './Illustration.astro'
+import type { IllustrationImage } from '@shared/lib/svg'
 
 type PolymorphicProps = { as?: 'p' | 'h1' | 'h2' }
 
@@ -10,7 +11,7 @@ interface Props extends PolymorphicProps {
   height?: number | string
   class?: string
   /** illustration file name, e.g. "computer-fix.svg" */
-  illustration?: string | undefined
+  illustration?: IllustrationImage | undefined
   /** big text rendered instead of an icon/illustration */
   iconText?: string | undefined
   title?: string

--- a/shared/ui/Illustration.astro
+++ b/shared/ui/Illustration.astro
@@ -1,18 +1,16 @@
 ---
-import freeIllustrations from '@data/free-illustrations.json'
-import { illustrationSvg } from '@shared/lib/svg'
+import { freeIllustrationSource, illustrationSvg, type IllustrationImage } from '@shared/lib/svg'
 
 interface Props {
   /** file name of the illustration, e.g. "boy-girl.svg" (the ".svg" suffix is stripped) */
-  image: string
+  image: IllustrationImage
   height?: number | string
   class?: string
 }
 
 const { image, height = 128, class: className } = Astro.props
 
-const key = image.replaceAll('.svg', '')
-const source = (freeIllustrations as { autodark: Record<string, string> }).autodark[key] ?? ''
+const source = freeIllustrationSource(image)
 
 const illustration = illustrationSvg(source, { ...(className ? { classes: className } : {}), height })
 ---


### PR DESCRIPTION
## Summary

- `Illustration` took `image: string`, so a typo rendered nothing: the component looks the name up in `free-illustrations.json` and fell back to an empty string. The prop is now the `IllustrationImage` union, built from the keys of that file, with or without the `.svg` suffix.
- `Empty` and `ErrorLayout` use the same type, so an illustration name coming from `errors.json` is checked too.
- The union lives in `shared/lib/svg.ts` next to `illustrationSvg`, together with a small `freeIllustrationSource()` helper. That replaces the `as { autodark: Record<string, string> }` cast in the component, which was what threw the key types away.
- The data files stay JSON. Only the type is derived, the same way `PaymentProvider` types the `Payment` component.

Note that the type covers the five illustrations bundled in `free-illustrations.json`, not all 130 in the package — those five are the only ones the component can actually render.

## Preview

- **URL:** [404 page](https://tabler-docs-git-feat-illustration-name-type-tabler-io.vercel.app/404)
- **How to test:** the illustration on the docs 404 page and on the preview error, wizard and sign-in pages should render as before. `pnpm run type-check` now fails if a component is given a name that is not bundled.
