### PR TITLE
Rewrite the README files in plainer English

### DIFF
--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -1,28 +1,29 @@
 # Release notes
 
-The release workflow writes the GitHub release body from two parts:
+The release workflow writes the GitHub release body from two parts.
 
-1. **The intro** — the file in this directory named after the version, for
-   example `1.5.0.md`. It is optional. Write it before the `chore: update
-   versions` pull request is merged, because the workflow reads it from the
-   commit it publishes.
-2. **The changes** — `## Core changes`, `## Demo changes` and `## Docs
-   changes`, built by `pnpm run release-notes` from the three `CHANGELOG.md`
-   files. Never write these by hand.
+The first part is the intro. It's the file in this directory named after the
+version, for example `1.5.0.md`, and it's optional. Write it before the
+`chore: update versions` pull request is merged, because the workflow reads it
+from the commit it publishes.
 
-A changeset that bumps several packages ends up in each of their changelogs, so
-the script shows every entry once: under Core if core is involved, otherwise
-under Demo, otherwise under Docs. The `Minor Changes` / `Patch Changes` split
-is dropped — each package gets one flat list.
+The second part is the list of changes: the `## Core changes`, `## Demo changes`
+and `## Docs changes` sections. `pnpm run release-notes` builds them from the
+three `CHANGELOG.md` files. Don't write these by hand.
+
+A changeset that bumps several packages ends up in each of their changelogs. The
+script shows every entry once. It goes under Core if core is involved, otherwise
+under Demo, and otherwise under Docs. The `Minor Changes` / `Patch Changes`
+split is dropped, so each package gets one flat list.
 
 The workflow also renames the release from `@tabler/core@1.5.0` to
 `Tabler v1.5.0`.
 
 ## What goes in the intro
 
-Follow the earlier releases: a cover image, then one `##` section per headline
-feature with two to four sentences on what it gives the user, and a screenshot
-or a screen recording where it helps.
+Follow the earlier releases. Start with a cover image, then add one `##` section
+per headline feature, with two to four sentences on what it gives the user. Add
+a screenshot or a screen recording where it helps.
 
 Images have to be reachable from GitHub. Either upload them to an issue comment
 first and paste the `user-attachments` URL, or commit them next to the intro and
@@ -32,8 +33,8 @@ link them by their raw URL on `dev`:
 ![Folded sidebar](https://raw.githubusercontent.com/tabler/tabler/dev/.github/release-notes/1.5.0-sidebar.png)
 ```
 
-Link the branch, not the release tag: a tag like `@tabler/core@1.5.0` contains a
-slash, which `raw.githubusercontent.com` cannot tell apart from the file path.
+Link the branch, not the release tag. A tag like `@tabler/core@1.5.0` contains a
+slash, and `raw.githubusercontent.com` can't tell it apart from the file path.
 
 For a cover that comes in both color modes, commit the two files and let GitHub
 pick:
@@ -53,4 +54,4 @@ the release goes out. Pass a path to write it to a file instead.
 ## Fixing a published release
 
 Edit the release on GitHub. The workflow only writes the body once, right after
-it publishes, so a later push to `dev` will not overwrite your edit.
+it publishes, so a later push to `dev` won't overwrite your edit.

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Tabler is a set of ready-made layouts, components and demo pages for admin panel
 </a>
 </p>
 
-- **Built on Bootstrap 5.** Bootstrap ships inside the package, so you only need one CSS and one JS file.
-- **120+ demo pages.** Dashboards, forms, tables, auth screens, error pages, marketing layouts and more, all in the [live demo](https://preview.tabler.io).
-- **Dark mode and RTL.** Every component has a dark color scheme, and every stylesheet ships in an RTL version.
-- **Over 6,000 icons.** [Tabler Icons](https://tabler.io/icons) are drawn on a 24×24 grid and match the UI kit.
-- **20+ plugins included.** Charts, date pickers, selects, sliders, editors, drag and drop and other libraries are bundled in `dist/libs`.
-- **Sass sources and TypeScript types.** Customize the theme with `@use … with ()` and use typed JavaScript components.
+- Bootstrap 5 ships inside the package, so you only need one CSS file and one JS file.
+- There are more than 120 demo pages in the [live demo](https://preview.tabler.io): dashboards, forms, tables, auth screens, error pages, marketing layouts and more.
+- Every component has a dark color scheme, and every stylesheet ships in an RTL version.
+- [Tabler Icons](https://tabler.io/icons) gives you over 6,000 icons, drawn on a 24×24 grid to match the UI kit.
+- More than 20 plugins are bundled in `dist/libs`: charts, date pickers, selects, sliders, editors, drag and drop and other libraries.
+- The Sass sources and TypeScript types are included, so you can customize the theme with `@use … with ()` and use typed JavaScript components.
 
 ## 🚀 Quick start
 
@@ -93,8 +93,7 @@ import '@tabler/core/dist/css/tabler.min.css'
 import '@tabler/core/dist/js/tabler.min.js'
 ```
 
-You can also [download the latest release](https://github.com/tabler/tabler/releases) as a ZIP archive, or try Tabler without installing anything: open the [tabler-starter](https://github.com/tabler/tabler-starter) template on [StackBlitz](https://stackblitz.com/github/tabler/tabler-starter),
-[CodeSandbox](https://codesandbox.io/s/github/tabler/tabler-starter) or [GitHub Codespaces](https://codespaces.new/tabler/tabler-starter).
+You can also [download the latest release](https://github.com/tabler/tabler/releases) as a ZIP archive. If you'd rather try Tabler without installing anything, open the [tabler-starter](https://github.com/tabler/tabler-starter) template on [StackBlitz](https://stackblitz.com/github/tabler/tabler-starter), [CodeSandbox](https://codesandbox.io/s/github/tabler/tabler-starter) or [GitHub Codespaces](https://codespaces.new/tabler/tabler-starter).
 
 See the [installation guide](https://docs.tabler.io/ui/getting-started/installation/) for more options.
 
@@ -116,7 +115,7 @@ The `@tabler/core` package contains compiled and minified CSS and JavaScript, th
 └── js/            TypeScript sources
 ```
 
-The stylesheets are split so that you load only what you use. `tabler.css` is enough for most projects; the other files add country flags, payment provider logos, social icons, marketing layouts or alternative gray palettes.
+The stylesheets are split so that you load only what you use. `tabler.css` is enough for most projects. The other files add country flags, payment provider logos, social icons, marketing layouts or alternative gray palettes.
 
 ## 🧩 Frameworks
 
@@ -128,7 +127,7 @@ Tabler is plain HTML and CSS, so it works with any framework. The documentation 
 
 ## 🌍 Ecosystem
 
-Tabler is more than the UI kit. These projects share the same design language:
+Tabler isn't only the UI kit. A few other projects share the same look and feel:
 
 | Project                                                                | What it is                                                                               |
 | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
@@ -143,16 +142,15 @@ Tabler is more than the UI kit. These projects share the same design language:
 
 ## 📖 Documentation
 
-The full documentation is available at [docs.tabler.io](https://docs.tabler.io/). It covers installation, customization, color modes, RTL, every component and plugin, and the [frequently asked questions](https://docs.tabler.io/ui/getting-started/faq/).
+The full documentation is at [docs.tabler.io](https://docs.tabler.io/). It covers installation, customization, color modes, RTL, every component and plugin, and the [frequently asked questions](https://docs.tabler.io/ui/getting-started/faq/).
 
-To see what changed in each release, check the [changelog](core/CHANGELOG.md) and [GitHub releases](https://github.com/tabler/tabler/releases). Updating from an older version? Read the [upgrade guide](https://docs.tabler.io/ui/getting-started/upgrade/) first, it lists every breaking change with a before-and-after
-example.
+To see what changed in each release, check the [changelog](core/CHANGELOG.md) and the [GitHub releases](https://github.com/tabler/tabler/releases). Updating from an older version? Read the [upgrade guide](https://docs.tabler.io/ui/getting-started/upgrade/) first. It lists every breaking change with a before-and-after example.
 
-Tabler follows [Semantic Versioning](https://semver.org/). Breaking changes only land in major releases, and every release ships a changeset-based changelog.
+Tabler follows [Semantic Versioning](https://semver.org/). Breaking changes only land in major releases, and every release comes with a changelog generated from changesets.
 
 ## 🌐 Browser support
 
-Tabler runs in every current browser. The minimum versions below come from the CSS features it relies on without a fallback: `light-dark()`, `color-mix()`, `:has()` and `@property`.
+Tabler works in any current browser. The minimum versions below come from the CSS features it uses without a fallback: `light-dark()`, `color-mix()`, `:has()` and `@property`.
 
 | Browser          | Minimum version |
 | ---------------- | --------------- |
@@ -167,8 +165,7 @@ See the [browser support page](https://docs.tabler.io/ui/getting-started/browser
 
 ## 🤝 Contributing
 
-We welcome contributions of all kinds. The [contributing guide](CONTRIBUTING.md) explains how to run the project locally (with Node.js and pnpm, Docker, or [GitHub Codespaces](https://codespaces.new/tabler/tabler)), where things live in the repository, and what a pull request needs. By participating, you agree to
-follow our [Code of Conduct](.github/CODE_OF_CONDUCT.md).
+We welcome contributions of all kinds. The [contributing guide](CONTRIBUTING.md) explains how to run the project locally (with Node.js and pnpm, Docker, or [GitHub Codespaces](https://codespaces.new/tabler/tabler)), where things live in the repository, and what a pull request needs. By participating, you agree to follow our [Code of Conduct](.github/CODE_OF_CONDUCT.md).
 
 The short version:
 
@@ -181,9 +178,9 @@ pnpm run dev
 
 This starts the preview at [http://localhost:3000](http://localhost:3000) and the documentation at [http://localhost:3010](http://localhost:3010), both with live reload.
 
-- **Found a bug?** [Open a bug report](https://github.com/tabler/tabler/issues/new?template=bug_report.yml).
-- **Have an idea?** [Open a feature request](https://github.com/tabler/tabler/issues/new?template=feature_request.yml) or start a [discussion](https://github.com/tabler/tabler/discussions).
-- **Found a security issue?** Please report it privately, see our [security policy](SECURITY.md).
+- Found a bug? [Open a bug report](https://github.com/tabler/tabler/issues/new?template=bug_report.yml).
+- Have an idea? [Open a feature request](https://github.com/tabler/tabler/issues/new?template=feature_request.yml) or start a [discussion](https://github.com/tabler/tabler/discussions).
+- Found a security issue? Please report it privately, see our [security policy](SECURITY.md).
 
 ## 💛 Sponsors
 
@@ -197,9 +194,9 @@ Tabler is free to use, and its development is funded by sponsors. If it saves yo
 
 ## 🤓 Creators
 
-- **Paweł Kuna** · [@codecalm](https://github.com/codecalm) · [codecalm.net](https://codecalm.net)
-- **Bartłomiej Gawęda** · [@BG-Software-BG](https://github.com/BG-Software-BG)
-- **Bartosz Dobija** · [@Bartosz-Do](https://github.com/Bartosz-Do)
+- Paweł Kuna · [@codecalm](https://github.com/codecalm) · [codecalm.net](https://codecalm.net)
+- Bartłomiej Gawęda · [@BG-Software-BG](https://github.com/BG-Software-BG)
+- Bartosz Dobija · [@Bartosz-Do](https://github.com/Bartosz-Do)
 
 Follow Tabler on [X](https://x.com/tabler_io) and [Facebook](https://www.facebook.com/tabler.io) for updates.
 
@@ -215,5 +212,4 @@ This project exists thanks to all the people who contribute.
 
 Tabler is licensed under the [MIT License](LICENSE).
 
-Third-party libraries shipped in `dist/libs` keep their own licenses. One of them needs attention: **ApexCharts is not MIT from version 5 on**. It is dual-licensed, free under its Community license for organizations under $2M in annual revenue and paid above that threshold, with a separate OEM license for
-redistribution. Check the [ApexCharts license options](https://apexcharts.com/license/) before you ship charts in a commercial product.
+Third-party libraries shipped in `dist/libs` keep their own licenses. One of them deserves a closer look. ApexCharts hasn't been MIT since version 5. It's dual-licensed now. Organizations under $2M in annual revenue can use it for free under the Community license, and anyone above that threshold pays. Redistribution needs a separate OEM license. Check the [ApexCharts license options](https://apexcharts.com/license/) before you ship charts in a commercial product.

--- a/core/README.md
+++ b/core/README.md
@@ -16,7 +16,7 @@ Free and open source HTML dashboard UI kit built on Bootstrap 5.
 <a href="https://preview.tabler.io">Live demo</a> · <a href="https://docs.tabler.io">Documentation</a> · <a href="https://github.com/tabler/tabler">GitHub</a> · <a href="https://github.com/tabler/tabler/blob/dev/core/CHANGELOG.md">Changelog</a>
 </p>
 
-`@tabler/core` is the CSS and JavaScript framework behind [Tabler](https://tabler.io): layouts, components and utilities for admin panels, dashboards and web apps. Bootstrap 5 ships inside the package, every component works in light and dark mode, and every stylesheet has an RTL version.
+`@tabler/core` is the CSS and JavaScript framework behind [Tabler](https://tabler.io). It has the layouts, components and utilities you need for admin panels, dashboards and web apps. Bootstrap 5 ships inside the package. Every component works in light and dark mode, and every stylesheet has an RTL version.
 
 ## Installation
 
@@ -46,7 +46,7 @@ import '@tabler/core/dist/css/tabler.min.css'
 import '@tabler/core/dist/js/tabler.min.js'
 ```
 
-The package also has an ES module build with named exports, useful when you create components from code:
+There's also an ES module build with named exports, which is handy when you create components from code:
 
 ```js
 import { Tooltip } from '@tabler/core'
@@ -87,8 +87,7 @@ The sources write custom properties without a prefix. Add [postcss-prefix-custom
 
 ### Plugins
 
-The third-party libraries used by the demo pages (ApexCharts, Tom Select, Litepicker, FullCalendar, Dropzone and others) are bundled in `dist/libs`. The list of shipped files is in [libs.json](https://github.com/tabler/tabler/blob/dev/core/libs.json), and each plugin has its own page in the
-[plugins documentation](https://docs.tabler.io/ui/plugins/).
+The third-party libraries used by the demo pages (ApexCharts, Tom Select, Litepicker, FullCalendar, Dropzone and others) are bundled in `dist/libs`. The list of shipped files is in [libs.json](https://github.com/tabler/tabler/blob/dev/core/libs.json), and each plugin has its own page in the [plugins documentation](https://docs.tabler.io/ui/plugins/).
 
 ## What's included
 
@@ -112,17 +111,15 @@ Updating from an older version? Read the [upgrade guide](https://docs.tabler.io/
 
 ## Browser support
 
-Tabler runs in every current browser. The CSS relies on `light-dark()`, `color-mix()`, `:has()` and `@property` without a fallback, which sets the floor at Chrome and Edge 123, Firefox 128, Safari 17.5, Opera 109, iOS 17.5 and Samsung Internet 27. See the
-[browser support page](https://docs.tabler.io/ui/getting-started/browser-support/) for details.
+Tabler works in any current browser. The CSS uses `light-dark()`, `color-mix()`, `:has()` and `@property` without a fallback. That sets the floor at Chrome and Edge 123, Firefox 128, Safari 17.5, Opera 109, iOS 17.5 and Samsung Internet 27. See the [browser support page](https://docs.tabler.io/ui/getting-started/browser-support/) for details.
 
 ## Documentation
 
-The full documentation is available at [docs.tabler.io](https://docs.tabler.io/): installation, [framework guides](https://docs.tabler.io/ui/getting-started/frameworks/), customization, color modes, RTL, and every component and plugin. Demo pages are at [preview.tabler.io](https://preview.tabler.io).
+The full documentation is at [docs.tabler.io](https://docs.tabler.io/). It covers installation, the [framework guides](https://docs.tabler.io/ui/getting-started/frameworks/), customization, color modes, RTL, and every component and plugin. The demo pages are at [preview.tabler.io](https://preview.tabler.io).
 
 ## Contributing
 
-We welcome contributions of all kinds. See the [contributing guide](https://github.com/tabler/tabler/blob/dev/CONTRIBUTING.md) to get started, [open an issue](https://github.com/tabler/tabler/issues/new/choose) to report a bug or request a feature, or join the
-[discussions](https://github.com/tabler/tabler/discussions).
+We welcome contributions of all kinds. See the [contributing guide](https://github.com/tabler/tabler/blob/dev/CONTRIBUTING.md) to get started, [open an issue](https://github.com/tabler/tabler/issues/new/choose) to report a bug or request a feature, or join the [discussions](https://github.com/tabler/tabler/discussions).
 
 ## Sponsors
 
@@ -138,5 +135,4 @@ Tabler is free to use, and its development is funded by sponsors. If it saves yo
 
 Tabler is licensed under the [MIT License](https://github.com/tabler/tabler/blob/dev/LICENSE).
 
-Third-party libraries shipped in `dist/libs` keep their own licenses. One of them needs attention: **ApexCharts is not MIT from version 5 on**. It is dual-licensed, free under its Community license for organizations under $2M in annual revenue and paid above that threshold, with a separate OEM license for
-redistribution. Check the [ApexCharts license options](https://apexcharts.com/license/) before you ship charts in a commercial product.
+Third-party libraries shipped in `dist/libs` keep their own licenses. One of them deserves a closer look. ApexCharts hasn't been MIT since version 5. It's dual-licensed now. Organizations under $2M in annual revenue can use it for free under the Community license, and anyone above that threshold pays. Redistribution needs a separate OEM license. Check the [ApexCharts license options](https://apexcharts.com/license/) before you ship charts in a commercial product.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Pages live at the package root (`srcDir: '.'`), not in `src/`:
 
 Shared components, layouts and data come from `../shared` (aliases `@shared`, `@ui`, `@data`).
 
-The sidebar tree is not generated from the filesystem — it is defined in `../shared/data/docs.json`. A new page needs an entry there to be reachable (see `components/DocsMenu.astro`).
+The sidebar tree isn't generated from the filesystem. It's defined in `../shared/data/docs.json`, and a new page needs an entry there to be reachable (see `components/DocsMenu.astro`).
 
 ## Build
 

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -2,15 +2,15 @@
 
 Pictures of Tabler components and screens, made the same way every time.
 
-We use them wherever Tabler needs to show itself: release notes, the website, the README, social posts. Each picture comes from a small page in this package, so it can be made again after any change to Tabler — with the same framing, the same fonts and the same data.
+We use them wherever Tabler needs to show itself: release notes, the website, the README, social posts. Each picture comes from a small page in this package, so it can be made again after any change to Tabler, with the same framing, the same fonts and the same data.
 
 ## What is in here
 
-- `pages/` — one page per picture. A page is a component or a whole app screen, set up to look its best.
-- `layouts/` — the two frames a page can use: a single component on a card, or a full app screen with sidebar and navbar.
-- `captures/` — the finished PNG files. This folder is not committed; run the capture to fill it.
+- `pages/` has one page per picture. A page is a component or a whole app screen, set up to look its best.
+- `layouts/` has the two frames a page can use: a single component on a card, or a full app screen with sidebar and navbar.
+- `captures/` holds the finished PNG files. This folder isn't committed. Run the capture to fill it.
 
-Every page is captured in light and dark mode, in normal and 2× size — four files per page.
+Every page is captured in light and dark mode, and in normal and 2× size. That's four files per page.
 
 ## How to use it
 
@@ -36,4 +36,4 @@ pnpm --dir screenshots run capture chart-radar dashboard-crm
 
 Copy one of the pages in `pages/` and change what it shows. The file name becomes the name of the pictures. Open the page in the browser in both color modes, then run the capture for that page and check the four files.
 
-The pages use the same components as the Tabler demo, so anything the demo can show, a picture can show too.
+The pages use the same components as the Tabler demo, so anything you can build in the demo can go into a picture too.


### PR DESCRIPTION
## Summary

- Rewrite the five README files (root, `core`, `docs`, `screenshots`, `.github/release-notes`) so they read more naturally.
- Split dense sentences, remove em dashes, and drop bold headers inside bullet lists.
- Keep every fact, link, badge, table and code sample as it was. Headings and anchors in the root README are unchanged.

## Preview

- **How to test:** Read the diff of the five README files. Check that no link, command or file path changed, only the prose around them.