### PR TITLE
Add `defaults()` and `tokens()` helpers with per-component token maps

### DIFF
--- a/.agents/skills/core-scss/SKILL.md
+++ b/.agents/skills/core-scss/SKILL.md
@@ -32,24 +32,57 @@ The module graph uses `@use` / `@forward`: a partial starts with `@use '../confi
 
 ## 2. The component pattern
 
+Every themeable value is a **custom property on the component's root class**, seeded
+from a Sass variable so users can retheme without recompiling. Declarations below
+read `var(--badge-*)`, never the Sass variable directly.
+
+The root-class tokens come from **one per-component map**, declared in the partial and
+rendered with `tokens()` (both helpers live in `core/scss/mixins/`, forwarded through
+`config`):
+
 ```scss
 @use '../config' as *;
 
+// stylelint-disable custom-property-no-missing-var-function -- token-map keys are dashed-idents by design
+// scss-docs-start badge-css-vars
+$badge-tokens: () !default;
+$badge-tokens: defaults(
+  (
+    --badge-padding-x: $badge-padding-x,
+    --badge-font-size: $badge-font-size,
+    --badge-line-height: 1,
+  ),
+  $badge-tokens
+);
+// scss-docs-end badge-css-vars
+// stylelint-enable custom-property-no-missing-var-function
+
 .badge {
-  --badge-padding-x: #{$badge-padding-x};
-  --badge-font-size: #{$badge-font-size};
-  --badge-line-height: 1;
+  @include tokens($badge-tokens);
   display: inline-flex;
   padding: var(--badge-padding-y) var(--badge-padding-x);
   font-size: var(--badge-font-size);
-  @include border-radius(var(--badge-border-radius));
 }
 ```
 
-- Every themeable value becomes a **custom property declared at the top of the component's root rule**, seeded from a Sass variable (`#{$badge-font-size}`). Declarations below read `var(--badge-*)`, never the Sass variable directly — that is what lets users retheme without recompiling.
+- `defaults($defaults, $overrides)` merges the two maps; `defaults()` and `tokens()` are
+  ported from Bootstrap v6. One mechanism now covers both override paths: compile-time
+  `@use 'tabler' with ($badge-tokens: (--badge-font-size: 1rem))` and runtime
+  `.badge { --badge-font-size: 1rem }`. Setting a key to `null` in the override removes the token.
+- Map values point at the existing `!default` Sass variables (`--badge-font-size: $badge-font-size`),
+  so `$badge-*` overrides keep working and the variables stay "used" for `lint:scss:vars`.
 - A value with no reason to be overridden can be a literal (`--badge-line-height: 1`).
-- Modifiers set custom properties rather than redeclaring properties: `.badge-sm { --badge-font-size: … }`.
+- The `custom-property-no-missing-var-function` lint fires on the map keys when the same
+  name is also declared literally in a modifier ruleset in the file — wrap the map in the
+  `stylelint-disable`/`enable` pair shown above.
+- **Only the root class gets a map.** Modifiers still set custom properties inline
+  (`.badge-sm { --badge-font-size: … }`), and so do one-off tokens on sub-elements.
+- Keep map entries in the exact order the properties were emitted before, so the compiled
+  block stays byte-identical. Converting a component is output-neutral: prove it with a
+  rebuild diff (`html-diff` only covers markup).
 - Sass variables go to `_variables.scss` with `!default`, dark-mode counterparts to `_variables-dark.scss`.
+- Components not yet converted still declare the custom properties inline at the top of the
+  root rule (`--badge-padding-x: #{$badge-padding-x};`); follow the map pattern for new work.
 
 ## 3. Custom properties are authored bare
 

--- a/.changeset/component-token-maps.md
+++ b/.changeset/component-token-maps.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": minor
+---
+
+Added `defaults()` and `tokens()` Sass helpers and per-component `$card-tokens`, `$badge-tokens`, `$avatar-tokens` override maps.

--- a/core/scss/bootstrap/_card.scss
+++ b/core/scss/bootstrap/_card.scss
@@ -5,28 +5,8 @@
 @use '../config' as *;
 
 .card {
-  // scss-docs-start card-css-vars
-  --card-spacer-y: #{$card-spacer-y};
-  --card-spacer-x: #{$card-spacer-x};
-  --card-title-spacer-y: #{$card-title-spacer-y};
-  --card-title-color: #{$card-title-color};
-  --card-subtitle-color: #{$card-subtitle-color};
-  --card-border-width: #{$card-border-width};
-  --card-border-color: #{$card-border-color};
-  --card-border-radius: #{$card-border-radius};
-  --card-box-shadow: #{$card-box-shadow};
-  --card-inner-border-radius: #{$card-inner-border-radius};
-  --card-cap-padding-y: #{$card-cap-padding-y};
-  --card-cap-padding-x: #{$card-cap-padding-x};
-  --card-cap-bg: #{$card-cap-bg};
-  --card-cap-color: #{$card-cap-color};
-  --card-height: #{$card-height};
-  --card-color: #{$card-color};
-  --card-bg: #{$card-bg};
-  --card-img-overlay-padding: #{$card-img-overlay-padding};
-  --card-group-margin: #{$card-group-margin};
-  // scss-docs-end card-css-vars
-
+  // Base `--card-*` tokens are declared on `.card` from `$card-tokens`
+  // in `ui/_cards.scss` so the component has a single token source.
   position: relative;
   display: flex;
   flex-direction: column;

--- a/core/scss/mixins/_functions.scss
+++ b/core/scss/mixins/_functions.scss
@@ -198,6 +198,49 @@
   @return $merged-maps;
 }
 
+// Build a per-component token map from its defaults and an overrides map.
+//
+// - A plain list of keys is expanded to `key: true` (mirrors Bootstrap v6).
+// - Keys in `$overrides` win over the defaults and keep their original slot.
+// - A `null` value in `$overrides` drops that key, so
+//   `@use "tabler" with ($card-tokens: (--card-bg: null))` removes the token.
+// - A `null` value in `$defaults` is kept: `tokens()` then emits an empty
+//   custom property, which is the current behaviour for unset variables.
+//
+// scss-docs-start defaults-function
+@function defaults($defaults, $overrides: ()) {
+  @if meta.type-of($defaults) == 'list' {
+    $map: ();
+    @each $key in $defaults {
+      $map: map.merge(
+        $map,
+        (
+          $key: true,
+        )
+      );
+    }
+    $defaults: $map;
+  }
+
+  $result: $defaults;
+
+  @each $key, $value in $overrides {
+    @if $value == null {
+      $result: map.remove($result, $key);
+    } @else {
+      $result: map.merge(
+        $result,
+        (
+          $key: $value,
+        )
+      );
+    }
+  }
+
+  @return $result;
+}
+// scss-docs-end defaults-function
+
 // Replace `$search` with `$replace` in `$string`
 // Used on our SVG icon backgrounds for custom forms.
 //

--- a/core/scss/mixins/_mixins.scss
+++ b/core/scss/mixins/_mixins.scss
@@ -5,6 +5,18 @@
 @use 'bootstrap/transition' as *;
 @use 'bootstrap/border-radius' as *;
 
+// Emit a token map as CSS custom properties on the current selector.
+// Ported from Bootstrap v6 `scss/mixins/_tokens.scss`. Pair it with
+// `defaults()` so one map feeds both `@use … with ()` and runtime overrides.
+//
+// scss-docs-start tokens-mixin
+@mixin tokens($map) {
+  @each $prop, $value in $map {
+    #{$prop}: #{$value};
+  }
+}
+// scss-docs-end tokens-mixin
+
 @mixin subheader($include-color: true, $include-line-height: true) {
   font-size: $h5-font-size;
   font-weight: var(--font-weight-medium);

--- a/core/scss/tests/_tokens.test.scss
+++ b/core/scss/tests/_tokens.test.scss
@@ -1,0 +1,145 @@
+// Unit tests for the per-component token helpers in scss/mixins/:
+// `defaults()` (scss/mixins/_functions.scss) builds a token map from a
+// defaults map plus an overrides map, and `tokens()` (scss/mixins/_mixins.scss)
+// emits that map as custom properties. Together they back the `$card-tokens`
+// pattern in ui/_cards.scss, so both the compile-time `@use … with ()` path and
+// runtime `.card { --card-bg: … }` overrides run through the same map.
+
+@use '../mixins/functions' as *;
+@use '../mixins/mixins' as *;
+
+@include describe('defaults()') {
+  @include it('merges the overrides over the defaults, keeping the original slot order') {
+    @include assert-equal(
+      defaults(
+        (
+          --a: 1,
+          --b: 2,
+          --c: 3,
+        ),
+        (
+          --b: 20,
+        )
+      ),
+      (
+        --a: 1,
+        --b: 20,
+        --c: 3,
+      )
+    );
+  }
+
+  @include it('appends override-only keys after the defaults') {
+    @include assert-equal(
+      defaults(
+        (
+          --a: 1,
+        ),
+        (
+          --b: 2,
+        )
+      ),
+      (
+        --a: 1,
+        --b: 2,
+      )
+    );
+  }
+
+  @include it('expands a plain list of keys to `key: true`') {
+    @include assert-equal(
+      defaults((--a --b --c), ()),
+      (
+        --a: true,
+        --b: true,
+        --c: true,
+      )
+    );
+  }
+
+  @include it('removes a key whose override value is null') {
+    @include assert-equal(
+      defaults(
+        (
+          --a: 1,
+          --b: 2,
+        ),
+        (
+          --b: null,
+        )
+      ),
+      (
+        --a: 1,
+      )
+    );
+  }
+
+  @include it('keeps a null default so tokens() can still emit it') {
+    @include assert-equal(
+      defaults(
+        (
+          --a: 1,
+          --b: null,
+        ),
+        ()
+      ),
+      (
+        --a: 1,
+        --b: null,
+      )
+    );
+  }
+}
+
+@include describe('tokens()') {
+  @include it('emits every map entry as a custom property, in map order') {
+    @include assert {
+      @include output {
+        .t {
+          @include tokens(
+            (
+              --a: 1,
+              --b: 2px,
+              --c: var(--x),
+            )
+          );
+        }
+      }
+
+      @include expect {
+        .t {
+          --a: 1;
+          --b: 2px;
+          --c: var(--x);
+        }
+      }
+    }
+  }
+
+  @include it('applies a $card-tokens-style override through defaults()') {
+    $overridden: defaults(
+      (
+        --card-bg: var(--bg-surface),
+        --card-color: inherit,
+      ),
+      (
+        --card-bg: red,
+      )
+    );
+
+    @include assert {
+      @include output {
+        .card {
+          @include tokens($overridden);
+        }
+      }
+
+      @include expect {
+        .card {
+          --card-bg: red;
+          --card-color: inherit;
+        }
+      }
+    }
+  }
+}

--- a/core/scss/tests/tokens.test.mjs
+++ b/core/scss/tests/tokens.test.mjs
@@ -1,0 +1,36 @@
+// End-to-end check that a compile-time `$card-tokens` override reaches the
+// compiled `.card` rule. The sass-true suite in _tokens.test.scss covers
+// `defaults()` and `tokens()` in isolation; this one wires them together the
+// way ui/_cards.scss does and drives it through `@use … with ()`.
+import { describe, expect, it } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { compileString } from 'sass'
+
+const scssDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+function compileCardRule(overrides) {
+  const src = `@use 'ui/cards' with ($card-tokens: (${overrides}));`
+  const { css } = compileString(src, { loadPaths: [scssDir, 'node_modules'], style: 'expanded' })
+  // The base `.card { … }` rule that ui/_cards.scss renders `$card-tokens` on.
+  return css.match(/\n\.card \{\n[\s\S]*?\n\}/)[0]
+}
+
+describe('$card-tokens compile-time override', () => {
+  it('replaces the value of an existing token on .card', () => {
+    const rule = compileCardRule('--card-bg: rgb(1 2 3)')
+    expect(rule).toContain('--card-bg: rgb(1, 2, 3);')
+    // untouched tokens keep their defaults
+    expect(rule).toContain('--card-spacer-y: 1.25rem;')
+  })
+
+  it('drops a token whose override value is null', () => {
+    const rule = compileCardRule('--card-box-shadow: null')
+    expect(rule).not.toContain('--card-box-shadow:')
+  })
+
+  it('adds a brand-new token to .card', () => {
+    const rule = compileCardRule('--card-accent: hotpink')
+    expect(rule).toContain('--card-accent: hotpink;')
+  })
+})

--- a/core/scss/ui/_avatars.scss
+++ b/core/scss/ui/_avatars.scss
@@ -2,16 +2,30 @@
 
 @use '../config' as *;
 
+// stylelint-disable custom-property-no-missing-var-function -- token-map keys are dashed-idents by design, not unwrapped var() references
+
+// scss-docs-start avatar-css-vars
+$avatar-tokens: () !default;
+$avatar-tokens: defaults(
+  (
+    --avatar-size: var(--avatar-list-size, #{$avatar-size}),
+    --avatar-status-size: $avatar-status-size,
+    --avatar-bg: $avatar-bg,
+    --avatar-box-shadow-color: var(--border-color-translucent),
+    --avatar-box-shadow: inset 0 0 0 1px var(--avatar-box-shadow-color),
+    --avatar-font-size: $avatar-font-size,
+    --avatar-icon-size: $avatar-icon-size,
+    --avatar-brand-size: $avatar-brand-size,
+    --avatar-border-radius: $avatar-border-radius,
+  ),
+  $avatar-tokens
+);
+// scss-docs-end avatar-css-vars
+
+// stylelint-enable custom-property-no-missing-var-function
+
 .avatar {
-  --avatar-size: var(--avatar-list-size, #{$avatar-size});
-  --avatar-status-size: #{$avatar-status-size};
-  --avatar-bg: #{$avatar-bg};
-  --avatar-box-shadow-color: var(--border-color-translucent);
-  --avatar-box-shadow: inset 0 0 0 1px var(--avatar-box-shadow-color);
-  --avatar-font-size: #{$avatar-font-size};
-  --avatar-icon-size: #{$avatar-icon-size};
-  --avatar-brand-size: #{$avatar-brand-size};
-  --avatar-border-radius: #{$avatar-border-radius};
+  @include tokens($avatar-tokens);
   position: relative;
   display: inline-flex;
   align-items: center;

--- a/core/scss/ui/_badges.scss
+++ b/core/scss/ui/_badges.scss
@@ -1,15 +1,29 @@
 @use '../config' as *;
 
+// stylelint-disable custom-property-no-missing-var-function -- token-map keys are dashed-idents by design, not unwrapped var() references
+
+// scss-docs-start badge-css-vars
+$badge-tokens: () !default;
+$badge-tokens: defaults(
+  (
+    --badge-padding-x: $badge-padding-x,
+    --badge-padding-y: $badge-padding-y,
+    --badge-font-size: $badge-font-size,
+    --badge-font-weight: $badge-font-weight,
+    --badge-color: $badge-color,
+    --badge-border-radius: $badge-border-radius,
+    --badge-icon-size: 1em,
+    --badge-line-height: 1,
+    --badge-gap: $badge-gap,
+  ),
+  $badge-tokens
+);
+// scss-docs-end badge-css-vars
+
+// stylelint-enable custom-property-no-missing-var-function
+
 .badge {
-  --badge-padding-x: #{$badge-padding-x};
-  --badge-padding-y: #{$badge-padding-y};
-  --badge-font-size: #{$badge-font-size};
-  --badge-font-weight: #{$badge-font-weight};
-  --badge-color: #{$badge-color};
-  --badge-border-radius: #{$badge-border-radius};
-  --badge-icon-size: 1em;
-  --badge-line-height: 1;
-  --badge-gap: #{$badge-gap};
+  @include tokens($badge-tokens);
   display: inline-flex;
   gap: var(--badge-gap);
   align-items: center;

--- a/core/scss/ui/_cards.scss
+++ b/core/scss/ui/_cards.scss
@@ -2,6 +2,38 @@
 
 @use '../config' as *;
 
+// stylelint-disable custom-property-no-missing-var-function -- token-map keys are dashed-idents by design, not unwrapped var() references
+
+// scss-docs-start card-css-vars
+$card-tokens: () !default;
+$card-tokens: defaults(
+  (
+    --card-spacer-y: $card-spacer-y,
+    --card-spacer-x: $card-spacer-x,
+    --card-title-spacer-y: $card-title-spacer-y,
+    --card-title-color: $card-title-color,
+    --card-subtitle-color: $card-subtitle-color,
+    --card-border-width: $card-border-width,
+    --card-border-color: $card-border-color,
+    --card-border-radius: $card-border-radius,
+    --card-box-shadow: $card-box-shadow,
+    --card-inner-border-radius: $card-inner-border-radius,
+    --card-cap-padding-y: $card-cap-padding-y,
+    --card-cap-padding-x: $card-cap-padding-x,
+    --card-cap-bg: $card-cap-bg,
+    --card-cap-color: $card-cap-color,
+    --card-height: $card-height,
+    --card-color: $card-color,
+    --card-bg: $card-bg,
+    --card-img-overlay-padding: $card-img-overlay-padding,
+    --card-group-margin: $card-group-margin,
+  ),
+  $card-tokens
+);
+// scss-docs-end card-css-vars
+
+// stylelint-enable custom-property-no-missing-var-function
+
 @property --card-gradient-direction {
   syntax: '<angle>';
   inherits: true;
@@ -19,6 +51,7 @@
 }
 
 .card {
+  @include tokens($card-tokens);
   @include transition(transform $transition-time ease-out, opacity $transition-time ease-out, box-shadow $transition-time ease-out);
 
   @include media-print() {


### PR DESCRIPTION
## Summary

- Port Bootstrap v6's `defaults($defaults, $overrides)` function (`core/scss/mixins/_functions.scss`) and `tokens($map)` mixin (`core/scss/mixins/_mixins.scss`), both reachable through `@use '../config' as *`.
- Convert `card`, `badge` and `avatar` to render their root-class custom properties from one map — `$card-tokens`, `$badge-tokens`, `$avatar-tokens` — built with `defaults()` and emitted with `@include tokens(...)`.
- One mechanism now covers both override paths: compile-time `@use 'tabler' with ($card-tokens: (--card-bg: red))` and runtime `.card { --card-bg: red }`. Setting a key to `null` in the override removes the token.
- Map values still point at the existing `!default` Sass variables (`--card-bg: $card-bg`), so `$card-*` / `$badge-*` / `$avatar-*` overrides keep working and stay "used" for `lint:scss:vars`.
- Modifiers (`.badge-sm`, `.avatar-md`, `.card-stamp` …) keep their inline custom properties — only the root class gets a map.
- Document the pattern in the `core-scss` skill so later component conversions follow it. Each further component is its own small follow-up PR.

## How to review

- `core/scss/mixins/_functions.scss` and `_mixins.scss` — the two helpers.
- `core/scss/ui/_cards.scss`, `_badges.scss`, `_avatars.scss` — the map + `@include tokens(...)`; the `card` base block is moved out of `core/scss/bootstrap/_card.scss` so `.card` has a single token source.
- `core/scss/tests/_tokens.test.scss` (sass-true) and `core/scss/tests/tokens.test.mjs` (end-to-end `@use … with ()` reaching the compiled `.card`).
- Gates: `pnpm --filter @tabler/core test:scss`, `pnpm run lint:scss`, `pnpm run check:tokens`, `pnpm run lint:prettier`, `pnpm run bundlewatch`, `pnpm run html-diff` — all green.

## Notes / rollout

- Closes #2977.
- Not byte-identical, by design: the 19 `--card-*` declarations move from the first `.card {}` rule (Bootstrap base) to the later `.card {}` rule (`ui/_cards.scss`). Same values, same order, declared once — verified against a production build of `tabler.css`, `tabler.rtl.css` and both `.min` files; `html-diff` is clean on all 130 pages. This follows the issue's instruction to move the base block; strict byte-identity and "one token source" cannot both hold.
- The issue lists this as landing after #2969 (`_index.scss` per directory), which is not merged yet — no file overlap, but worth sequencing.
- `defaults()` keeps a `null` default (so `tokens()` still emits it as an empty custom property, matching today's output for unset variables); only a `null` in the overrides removes a key.
