### PR TITLE
Restore CodeQL scanning with build artifacts excluded

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  pull_request: null
+  push:
+    branches:
+      - dev
+      - main
+  schedule:
+    - cron: '0 3 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          config: |
+            paths-ignore:
+              - '**/dist/**'
+              - '**/libs/**'
+              - 'packages-zip/**'
+              - 'core/js/tests/**'
+              - 'core/scss/tests/**'
+              - 'screenshots/**'
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:javascript-typescript'


### PR DESCRIPTION
## Why

Code scanning on this repo is effectively dead. The last CodeQL analysis ran on **2022-10-24** against commit `fcf850c` on `dev`, and `.github/workflows/codeql-analysis.yml` has since been removed — so the scan never ran again and the alerts froze in place.

That left **91 open alerts** that point at files which no longer exist:

- **82 of 91** were in vendored third-party bundles under `dist/libs/` and `demo/dist/libs/` — TinyMCE (26), Plyr (20), Dropzone (10), ApexCharts (8). Never Tabler code, and `dist/` is not committed any more.
- The rest pointed at `dist/js/tabler.js`, `dist/js/tabler.esm.js`, `src/pages/logs.html` and `demo/cards-masonry.html` — all gone since the repo moved to `core/js/src/*.ts`.

Those alerts are being dismissed separately as stale.

## What this does

Adds `.github/workflows/codeql.yml`:

- `javascript-typescript` with `build-mode: none`
- runs on PRs, on pushes to `dev`/`main`, and weekly on Monday 03:00 UTC
- `paths-ignore` for `**/dist/**`, `**/libs/**`, `packages-zip/**`, tests and `screenshots/**`

The exclusions are the important part — without them the scan immediately re-reports the same 82 alerts from third-party bundles as soon as anything builds into `dist/`.

Follows the existing workflow conventions in this repo (`actions/checkout@v7`, `pull_request: null`, read-only default permissions with `security-events: write` scoped to the job).