### PR TITLE
Replace Popper with Floating UI in dropdowns, tooltips and popovers

### DIFF
--- a/.changeset/floating-ui.md
+++ b/.changeset/floating-ui.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": minor
+---
+
+Updated dropdowns, tooltips and popovers to use Floating UI instead of Popper, with `positionConfig` replacing `popperConfig`.

--- a/core/js/src/bootstrap.ts
+++ b/core/js/src/bootstrap.ts
@@ -1,4 +1,8 @@
-export * as Popper from '@popperjs/core'
+import { arrow, autoPlacement, autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom'
+
+// The middleware the components use, so a `positionConfig` can be built without
+// pulling in Floating UI separately.
+export const FloatingUI = { arrow, autoPlacement, autoUpdate, computePosition, flip, offset, shift }
 
 export { default as Alert } from './bootstrap/alert'
 export { default as Button } from './bootstrap/button'

--- a/core/js/src/bootstrap/dropdown.ts
+++ b/core/js/src/bootstrap/dropdown.ts
@@ -5,12 +5,13 @@
  * --------------------------------------------------------------------------
  */
 
-import * as Popper from '@popperjs/core'
+import { flip, offset, shift, type Placement } from '@floating-ui/dom'
 import BaseComponent from './base-component'
 import EventHandler from './dom/event-handler'
 import Manipulator from './dom/manipulator'
 import SelectorEngine from './dom/selector-engine'
-import { execute, getElement, getNextActiveElement, isDisabled, isElement, isRTL, isVisible, noop } from './util/index'
+import FloatingUi, { type FloatingConfig } from './util/floating-ui'
+import { execute, getNextActiveElement, isDisabled, isElement, isRTL, isVisible, noop } from './util/index'
 import type { ComponentConfig, ComponentConfigType } from './types'
 
 const NAME = 'dropdown'
@@ -61,6 +62,7 @@ const Default: ComponentConfig = {
   display: 'dynamic',
   offset: [0, 2],
   popperConfig: null,
+  positionConfig: null,
   reference: 'toggle',
 }
 
@@ -70,11 +72,12 @@ const DefaultType: ComponentConfigType = {
   display: 'string',
   offset: '(array|string|function)',
   popperConfig: '(null|object|function)',
+  positionConfig: '(null|object|function)',
   reference: '(string|element|object)',
 }
 
 class Dropdown extends BaseComponent {
-  _popper: Popper.Instance | null
+  _floatingUi: FloatingUi
   _parent: HTMLElement
   _menu: HTMLElement
   _inNavbar: boolean
@@ -82,7 +85,7 @@ class Dropdown extends BaseComponent {
   constructor(element: HTMLElement | string, config?: Partial<ComponentConfig>) {
     super(element, config)
 
-    this._popper = null
+    this._floatingUi = new FloatingUi()
     this._parent = this._element.parentNode as HTMLElement
     this._menu = SelectorEngine.next(this._element, SELECTOR_MENU)[0] || SelectorEngine.prev(this._element, SELECTOR_MENU)[0] || SelectorEngine.findOne(SELECTOR_MENU, this._parent)!
     this._inNavbar = this._detectNavbar()
@@ -119,7 +122,7 @@ class Dropdown extends BaseComponent {
       return
     }
 
-    this._createPopper()
+    this._createFloatingUi()
 
     if ('ontouchstart' in document.documentElement && !this._parent.closest(SELECTOR_NAVBAR_NAV)) {
       for (const element of [].concat(...(document.body.children as any))) {
@@ -148,18 +151,13 @@ class Dropdown extends BaseComponent {
   }
 
   dispose(): void {
-    if (this._popper) {
-      this._popper.destroy()
-    }
-
+    this._floatingUi.stop()
     super.dispose()
   }
 
   update(): void {
     this._inNavbar = this._detectNavbar()
-    if (this._popper) {
-      this._popper.update()
-    }
+    this._floatingUi.update()
   }
 
   _completeHide(relatedTarget: Record<string, any>): void {
@@ -174,9 +172,7 @@ class Dropdown extends BaseComponent {
       }
     }
 
-    if (this._popper) {
-      this._popper.destroy()
-    }
+    this._floatingUi.stop()
 
     this._menu.classList.remove(CLASS_NAME_SHOW)
     this._element.classList.remove(CLASS_NAME_SHOW)
@@ -195,23 +191,15 @@ class Dropdown extends BaseComponent {
     return config
   }
 
-  _createPopper(): void {
-    if (typeof Popper === 'undefined') {
-      throw new TypeError("Bootstrap's dropdowns require Popper (https://popper.js.org/docs/v2/)")
+  _createFloatingUi(): void {
+    // A static menu is placed by the stylesheet, so nothing has to be computed.
+    if (this._inNavbar || this._config.display === 'static') {
+      Manipulator.setDataAttribute(this._menu, 'popper', 'static')
+      return
     }
 
-    let referenceElement: HTMLElement | Popper.VirtualElement = this._element
-
-    if (this._config.reference === 'parent') {
-      referenceElement = this._parent
-    } else if (isElement(this._config.reference)) {
-      referenceElement = getElement(this._config.reference as HTMLElement | string)!
-    } else if (typeof this._config.reference === 'object') {
-      referenceElement = this._config.reference as Popper.VirtualElement
-    }
-
-    const popperConfig = this._getPopperConfig()
-    this._popper = Popper.createPopper(referenceElement, this._menu, popperConfig)
+    const referenceElement = FloatingUi.getReferenceElement(this._config.reference, this._element, this._parent)
+    this._floatingUi.calculate(referenceElement, this._menu, this._getFloatingConfig())
   }
 
   _isShown(): boolean {
@@ -250,53 +238,18 @@ class Dropdown extends BaseComponent {
     return this._element.closest(SELECTOR_NAVBAR) !== null
   }
 
-  _getOffset(): number[] | ((popperData: any) => number[]) {
-    const { offset } = this._config
+  _getFloatingConfig(): FloatingConfig {
+    const boundary = FloatingUi.getBoundary(this._config.boundary)
 
-    if (typeof offset === 'string') {
-      return offset.split(',').map((value) => Number.parseInt(value, 10))
+    const defaultBsConfig: FloatingConfig = {
+      placement: this._getPlacement() as Placement,
+      middleware: [offset(FloatingUi.parseOffset(this._config.offset, this._element)), flip({ boundary }), shift({ boundary })],
     }
 
-    if (typeof offset === 'function') {
-      return (popperData: any) => (offset as Function)(popperData, this._element)
-    }
-
-    return offset as number[]
-  }
-
-  _getPopperConfig(): Partial<Popper.Options> {
-    const defaultBsPopperConfig: Partial<Popper.Options> = {
-      placement: this._getPlacement() as Popper.Placement,
-      modifiers: [
-        {
-          name: 'preventOverflow',
-          options: {
-            boundary: this._config.boundary,
-          },
-        },
-        {
-          name: 'offset',
-          options: {
-            offset: this._getOffset(),
-          },
-        },
-      ],
-    }
-
-    if (this._inNavbar || this._config.display === 'static') {
-      Manipulator.setDataAttribute(this._menu, 'popper', 'static')
-      defaultBsPopperConfig.modifiers = [
-        {
-          name: 'applyStyles',
-          enabled: false,
-        },
-      ]
-    }
-
-    const popperConfig = execute(this._config.popperConfig, [undefined, defaultBsPopperConfig])
+    const positionConfig = execute(this._config.positionConfig ?? this._config.popperConfig, [undefined, defaultBsConfig])
     return {
-      ...defaultBsPopperConfig,
-      ...(typeof popperConfig === 'object' && popperConfig !== null ? popperConfig : {}),
+      ...defaultBsConfig,
+      ...(typeof positionConfig === 'object' && positionConfig !== null ? positionConfig : {}),
     }
   }
 

--- a/core/js/src/bootstrap/tooltip.ts
+++ b/core/js/src/bootstrap/tooltip.ts
@@ -5,10 +5,11 @@
  * --------------------------------------------------------------------------
  */
 
-import * as Popper from '@popperjs/core'
+import { arrow, autoPlacement, flip, offset, shift, type Middleware, type Placement } from '@floating-ui/dom'
 import BaseComponent from './base-component'
 import EventHandler from './dom/event-handler'
 import Manipulator from './dom/manipulator'
+import FloatingUi, { type FloatingConfig } from './util/floating-ui'
 import { execute, findShadowRoot, getElement, getUID, isRTL, noop } from './util/index'
 import { DefaultAllowlist } from './util/sanitizer'
 import TemplateFactory from './util/template-factory'
@@ -26,6 +27,8 @@ const CLASS_NAME_SHOW = 'show'
 
 const SELECTOR_TOOLTIP_INNER = '.tooltip-inner'
 const SELECTOR_MODAL = `.${CLASS_NAME_MODAL}`
+
+const PLACEMENT_AUTO = 'auto'
 
 const EVENT_MODAL_HIDE = 'hide.bs.modal'
 
@@ -73,6 +76,7 @@ const Default: ComponentConfig = {
   offset: [0, 6],
   placement: 'top',
   popperConfig: null,
+  positionConfig: null,
   sanitize: true,
   sanitizeFn: null,
   selector: false,
@@ -93,6 +97,7 @@ const DefaultType: ComponentConfigType = {
   offset: '(array|string|function)',
   placement: '(string|function)',
   popperConfig: '(null|object|function)',
+  positionConfig: '(null|object|function)',
   sanitize: 'boolean',
   sanitizeFn: '(null|function)',
   selector: '(string|boolean)',
@@ -110,24 +115,20 @@ class Tooltip extends BaseComponent {
   _timeout: ReturnType<typeof setTimeout> | number
   _isHovered: boolean | null
   _activeTrigger: Record<string, boolean>
-  _popper: Popper.Instance | null
+  _floatingUi: FloatingUi
   _templateFactory: TemplateFactory | null
   _newContent: Record<string, any> | null
   tip: HTMLElement | null
   _hideModalHandler: (() => void) | null
 
   constructor(element: HTMLElement | string, config?: Partial<ComponentConfig>) {
-    if (typeof Popper === 'undefined') {
-      throw new TypeError("Bootstrap's tooltips require Popper (https://popper.js.org/docs/v2/)")
-    }
-
     super(element, config)
 
     this._isEnabled = true
     this._timeout = 0
     this._isHovered = null
     this._activeTrigger = {}
-    this._popper = null
+    this._floatingUi = new FloatingUi()
     this._templateFactory = null
     this._newContent = null
 
@@ -187,7 +188,7 @@ class Tooltip extends BaseComponent {
       this._element.setAttribute('title', this._element.getAttribute('data-bs-original-title') || this._element.getAttribute('data-tblr-original-title') || '')
     }
 
-    this._disposePopper()
+    this._disposeFloatingUi()
     super.dispose()
   }
 
@@ -208,7 +209,7 @@ class Tooltip extends BaseComponent {
       return
     }
 
-    this._disposePopper()
+    this._disposeFloatingUi()
 
     const tip = this._getTipElement()
 
@@ -221,7 +222,7 @@ class Tooltip extends BaseComponent {
       EventHandler.trigger(this._element, (this.constructor as typeof Tooltip).eventName(EVENT_INSERTED))
     }
 
-    this._popper = this._createPopper(tip!)
+    this._createFloatingUi(tip!)
 
     tip!.classList.add(CLASS_NAME_SHOW)
 
@@ -274,7 +275,7 @@ class Tooltip extends BaseComponent {
       }
 
       if (!this._isHovered) {
-        this._disposePopper()
+        this._disposeFloatingUi()
       }
 
       this._element.removeAttribute('aria-describedby')
@@ -285,9 +286,7 @@ class Tooltip extends BaseComponent {
   }
 
   update(): void {
-    if (this._popper) {
-      this._popper.update()
-    }
+    this._floatingUi.update()
   }
 
   _isWithContent(): boolean {
@@ -326,7 +325,7 @@ class Tooltip extends BaseComponent {
   setContent(content: Record<string, any>): void {
     this._newContent = content
     if (this._isShown()) {
-      this._disposePopper()
+      this._disposeFloatingUi()
       this.show()
     }
   }
@@ -367,73 +366,48 @@ class Tooltip extends BaseComponent {
     return this.tip !== null && this.tip.classList.contains(CLASS_NAME_SHOW)
   }
 
-  _createPopper(tip: HTMLElement): Popper.Instance {
+  _createFloatingUi(tip: HTMLElement): void {
     const placement = execute(this._config.placement, [this, tip, this._element]) as string
     const attachment = AttachmentMap[placement.toUpperCase()]
-    return Popper.createPopper(this._element, tip, this._getPopperConfig(attachment))
+    const arrowElement = this._getArrowElement(tip)
+
+    this._floatingUi.calculate(this._element, tip, this._getFloatingConfig(attachment, tip), arrowElement)
   }
 
-  _getOffset(): number[] | ((popperData: any) => number[]) {
-    const { offset } = this._config
-
-    if (typeof offset === 'string') {
-      return offset.split(',').map((value: string) => Number.parseInt(value, 10))
-    }
-
-    if (typeof offset === 'function') {
-      return (popperData: any) => (offset as Function)(popperData, this._element)
-    }
-
-    return offset as number[]
+  _getArrowElement(tip: HTMLElement): HTMLElement | null {
+    return tip.querySelector<HTMLElement>(`.${(this.constructor as typeof Tooltip).NAME}-arrow`)
   }
 
   _resolvePossibleFunction(arg: any): any {
     return execute(arg, [this._element, this._element])
   }
 
-  _getPopperConfig(attachment: string): Partial<Popper.Options> {
-    const defaultBsPopperConfig: Partial<Popper.Options> = {
-      placement: attachment as Popper.Placement,
-      modifiers: [
-        {
-          name: 'flip',
-          options: {
-            fallbackPlacements: this._config.fallbackPlacements,
-          },
-        },
-        {
-          name: 'offset',
-          options: {
-            offset: this._getOffset(),
-          },
-        },
-        {
-          name: 'preventOverflow',
-          options: {
-            boundary: this._config.boundary,
-          },
-        },
-        {
-          name: 'arrow',
-          options: {
-            element: `.${(this.constructor as typeof Tooltip).NAME}-arrow`,
-          },
-        },
-        {
-          name: 'preSetPlacement',
-          enabled: true,
-          phase: 'beforeMain',
-          fn: (data: any) => {
-            this._getTipElement()!.setAttribute('data-popper-placement', data.state.placement)
-          },
-        },
-      ],
+  _getFloatingConfig(attachment: string, tip: HTMLElement | null = null): FloatingConfig {
+    const boundary = FloatingUi.getBoundary(this._config.boundary)
+    const middleware: Middleware[] = [offset(FloatingUi.parseOffset(this._config.offset, this._element))]
+
+    // Popper resolved `auto` inside its flip modifier, Floating UI has a
+    // dedicated one and the two must not be combined.
+    middleware.push(attachment === PLACEMENT_AUTO ? autoPlacement({ boundary }) : flip({ boundary, fallbackPlacements: this._config.fallbackPlacements }), shift({ boundary }))
+
+    const arrowElement = tip ? this._getArrowElement(tip) : null
+
+    if (arrowElement) {
+      // The attribute has to land before the arrow is measured: the arrow swaps
+      // its width and height between the vertical and horizontal placements.
+      middleware.push(FloatingUi.setPlacement(tip!), arrow({ element: arrowElement }))
     }
 
-    const popperConfig = execute(this._config.popperConfig, [undefined, defaultBsPopperConfig])
+    const defaultBsConfig: FloatingConfig = {
+      // `auto` is not a Floating UI placement, `autoPlacement()` resolves it.
+      placement: attachment === PLACEMENT_AUTO ? undefined : (attachment as Placement),
+      middleware,
+    }
+
+    const positionConfig = execute(this._config.positionConfig ?? this._config.popperConfig, [undefined, defaultBsConfig])
     return {
-      ...defaultBsPopperConfig,
-      ...(typeof popperConfig === 'object' && popperConfig !== null ? popperConfig : {}),
+      ...defaultBsConfig,
+      ...(typeof positionConfig === 'object' && positionConfig !== null ? positionConfig : {}),
     }
   }
 
@@ -582,11 +556,8 @@ class Tooltip extends BaseComponent {
     return config
   }
 
-  _disposePopper(): void {
-    if (this._popper) {
-      this._popper.destroy()
-      this._popper = null
-    }
+  _disposeFloatingUi(): void {
+    this._floatingUi.stop()
 
     if (this.tip) {
       this.tip.remove()

--- a/core/js/src/bootstrap/util/floating-ui.ts
+++ b/core/js/src/bootstrap/util/floating-ui.ts
@@ -1,0 +1,180 @@
+/**
+ * --------------------------------------------------------------------------
+ * Bootstrap util/floating-ui.ts
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ * --------------------------------------------------------------------------
+ */
+
+import { autoUpdate, computePosition, type Boundary, type Middleware, type OffsetOptions, type Placement, type ReferenceElement, type Strategy } from '@floating-ui/dom'
+import { getElement, isElement } from './index'
+
+/**
+ * Constants
+ */
+
+const ATTRIBUTE_PLACEMENT = 'data-popper-placement'
+const STRATEGY_ABSOLUTE = 'absolute'
+const BOUNDARY_CLIPPING_ANCESTORS = 'clippingAncestors'
+
+/**
+ * Types
+ */
+
+type OffsetValue = number | { mainAxis?: number; crossAxis?: number; alignmentAxis?: number | null }
+
+export interface FloatingConfig {
+  placement?: Placement
+  strategy?: Strategy
+  middleware?: Middleware[]
+}
+
+/**
+ * Class definition
+ *
+ * Thin wrapper around Floating UI that keeps the DOM writes Popper used to do
+ * for us: positioning styles, the placement attribute and the arrow offset.
+ */
+
+class FloatingUi {
+  _cleanup: (() => void) | null
+  _compute: (() => void) | null
+
+  constructor() {
+    if (typeof computePosition === 'undefined') {
+      throw new TypeError('Tabler requires Floating UI (https://floating-ui.com/)')
+    }
+
+    this._cleanup = null
+    this._compute = null
+  }
+
+  calculate(reference: ReferenceElement, floating: HTMLElement, config: FloatingConfig, arrowElement: HTMLElement | null = null): void {
+    this.stop()
+
+    // Take the element out of the flow before anything is measured, the way
+    // Popper's `applyStyles` effect did. A floating element still laid out as
+    // a block would be measured at its container's width.
+    Object.assign(floating.style, {
+      position: config.strategy ?? STRATEGY_ABSOLUTE,
+      top: '0',
+      right: 'auto',
+      bottom: 'auto',
+      left: '0',
+      margin: '0',
+    })
+
+    if (arrowElement) {
+      arrowElement.style.position = 'absolute'
+    }
+
+    this._compute = () => {
+      void computePosition(reference, floating, { strategy: STRATEGY_ABSOLUTE, ...config }).then(({ x, y, strategy, placement, middlewareData }) => {
+        Object.assign(floating.style, {
+          position: strategy,
+          top: `${y}px`,
+          right: 'auto',
+          bottom: 'auto',
+          left: `${x}px`,
+        })
+
+        floating.setAttribute(ATTRIBUTE_PLACEMENT, placement)
+
+        if (arrowElement && middlewareData.arrow) {
+          const { x: arrowX, y: arrowY } = middlewareData.arrow
+
+          // Only the axis Floating UI resolved is written, so the stylesheet
+          // keeps owning the side the arrow sticks out of.
+          Object.assign(arrowElement.style, {
+            left: arrowX === undefined ? '' : `${arrowX}px`,
+            top: arrowY === undefined ? '' : `${arrowY}px`,
+          })
+        }
+      })
+    }
+
+    // `autoUpdate` positions the element straight away and keeps it in place
+    // while scrolling or resizing. It returns the listener cleanup.
+    this._cleanup = autoUpdate(reference, floating, this._compute)
+  }
+
+  update(): void {
+    if (this._compute) {
+      this._compute()
+    }
+  }
+
+  stop(): void {
+    if (this._cleanup) {
+      this._cleanup()
+      this._cleanup = null
+    }
+
+    this._compute = null
+  }
+
+  static getReferenceElement(reference: unknown, defaultElement: HTMLElement, parent: HTMLElement): ReferenceElement {
+    if (reference === 'parent') {
+      return parent
+    }
+
+    if (isElement(reference)) {
+      return getElement(reference as HTMLElement | string)!
+    }
+
+    if (typeof reference === 'object' && reference !== null) {
+      return reference as ReferenceElement
+    }
+
+    return defaultElement
+  }
+
+  // Popper set the placement attribute in its `beforeMain` phase so the arrow
+  // was measured with the stylesheet rules of the placement it ends up in.
+  static setPlacement(floating: HTMLElement): Middleware {
+    return {
+      name: 'preSetPlacement',
+      fn({ placement }) {
+        floating.setAttribute(ATTRIBUTE_PLACEMENT, placement)
+        return {}
+      },
+    }
+  }
+
+  static getBoundary(boundary: unknown): Boundary {
+    if (typeof boundary === 'string' || !boundary) {
+      return BOUNDARY_CLIPPING_ANCESTORS
+    }
+
+    return boundary as Boundary
+  }
+
+  // Popper took `[skidding, distance]`, Floating UI takes named axes.
+  static parseOffset(value: unknown, element: HTMLElement): OffsetOptions {
+    if (typeof value === 'function') {
+      return (state) => normalizeOffset((value as (state: unknown, element: HTMLElement) => unknown)(state, element))
+    }
+
+    return normalizeOffset(value)
+  }
+}
+
+function normalizeOffset(value: unknown): OffsetValue {
+  let raw = value
+
+  if (typeof raw === 'string') {
+    raw = raw.split(',').map((part) => Number.parseInt(part, 10))
+  }
+
+  if (Array.isArray(raw)) {
+    const [crossAxis = 0, mainAxis = 0] = raw
+    return { mainAxis, crossAxis }
+  }
+
+  if (typeof raw === 'number' || (typeof raw === 'object' && raw !== null)) {
+    return raw as OffsetValue
+  }
+
+  return 0
+}
+
+export default FloatingUi

--- a/core/js/tests/unit/dropdown.spec.ts
+++ b/core/js/tests/unit/dropdown.spec.ts
@@ -1,14 +1,7 @@
 import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest'
 import Dropdown from '../../src/bootstrap/dropdown'
+import FloatingUi from '../../src/bootstrap/util/floating-ui'
 import { clearFixture, getFixture } from '../helpers/fixture'
-
-vi.mock('@popperjs/core', () => ({
-  createPopper: vi.fn(() => ({
-    destroy: vi.fn(),
-    update: vi.fn(),
-    setOptions: vi.fn(),
-  })),
-}))
 
 describe('Dropdown', () => {
   let fixtureEl: HTMLElement
@@ -61,13 +54,24 @@ describe('Dropdown', () => {
     it('should create offset from string data attribute', () => {
       fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown" data-bs-offset="10,20">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
-      const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
+      const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')! as HTMLElement
       const dropdown = new Dropdown(btnDropdown)
 
-      expect(dropdown._getOffset()).toEqual([10, 20])
+      expect(FloatingUi.parseOffset(dropdown._config.offset, btnDropdown)).toEqual({ mainAxis: 20, crossAxis: 10 })
     })
 
-    it('should allow popperConfig override', () => {
+    it('should allow positionConfig override', () => {
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
+
+      const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
+      const dropdown = new Dropdown(btnDropdown, {
+        positionConfig: { placement: 'left' },
+      })
+
+      expect(dropdown._getFloatingConfig().placement).toBe('left')
+    })
+
+    it('should still accept the deprecated popperConfig option', () => {
       fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
       const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
@@ -75,8 +79,7 @@ describe('Dropdown', () => {
         popperConfig: { placement: 'left' },
       })
 
-      const popperConfig = dropdown._getPopperConfig()
-      expect(popperConfig.placement).toBe('left')
+      expect(dropdown._getFloatingConfig().placement).toBe('left')
     })
   })
 
@@ -281,7 +284,7 @@ describe('Dropdown', () => {
   })
 
   describe('update', () => {
-    it('should call update on popper', () => {
+    it('should call update on the positioner', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
@@ -289,8 +292,9 @@ describe('Dropdown', () => {
         const dropdown = new Dropdown(btnDropdown)
 
         btnDropdown.addEventListener('shown.bs.dropdown', () => {
+          const updateSpy = vi.spyOn(dropdown._floatingUi, 'update')
           dropdown.update()
-          expect(dropdown._popper!.update).toHaveBeenCalled()
+          expect(updateSpy).toHaveBeenCalled()
           resolve()
         })
 
@@ -489,69 +493,54 @@ describe('Dropdown', () => {
     })
   })
 
-  describe('_getOffset', () => {
-    it('should handle function offset', () => {
-      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
+  describe('_createFloatingUi', () => {
+    it('should mark the menu static in a navbar and skip positioning', () => {
+      fixtureEl.innerHTML = ['<nav class="navbar">', '  <div class="dropdown">', '    <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '    <div class="dropdown-menu"></div>', '  </div>', '</nav>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
-      const offsetFn = vi.fn().mockReturnValue([10, 20])
-      const dropdown = new Dropdown(btn, { offset: offsetFn })
+      const menu = fixtureEl.querySelector('.dropdown-menu')!
+      const dropdown = new Dropdown(btn)
 
-      const offset = dropdown._getOffset()
-      expect(typeof offset).toBe('function')
+      dropdown._createFloatingUi()
+
+      expect(menu.getAttribute('data-tblr-popper')).toBe('static')
+      expect(dropdown._floatingUi._cleanup).toBeNull()
     })
 
-    it('should handle array offset', () => {
+    it('should mark the menu static when display is static', () => {
       fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
-      const dropdown = new Dropdown(btn, { offset: [5, 10] })
+      const menu = fixtureEl.querySelector('.dropdown-menu')!
+      const dropdown = new Dropdown(btn, { display: 'static' })
 
-      expect(dropdown._getOffset()).toEqual([5, 10])
-    })
+      dropdown._createFloatingUi()
 
-    it('should handle string offset', () => {
-      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
-
-      const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
-      const dropdown = new Dropdown(btn, { offset: '10,20' as any })
-
-      expect(dropdown._getOffset()).toEqual([10, 20])
+      expect(menu.getAttribute('data-tblr-popper')).toBe('static')
+      expect(dropdown._floatingUi._cleanup).toBeNull()
     })
   })
 
-  describe('_getPopperConfig', () => {
-    it('should set popper static in navbar', () => {
-      fixtureEl.innerHTML = ['<nav class="navbar">', '  <div class="dropdown">', '    <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '    <div class="dropdown-menu"></div>', '  </div>', '</nav>'].join('')
+  describe('_getFloatingConfig', () => {
+    it('should build the default middleware', () => {
+      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
       const dropdown = new Dropdown(btn)
 
-      const config = dropdown._getPopperConfig()
-      expect(config.modifiers).toBeDefined()
-      expect(config.modifiers!.some((m: any) => m.name === 'applyStyles' && m.enabled === false)).toBe(true)
+      const config = dropdown._getFloatingConfig()
+      expect(config.placement).toBe('bottom-start')
+      expect(config.middleware!.map((middleware) => middleware.name)).toEqual(['offset', 'flip', 'shift'])
     })
 
-    it('should set popper static when display is static', () => {
+    it('should apply a custom positionConfig function', () => {
       fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
 
       const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
-      const dropdown = new Dropdown(btn, { display: 'static' })
+      const customConfig = (_defaultConfig: any) => ({ ..._defaultConfig, strategy: 'fixed' as const })
+      const dropdown = new Dropdown(btn, { positionConfig: customConfig })
 
-      const config = dropdown._getPopperConfig()
-      expect(config.modifiers).toBeDefined()
-      expect(config.modifiers!.some((m: any) => m.name === 'applyStyles' && m.enabled === false)).toBe(true)
-    })
-
-    it('should apply custom popperConfig function', () => {
-      fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu"></div>', '</div>'].join('')
-
-      const btn = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')!
-      const customPopperConfig = (_defaultConfig: any) => ({ ..._defaultConfig, strategy: 'fixed' as const })
-      const dropdown = new Dropdown(btn, { popperConfig: customPopperConfig })
-
-      const config = dropdown._getPopperConfig()
-      expect(config.strategy).toBe('fixed')
+      expect(dropdown._getFloatingConfig().strategy).toBe('fixed')
     })
   })
 
@@ -672,7 +661,7 @@ describe('Dropdown', () => {
     })
   })
 
-  describe('_createPopper with reference', () => {
+  describe('_createFloatingUi with reference', () => {
     it('should use parent as reference', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
@@ -681,7 +670,7 @@ describe('Dropdown', () => {
         const dropdown = new Dropdown(btn, { reference: 'parent' })
 
         btn.addEventListener('shown.bs.dropdown', () => {
-          expect(dropdown._popper).not.toBeNull()
+          expect(dropdown._floatingUi._cleanup).not.toBeNull()
           resolve()
         })
 
@@ -697,7 +686,7 @@ describe('Dropdown', () => {
         const dropdown = new Dropdown(btn, { reference: fixtureEl })
 
         btn.addEventListener('shown.bs.dropdown', () => {
-          expect(dropdown._popper).not.toBeNull()
+          expect(dropdown._floatingUi._cleanup).not.toBeNull()
           resolve()
         })
 
@@ -717,7 +706,7 @@ describe('Dropdown', () => {
         const dropdown = new Dropdown(btn, { reference: virtualRef as any })
 
         btn.addEventListener('shown.bs.dropdown', () => {
-          expect(dropdown._popper).not.toBeNull()
+          expect(dropdown._floatingUi._cleanup).not.toBeNull()
           resolve()
         })
 
@@ -726,8 +715,8 @@ describe('Dropdown', () => {
     })
   })
 
-  describe('dispose with popper', () => {
-    it('should destroy popper on dispose', () => {
+  describe('dispose with a positioner', () => {
+    it('should stop the positioner on dispose', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = ['<div class="dropdown">', '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>', '  <div class="dropdown-menu">', '    <a class="dropdown-item" href="#">Link</a>', '  </div>', '</div>'].join('')
 
@@ -735,9 +724,9 @@ describe('Dropdown', () => {
         const dropdown = new Dropdown(btn)
 
         btn.addEventListener('shown.bs.dropdown', () => {
-          const destroySpy = dropdown._popper!.destroy
+          const stopSpy = vi.spyOn(dropdown._floatingUi, 'stop')
           dropdown.dispose()
-          expect(destroySpy).toHaveBeenCalled()
+          expect(stopSpy).toHaveBeenCalled()
           resolve()
         })
 

--- a/core/js/tests/unit/popover.spec.ts
+++ b/core/js/tests/unit/popover.spec.ts
@@ -3,14 +3,6 @@ import Popover from '../../src/bootstrap/popover'
 import Tooltip from '../../src/bootstrap/tooltip'
 import { clearFixture, getFixture } from '../helpers/fixture'
 
-vi.mock('@popperjs/core', () => ({
-  createPopper: vi.fn(() => ({
-    destroy: vi.fn(),
-    update: vi.fn(),
-    setOptions: vi.fn(),
-  })),
-}))
-
 describe('Popover', () => {
   let fixtureEl: HTMLElement
 

--- a/core/js/tests/unit/tooltip.spec.ts
+++ b/core/js/tests/unit/tooltip.spec.ts
@@ -2,14 +2,6 @@ import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest'
 import Tooltip from '../../src/bootstrap/tooltip'
 import { clearFixture, getFixture } from '../helpers/fixture'
 
-vi.mock('@popperjs/core', () => ({
-  createPopper: vi.fn(() => ({
-    destroy: vi.fn(),
-    update: vi.fn(),
-    setOptions: vi.fn(),
-  })),
-}))
-
 describe('Tooltip', () => {
   let fixtureEl: HTMLElement
 
@@ -286,15 +278,16 @@ describe('Tooltip', () => {
   })
 
   describe('update', () => {
-    it('should call popper update', () => {
+    it('should call update on the positioner', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })
 
         el.addEventListener('shown.bs.tooltip', () => {
+          const updateSpy = vi.spyOn(tooltip._floatingUi, 'update')
           tooltip.update()
-          expect(tooltip._popper!.update).toHaveBeenCalled()
+          expect(updateSpy).toHaveBeenCalled()
           resolve()
         })
 
@@ -302,7 +295,7 @@ describe('Tooltip', () => {
       })
     })
 
-    it('should do nothing if popper is null', () => {
+    it('should do nothing if the tooltip was never shown', () => {
       fixtureEl.innerHTML = '<a href="#" title="Tooltip">Trigger</a>'
       const el = fixtureEl.querySelector('a')!
       const tooltip = new Tooltip(el)
@@ -331,16 +324,16 @@ describe('Tooltip', () => {
       expect(el.getAttribute('title')).toBe('Tooltip title')
     })
 
-    it('should destroy popper on dispose', () => {
+    it('should stop the positioner on dispose', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })
 
         el.addEventListener('shown.bs.tooltip', () => {
-          const destroySpy = tooltip._popper!.destroy
+          const stopSpy = vi.spyOn(tooltip._floatingUi, 'stop')
           tooltip.dispose()
-          expect(destroySpy).toHaveBeenCalled()
+          expect(stopSpy).toHaveBeenCalled()
           resolve()
         })
 
@@ -484,31 +477,51 @@ describe('Tooltip', () => {
     })
   })
 
-  describe('_getOffset', () => {
-    it('should handle string offset', () => {
+  describe('_getFloatingConfig', () => {
+    it('should build the default middleware', () => {
       fixtureEl.innerHTML = '<a href="#" title="Tooltip">Trigger</a>'
       const el = fixtureEl.querySelector('a')!
-      const tooltip = new Tooltip(el, { offset: '10,20' as any })
+      const tooltip = new Tooltip(el)
 
-      expect(tooltip._getOffset()).toEqual([10, 20])
+      const config = tooltip._getFloatingConfig('top')
+      expect(config.placement).toBe('top')
+      expect(config.middleware!.map((middleware) => middleware.name)).toEqual(['offset', 'flip', 'shift'])
     })
 
-    it('should handle function offset', () => {
+    it('should set the placement attribute before the arrow is measured', () => {
       fixtureEl.innerHTML = '<a href="#" title="Tooltip">Trigger</a>'
       const el = fixtureEl.querySelector('a')!
-      const offsetFn = vi.fn().mockReturnValue([5, 10])
-      const tooltip = new Tooltip(el, { offset: offsetFn })
+      const tooltip = new Tooltip(el)
+      const tip = tooltip._getTipElement()!
 
-      const offset = tooltip._getOffset()
-      expect(typeof offset).toBe('function')
+      const names = tooltip._getFloatingConfig('top', tip).middleware!.map((middleware) => middleware.name)
+      expect(names).toEqual(['offset', 'flip', 'shift', 'preSetPlacement', 'arrow'])
     })
 
-    it('should handle array offset', () => {
+    it('should resolve auto with autoPlacement instead of flip', () => {
       fixtureEl.innerHTML = '<a href="#" title="Tooltip">Trigger</a>'
       const el = fixtureEl.querySelector('a')!
-      const tooltip = new Tooltip(el, { offset: [5, 15] })
+      const tooltip = new Tooltip(el)
 
-      expect(tooltip._getOffset()).toEqual([5, 15])
+      const config = tooltip._getFloatingConfig('auto')
+      expect(config.placement).toBeUndefined()
+      expect(config.middleware!.map((middleware) => middleware.name)).toEqual(['offset', 'autoPlacement', 'shift'])
+    })
+
+    it('should apply a custom positionConfig function', () => {
+      fixtureEl.innerHTML = '<a href="#" title="Tooltip">Trigger</a>'
+      const el = fixtureEl.querySelector('a')!
+      const tooltip = new Tooltip(el, { positionConfig: (defaultConfig: any) => ({ ...defaultConfig, strategy: 'fixed' }) })
+
+      expect(tooltip._getFloatingConfig('top').strategy).toBe('fixed')
+    })
+
+    it('should still accept the deprecated popperConfig option', () => {
+      fixtureEl.innerHTML = '<a href="#" title="Tooltip">Trigger</a>'
+      const el = fixtureEl.querySelector('a')!
+      const tooltip = new Tooltip(el, { popperConfig: { placement: 'bottom' } })
+
+      expect(tooltip._getFloatingConfig('top').placement).toBe('bottom')
     })
   })
 
@@ -525,20 +538,20 @@ describe('Tooltip', () => {
     })
   })
 
-  describe('_disposePopper', () => {
-    it('should destroy popper and remove tip', () => {
+  describe('_disposeFloatingUi', () => {
+    it('should stop the positioner and remove the tip', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = '<a href="#" title="Tooltip title">Trigger</a>'
         const el = fixtureEl.querySelector('a')!
         const tooltip = new Tooltip(el, { animation: false })
 
         el.addEventListener('shown.bs.tooltip', () => {
-          expect(tooltip._popper).not.toBeNull()
+          expect(tooltip._floatingUi._cleanup).not.toBeNull()
           expect(tooltip.tip).not.toBeNull()
 
-          tooltip._disposePopper()
+          tooltip._disposeFloatingUi()
 
-          expect(tooltip._popper).toBeNull()
+          expect(tooltip._floatingUi._cleanup).toBeNull()
           expect(tooltip.tip).toBeNull()
           resolve()
         })

--- a/core/js/tests/unit/util/floating-ui.spec.ts
+++ b/core/js/tests/unit/util/floating-ui.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest'
+import FloatingUi from '../../../src/bootstrap/util/floating-ui'
+import { clearFixture, getFixture } from '../../helpers/fixture'
+
+describe('FloatingUi', () => {
+  let fixtureEl: HTMLElement
+
+  beforeAll(() => {
+    fixtureEl = getFixture()
+  })
+
+  afterEach(() => {
+    clearFixture()
+    vi.restoreAllMocks()
+  })
+
+  describe('parseOffset', () => {
+    it('should turn a skidding/distance array into named axes', () => {
+      expect(FloatingUi.parseOffset([5, 10], fixtureEl)).toEqual({ mainAxis: 10, crossAxis: 5 })
+    })
+
+    it('should parse a comma separated string', () => {
+      expect(FloatingUi.parseOffset('10,20', fixtureEl)).toEqual({ mainAxis: 20, crossAxis: 10 })
+    })
+
+    it('should keep a plain number', () => {
+      expect(FloatingUi.parseOffset(8, fixtureEl)).toBe(8)
+    })
+
+    it('should wrap a function and pass the element as second argument', () => {
+      const offsetFn = vi.fn().mockReturnValue([5, 10])
+      const parsed = FloatingUi.parseOffset(offsetFn, fixtureEl)
+
+      expect(typeof parsed).toBe('function')
+      expect((parsed as (state: unknown) => unknown)({ placement: 'top' })).toEqual({ mainAxis: 10, crossAxis: 5 })
+      expect(offsetFn).toHaveBeenCalledWith({ placement: 'top' }, fixtureEl)
+    })
+
+    it('should fall back to no offset', () => {
+      expect(FloatingUi.parseOffset(null, fixtureEl)).toBe(0)
+    })
+  })
+
+  describe('getBoundary', () => {
+    it('should map Popper string boundaries to clippingAncestors', () => {
+      expect(FloatingUi.getBoundary('clippingParents')).toBe('clippingAncestors')
+      expect(FloatingUi.getBoundary(undefined)).toBe('clippingAncestors')
+    })
+
+    it('should keep an element boundary', () => {
+      expect(FloatingUi.getBoundary(fixtureEl)).toBe(fixtureEl)
+    })
+  })
+
+  describe('getReferenceElement', () => {
+    it('should return the parent for "parent"', () => {
+      fixtureEl.innerHTML = '<div class="parent"><button>Toggle</button></div>'
+      const parent = fixtureEl.querySelector('.parent') as HTMLElement
+      const button = fixtureEl.querySelector('button') as HTMLElement
+
+      expect(FloatingUi.getReferenceElement('parent', button, parent)).toBe(parent)
+    })
+
+    it('should return a given element', () => {
+      fixtureEl.innerHTML = '<div class="parent"><button>Toggle</button></div>'
+      const parent = fixtureEl.querySelector('.parent') as HTMLElement
+      const button = fixtureEl.querySelector('button') as HTMLElement
+
+      expect(FloatingUi.getReferenceElement(fixtureEl, button, parent)).toBe(fixtureEl)
+    })
+
+    it('should return a virtual element', () => {
+      fixtureEl.innerHTML = '<div class="parent"><button>Toggle</button></div>'
+      const parent = fixtureEl.querySelector('.parent') as HTMLElement
+      const button = fixtureEl.querySelector('button') as HTMLElement
+      const virtualElement = { getBoundingClientRect: () => new DOMRect() }
+
+      expect(FloatingUi.getReferenceElement(virtualElement, button, parent)).toBe(virtualElement)
+    })
+
+    it('should fall back to the default element', () => {
+      fixtureEl.innerHTML = '<div class="parent"><button>Toggle</button></div>'
+      const parent = fixtureEl.querySelector('.parent') as HTMLElement
+      const button = fixtureEl.querySelector('button') as HTMLElement
+
+      expect(FloatingUi.getReferenceElement('toggle', button, parent)).toBe(button)
+    })
+  })
+
+  describe('calculate', () => {
+    it('should position the floating element and set the placement attribute', async () => {
+      fixtureEl.innerHTML = '<button>Toggle</button><div class="floating">Floating</div>'
+      const button = fixtureEl.querySelector('button') as HTMLElement
+      const floating = fixtureEl.querySelector('.floating') as HTMLElement
+      const floatingUi = new FloatingUi()
+
+      floatingUi.calculate(button, floating, { placement: 'bottom-start' })
+      await vi.waitFor(() => expect(floating.getAttribute('data-popper-placement')).toBe('bottom-start'))
+
+      expect(floating.style.position).toBe('absolute')
+      expect(floating.style.top).not.toBe('')
+      expect(floating.style.left).not.toBe('')
+
+      floatingUi.stop()
+    })
+
+    it('should reposition on its own when the reference moves', async () => {
+      fixtureEl.innerHTML = '<div style="position: relative; height: 400px"><button style="position: absolute; top: 20px; left: 20px">Toggle</button><div class="floating" style="width: 50px; height: 20px">Floating</div></div>'
+      const button = fixtureEl.querySelector('button') as HTMLElement
+      const floating = fixtureEl.querySelector('.floating') as HTMLElement
+      const floatingUi = new FloatingUi()
+
+      floatingUi.calculate(button, floating, { placement: 'bottom-start' })
+      await vi.waitFor(() => expect(floating.style.left).not.toBe(''))
+
+      const initialLeft = floating.style.left
+      button.style.left = '160px'
+
+      await vi.waitFor(() => expect(floating.style.left).not.toBe(initialLeft))
+
+      floatingUi.stop()
+    })
+
+    it('should stop the auto update listeners', () => {
+      fixtureEl.innerHTML = '<button>Toggle</button><div class="floating">Floating</div>'
+      const button = fixtureEl.querySelector('button') as HTMLElement
+      const floating = fixtureEl.querySelector('.floating') as HTMLElement
+      const floatingUi = new FloatingUi()
+
+      floatingUi.calculate(button, floating, { placement: 'top' })
+      expect(floatingUi._cleanup).not.toBeNull()
+
+      floatingUi.stop()
+
+      expect(floatingUi._cleanup).toBeNull()
+      expect(floatingUi._compute).toBeNull()
+    })
+
+    it('should do nothing on update when it was never started', () => {
+      const floatingUi = new FloatingUi()
+
+      expect(() => floatingUi.update()).not.toThrow()
+    })
+  })
+})

--- a/core/package.json
+++ b/core/package.json
@@ -242,14 +242,10 @@
       }
     ]
   },
-  "dependencies": {
-    "@popperjs/core": "^2.11.8"
-  },
   "devDependencies": {
     "@melloware/coloris": "^0.25.0",
     "@types/node": "^26.4.0",
     "@vitest/browser-playwright": "4.1.11",
-    "playwright": "1.62.1",
     "@vitest/coverage-istanbul": "4.1.11",
     "apexcharts": "7.0.0",
     "autosize": "^6.0.1",
@@ -268,15 +264,19 @@
     "list.js": "^2.3.1",
     "litepicker": "^2.0.12",
     "nouislider": "^15.8.1",
+    "playwright": "1.62.1",
     "plyr": "^3.8.4",
-    "signature_pad": "^5.1.4",
     "sass": "1.103.1",
     "sass-true": "^10.1.0",
+    "signature_pad": "^5.1.4",
     "sortablejs": "^1.15.7",
     "star-rating.js": "^4.3.1",
     "tom-select": "^2.6.2",
     "typed.js": "^3.0.0",
     "typescript": "^7.0.2",
     "vitest": "4.1.11"
+  },
+  "dependencies": {
+    "@floating-ui/dom": "^1.8.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,9 +112,9 @@ importers:
 
   core:
     dependencies:
-      '@popperjs/core':
-        specifier: ^2.11.8
-        version: 2.11.8
+      '@floating-ui/dom':
+        specifier: ^1.8.0
+        version: 1.8.0
     devDependencies:
       '@melloware/coloris':
         specifier: ^0.25.0
@@ -928,6 +928,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
   '@fullcalendar/core@6.1.21':
     resolution: {integrity: sha512-t3u/+sqh3Iq7TWtUnVLcGDUE6OWZh0UD3c04bI/l7lSLAgAKr3kngBmhHiQD1QXpwC8ZN5iNqG7a7gOVixhSKQ==}
 
@@ -1327,9 +1336,6 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
-
-  '@popperjs/core@2.11.8':
-    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@prettier/sync@0.6.1':
     resolution: {integrity: sha512-yF9G8vK/LYUTF3Cijd7VC9La3b20F20/J/fgoR4H0B8JGOWnZVZX6+I6+vODPosjmMcpdlUV+gUqJQZp3kLOcw==}
@@ -5580,6 +5586,17 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/utils@0.2.12': {}
+
   '@fullcalendar/core@6.1.21':
     dependencies:
       preact: 10.12.1
@@ -5929,8 +5946,6 @@ snapshots:
   '@pnpm/deps.graph-sequencer@1100.0.1': {}
 
   '@polka/url@1.0.0-next.29': {}
-
-  '@popperjs/core@2.11.8': {}
 
   '@prettier/sync@0.6.1(prettier@3.9.5)':
     dependencies:


### PR DESCRIPTION
## Summary

- **2.0 phase:** Phase 5, JavaScript runtime (`BOOTSTRAP-V6-MIGRATION.md`). Rebased onto `v2-dev`.
- Dropdowns, tooltips and popovers now position with `@floating-ui/dom` instead of `@popperjs/core`. Popper is deprecated and Floating UI is its successor from the same maintainers.
- A new `core/js/src/bootstrap/util/floating-ui.ts` helper wraps `computePosition` and `autoUpdate`, and does the DOM writes Popper used to do for us: the positioning styles, the placement attribute and the arrow offset. This follows Bootstrap's own draft branch `v6/gs/use-floating-ui-in-place-of-popper` (twbs/bootstrap#36683).
- The `popperConfig` option is now `positionConfig`. The old name still works, so nothing breaks for people who set it.
- No CSS changed. The `data-popper-placement` and `data-tblr-popper="static"` attribute names are kept on purpose, so the stylesheet needs no update. Renaming them belongs to 2.0.

## Preview

- **URL:** [all-elements.html](https://tabler-git-migrate-popper-to-floating-ui-tabler-io.vercel.app/all-elements.html) and [card-actions.html](https://tabler-git-migrate-popper-to-floating-ui-tabler-io.vercel.app/card-actions.html)
- **How to test:** On `all-elements.html`, hover the four tooltip buttons and click the two popover buttons. Each one must open on the side its `data-bs-placement` asks for, with a 6px gap for tooltips and 8px for popovers, and the arrow centred on the button. On `card-actions.html`, open the card action dropdown: the menu sits 2px under the toggle, aligned to its right edge, and flips above the toggle when there is no room below. Scroll while a dropdown is open — the menu must stay glued to the toggle.

## Notes / rollout

- **Breaking:** `tabler.Popper` is gone. `tabler.FloatingUI` takes its place and exports the middleware the components use (`arrow`, `autoPlacement`, `autoUpdate`, `computePosition`, `flip`, `offset`, `shift`), so a custom `positionConfig` can be written without adding Floating UI to your own bundle.
- **Size:** `tabler.min.js` grows from 25 106 B to 25 541 B gzip, so **+430 B (+1.7%)**. A plain `export * as FloatingUI from '@floating-ui/dom'` would have cost 1.3 kB more, because a namespace re-export defeats tree shaking and pulls in `size`, `hide`, `inline` and `limitShift`. Exporting a hand-built object keeps the namespace for the price of no export at all.
- Two Popper behaviours had to be written by hand and are worth a reviewer's eye. Popper set `position: absolute` on the floating element **before** the first measurement; without that a `.tooltip` (which has no `position` in CSS) is measured as a full-width block and every tooltip lands at `left: 0`. And Bootstrap's `preSetPlacement` modifier set the placement attribute **before** the arrow was measured, because `.tooltip-arrow` swaps its width and height between vertical and horizontal placements; without it side arrows sit about 3px off centre. Both are reproduced in the helper and covered by tests.
- Offset mapping keeps Popper's meaning: `[skidding, distance]` becomes `{ crossAxis, mainAxis }`. Floating UI's `alignmentAxis` would have flipped the sign on `-end` placements, which Popper never did.
- Tests: 777 pass, including a new `util/floating-ui.spec.ts`. The specs no longer mock the positioning library — they run against real Floating UI in Chromium.

