### PR TITLE
Paint the ApexCharts tooltip arrow like the tooltip

### DIFF
--- a/.changeset/apexcharts-tooltip-arrow.md
+++ b/.changeset/apexcharts-tooltip-arrow.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed the ApexCharts tooltip arrow staying white on the dark tooltip by setting the `--apx-tt-bg` and `--apx-tt-border` tokens.

--- a/core/scss/tests/__snapshots__/css-var-prefix.test.mjs.snap
+++ b/core/scss/tests/__snapshots__/css-var-prefix.test.mjs.snap
@@ -10,6 +10,8 @@ exports[`css custom-property prefixing > leaves vendor-owned names alone and pre
   "--apx-series-3",
   "--apx-series-4",
   "--apx-series-5",
+  "--apx-tt-bg",
+  "--apx-tt-border",
   "--apx-tt-color-muted",
   "--fc-border-color",
   "--fc-daygrid-event-dot-width",

--- a/core/scss/vendor/_apexcharts.scss
+++ b/core/scss/vendor/_apexcharts.scss
@@ -30,6 +30,11 @@
   // !important because ApexCharts injects its own stylesheet at runtime, after this one,
   // and its default lands on the same selector.
   --apx-tt-color-muted: #{$tooltip-color} !important;
+  // The arrow connector is a separate element painted from these two tokens, not
+  // from the box's background: without them it stays white on the dark tooltip,
+  // with a hairline the box itself does not have.
+  --apx-tt-bg: #{$tooltip-bg} !important;
+  --apx-tt-border: transparent !important;
 
   padding: 0.25rem !important;
   font-size: $tooltip-font-size !important;

--- a/core/scss/vendor/_apexcharts.scss
+++ b/core/scss/vendor/_apexcharts.scss
@@ -31,16 +31,17 @@
   // and its default lands on the same selector.
   --apx-tt-color-muted: #{$tooltip-color} !important;
   // The arrow connector is a separate element painted from these two tokens, not
-  // from the box's background: without them it stays white on the dark tooltip,
-  // with a hairline the box itself does not have.
+  // from the box's background: without them it stays white on the dark tooltip.
+  // The border token keeps the tooltip color rather than going transparent, and
+  // the box keeps its 1px border: ApexCharts parks the arrow's centre on that
+  // border line, so removing it leaves a 1px seam between box and arrow.
   --apx-tt-bg: #{$tooltip-bg} !important;
-  --apx-tt-border: transparent !important;
+  --apx-tt-border: #{$tooltip-bg} !important;
 
   padding: 0.25rem !important;
   font-size: $tooltip-font-size !important;
   color: $tooltip-color !important;
   background: $tooltip-bg !important;
-  border: 0 !important;
   box-shadow: none !important;
 }
 


### PR DESCRIPTION
## Summary

- ApexCharts 7 draws the tooltip arrow as its own element, painted from the `--apx-tt-bg` token. Tabler colored the tooltip box with `background` but left the token at its white default, so the arrow stayed white on the dark tooltip, with a hairline the box does not have.
- The override in `core/scss/vendor/_apexcharts.scss` now sets both `--apx-tt-bg` and `--apx-tt-border` to the tooltip color and keeps the box's 1px border. ApexCharts parks the arrow's centre on that border line, so the border has to exist, in the same color as the box, for the two shapes to meet without a seam.
- The vendor variable snapshot gains the two token names; they stay unprefixed on purpose, since ApexCharts owns them.

## Preview

- **URL:** [charts-advanced.html](https://tabler-git-fix-apexcharts-tooltip-arrow-tabler-io.vercel.app/charts-advanced.html)
- **How to test:** hover the Uptime chart until the tooltip shows on the left of the cursor. The arrow on its right edge is the same dark color as the tooltip, with no white outline. The sparkline cards on the dashboard have the same tooltip without an arrow and look unchanged.
