### PR TITLE
Remove the stale Repobeats section from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,6 @@ We welcome contributions of all kinds! Please read the [contributing guide](CONT
 - **Have an idea?** [Open a feature request](https://github.com/tabler/tabler/issues/new?template=feature_request.yml) or start a [discussion](https://github.com/tabler/tabler/discussions).
 - **Found a security issue?** Please report it privately — see our [security policy](SECURITY.md).
 
-## 🪴 Project activity
-
-<p align="center">
-	<img src="https://repobeats.axiom.co/api/embed/61d1db34446967b0848af68198a392067e0f5870.svg" alt="Repobeats analytics image" />
-</p>
-
 ## 🤓 Creators
 
 **Paweł Kuna**


### PR DESCRIPTION
## Summary

- Remove the `## 🪴 Project activity` section from the README. The embedded Repobeats chart stopped showing real data.
- The widget reported **1 pull request opened** in the last 30 days. The real number for this repo is **118**.
- This is not a misconfiguration on our side. The same widget is just as wrong on `immich-app/immich`, the only other repo out of 30 popular ones that still embeds it: it reported **6** opened pull requests against **325** actual ones. The served SVG was also byte-identical across a full day, so the data is frozen.
- The embed was added in August 2022 and never touched since. Nothing else in the README or anywhere else in the repo referenced this section.

## How to review

Read the diff. It only deletes the heading and the `<p align="center">` block that held the image. No preview link is needed, because the README is not part of the preview or docs site.

## Notes / rollout

- Repobeats is not installed as a GitHub App on the `tabler` org, but installing it would most likely not help, given the same breakage on immich.
- If we want an activity chart again later, the safer route is generating an SVG in CI and committing it, the way `tabler/sponsors` already does for `sponsors.svg`.
