### PR TITLE
Drop the Vercel Web Analytics option from the docs config

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -26,11 +26,7 @@ export default defineConfig({
   },
   // Static output + the Vercel adapter: turns `redirects` below into real HTTP
   // redirects at Vercel's routing layer (no adapter = meta-refresh HTML pages).
-  adapter: vercel({
-    webAnalytics: {
-      enabled: true,
-    },
-  }),
+  adapter: vercel(),
   // renamed/moved pages, shared with middleware.ts
   redirects,
   // pages live at the package root (./pages) — content-first layout; all


### PR DESCRIPTION
## Why

`docs/astro.config.mjs` passed `webAnalytics: { enabled: true }` to the Vercel adapter, but **Web Analytics is not enabled for the `tabler-docs` project**, so the feature never worked.

What the option actually did: the adapter injects an inline `window.va` shim into `<head>` and appends a `<script defer src="/_vercel/insights/script.js">`. Vercel only serves that endpoint when Web Analytics is turned on for the project. On production it is not:

```
GET https://docs.tabler.io/_vercel/insights/script.js  →  HTTP 404 (73 kB, the site's own 404 page)
```

So every one of the 149 pages shipped an inline script and paid for a failed request, and we collected nothing in return. A config that points at a disabled feature is worse than no config — it reads as if analytics were running.

There is no other analytics in the repo (no `@vercel/analytics`, PostHog, Plausible or GA), so nothing here was redundant — it was simply dead.

## What changed

```diff
-  adapter: vercel({
-    webAnalytics: {
-      enabled: true,
-    },
-  }),
+  adapter: vercel(),
```

The adapter itself stays. It is there for `redirects` — without it Astro emits meta-refresh HTML instead of real HTTP redirects.

## Verification

Built `@tabler/docs` locally against this branch:

- `_vercel/insights` in the build output: **0 files** (was on every page)
- `window.va` in the build output: **0 files**
- `.vercel/output/config.json` still carries **54 `301` routes** — the redirects the adapter exists for are untouched
- Prettier clean

## If we do want the data

Enabling Web Analytics in the `tabler-docs` project settings is the other half of this; the option can come back at that point and will work immediately.