### PR TITLE
Emit block-axis logical properties from spacing and border utilities

### DIFF
--- a/.changeset/logical-block-axis-utilities.md
+++ b/.changeset/logical-block-axis-utilities.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Updated spacing and border utilities to emit block-axis logical properties like `margin-block-start` and `border-block-end`.

--- a/BOOTSTRAP-V6-MIGRATION.md
+++ b/BOOTSTRAP-V6-MIGRATION.md
@@ -271,6 +271,39 @@ which validates the direction.
 
 **Gate:** RTL build comparison; `html-diff` zero diff.
 
+**Status:** #2974 landed the block axis of the spacing and border utilities (`mt` / `mb` / `my`,
+`pt` / `pb` / `py`, `.border-top` / `.border-bottom` / `.border-y`, negative `mt` / `mb` / `my`) plus
+the non-geometry physical leftovers (`_extends.scss` markdown-table padding, `_spinners.scss` border).
+The inline axis was already logical. `tabler.css` changed by property rename only; `tabler.rtl.css`
+changed by the same renames plus the three inline-axis sweep lines, which rtlcss no longer flips
+because the logical property now resolves the direction itself — rendered output is unchanged.
+
+**Why rtlcss and `--dir` stay.** Logical properties cover box-model sides (margin, padding, border,
+inset, size) but there is no logical form for `transform`, so a physical `translateX(-50%)` cannot be
+mirrored by the browser. Tabler bridges that with `--tblr-dir` (`1` in LTR, `-1` in RTL, set in
+`_props.scss`) multiplied into the `calc()` of every direction-sensitive translate — `.translate-middle`
+in `_utilities.scss`, `$form-floating-label-transform` in `_variables.scss` — each carrying a
+`/*rtl:ignore*/` so rtlcss (which would otherwise negate the `calc()` a second time) leaves it alone.
+rtlcss is still run in `.build/build-css.ts` for everything `--dir` does not reach.
+
+**What would let us drop rtlcss.** Every remaining `rtl:` marker under `core/scss` has to be gone
+first — `grep -rn 'rtl:' core/scss --include='*.scss'` is the live checklist. They fall into:
+
+- *Transforms* — `.translate-middle`, `$form-floating-label-transform`, and the `translateX` /
+  `rotate` uses in `ui/_steps.scss`, `ui/_switch-icon.scss`, `ui/_buttons.scss`, `ui/_badges.scss`,
+  `ui/_loaders.scss`, `ui/_dropdowns.scss`, `layout/_navbar.scss`, `bootstrap/_carousel.scss`,
+  `bootstrap/_offcanvas.scss`, `bootstrap/_spinners.scss`. These need the `--dir` multiplier applied
+  the same way, or a future CSS logical transform.
+- *Popover / tooltip arrow geometry* (`bootstrap/_popover.scss`, `_tooltip.scss`) — physical
+  `border-*` triangles on absolutely positioned arrows; the Floating UI work (phase 5) is expected to
+  replace this with placement-driven values.
+- *`rtl:raw` blocks* in `bootstrap/_reboot.scss` and `ui/_breadcrumbs.scss`, and the
+  `rtl:begin:remove` block in `mixins/bootstrap/_utilities.scss` — hand-written RTL overrides that
+  would need a logical-property equivalent.
+
+Once the checklist is empty, `rtlcss` and the `tabler.rtl.css` build come out and one stylesheet
+serves both directions, matching Bootstrap v6.
+
 ### Phase 5 — JavaScript runtime
 
 - ESM only. Drop the UMD build from `core/package.json` (`js:build:standalone`, `js:min:*`); no

--- a/core/scss/_extends.scss
+++ b/core/scss/_extends.scss
@@ -60,12 +60,12 @@
 
   th:first-child,
   td:first-child {
-    padding-left: 0;
+    padding-inline-start: 0;
   }
 
   th:last-child,
   td:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
 
   tr:last-child > * {

--- a/core/scss/_utilities.scss
+++ b/core/scss/_utilities.scss
@@ -5,11 +5,13 @@
 @use 'maps' as *;
 @use 'mixins/functions' as *;
 
+// Border utility values. Uses the `--border-color-translucent` custom property
+// (dark-mode aware) rather than the light-only Sass token.
 $border-values: (
   null: var(--border-width) var(--border-style) var(--border-color-translucent),
   wide: $border-width-wide var(--border-style) var(--border-color-translucent),
   0: 0,
-);
+) !default;
 
 $utilities-border-colors: map-loop(
   (
@@ -168,7 +170,8 @@ $utilities: map.merge(
       values: $border-values,
     ),
     'border-top': (
-      property: border-top,
+      class: border-top,
+      property: border-block-start,
       values: $border-values,
     ),
     'border-end': (
@@ -177,7 +180,8 @@ $utilities: map.merge(
       values: $border-values,
     ),
     'border-bottom': (
-      property: border-bottom,
+      class: border-bottom,
+      property: border-block-end,
       values: $border-values,
     ),
     'border-start': (
@@ -192,7 +196,7 @@ $utilities: map.merge(
     ),
     'border-y': (
       class: border-y,
-      property: border-top border-bottom,
+      property: border-block-start border-block-end,
       values: $border-values,
     ),
     'border-color': (
@@ -406,7 +410,7 @@ $utilities: map.merge(
     ),
     'margin-y': (
       responsive: true,
-      property: margin-top margin-bottom,
+      property: margin-block-start margin-block-end,
       class: my,
       values: map.merge(
           $spacers,
@@ -417,7 +421,7 @@ $utilities: map.merge(
     ),
     'margin-top': (
       responsive: true,
-      property: margin-top,
+      property: margin-block-start,
       class: mt,
       values: map.merge(
           $spacers,
@@ -439,7 +443,7 @@ $utilities: map.merge(
     ),
     'margin-bottom': (
       responsive: true,
-      property: margin-bottom,
+      property: margin-block-end,
       class: mb,
       values: map.merge(
           $spacers,
@@ -474,13 +478,13 @@ $utilities: map.merge(
     ),
     'negative-margin-y': (
       responsive: true,
-      property: margin-top margin-bottom,
+      property: margin-block-start margin-block-end,
       class: my,
       values: $negative-spacers,
     ),
     'negative-margin-top': (
       responsive: true,
-      property: margin-top,
+      property: margin-block-start,
       class: mt,
       values: $negative-spacers,
     ),
@@ -492,7 +496,7 @@ $utilities: map.merge(
     ),
     'negative-margin-bottom': (
       responsive: true,
-      property: margin-bottom,
+      property: margin-block-end,
       class: mb,
       values: $negative-spacers,
     ),
@@ -517,13 +521,13 @@ $utilities: map.merge(
     ),
     'padding-y': (
       responsive: true,
-      property: padding-top padding-bottom,
+      property: padding-block-start padding-block-end,
       class: py,
       values: $spacers,
     ),
     'padding-top': (
       responsive: true,
-      property: padding-top,
+      property: padding-block-start,
       class: pt,
       values: $spacers,
     ),
@@ -535,7 +539,7 @@ $utilities: map.merge(
     ),
     'padding-bottom': (
       responsive: true,
-      property: padding-bottom,
+      property: padding-block-end,
       class: pb,
       values: $spacers,
     ),

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -765,12 +765,6 @@ $border-radiuses: (
   null: var(--border-radius-md),
 ) !default;
 
-$border-values: (
-  null: var(--border-width) var(--border-style) $border-color-translucent,
-  wide: $border-width-wide var(--border-style) $border-color-translucent,
-  0: 0,
-);
-
 $icon-color: var(--gray-400) !default;
 
 // Code

--- a/core/scss/bootstrap/_spinners.scss
+++ b/core/scss/bootstrap/_spinners.scss
@@ -35,7 +35,7 @@
   // scss-docs-end spinner-border-css-vars
 
   border: var(--spinner-border-width) solid currentColor;
-  border-right-color: transparent;
+  border-inline-end-color: transparent;
 }
 
 .spinner-border-sm {


### PR DESCRIPTION
Closes #2974. Phase 4 (logical properties) of `BOOTSTRAP-V6-MIGRATION.md`.

## What changed

The inline axis of the spacing and border utilities was already logical. This switches the **block axis** too, following Bootstrap v6, with class names unchanged.

`core/scss/_utilities.scss`:

| Class | before | after |
| --- | --- | --- |
| `mt-*` / `mb-*` / `my-*` (and negative) | `margin-top` / `margin-bottom` | `margin-block-start` / `margin-block-end` |
| `pt-*` / `pb-*` / `py-*` | `padding-top` / `padding-bottom` | `padding-block-start` / `padding-block-end` |
| `.border-top` / `.border-bottom` / `.border-y` | `border-top` / `border-bottom` | `border-block-start` / `border-block-end` |

`.border-top` / `.border-bottom` gain an explicit `class` key (like the sibling `border-start` / `border-end` / `border-x` / `border-y` entries): the utilities API derives the class from the first property when no `class` key is present, so without it the classes would become `.border-block-start` / `.border-block-end`.

**Non-utility physical leftovers swept** (not geometry):

- `core/scss/_extends.scss` — markdown-table first/last cell padding: `padding-left/right: 0` → `padding-inline-start/end: 0`
- `core/scss/bootstrap/_spinners.scss` — `border-right-color: transparent` → `border-inline-end-color: transparent`

Popover / tooltip arrow geometry and `.btn-close` centring stay physical — direction-neutral or already RTL-handled.

**`$border-values` de-duplicated** — the map was defined in `_variables.scss` (unused) and shadowed without `!default` in `_utilities.scss`. The dead `_variables.scss` copy is removed; the surviving `_utilities.scss` copy (which references the dark-mode-aware `--border-color-translucent` custom property) gains `!default`. Internal Sass API, not part of the public contract.

**Plan notes** — `BOOTSTRAP-V6-MIGRATION.md` Phase 4 gains a status line, the rationale for keeping rtlcss and the `--dir` multiplier (no logical form for `transform`), and a checklist of the remaining `rtl:` markers that would have to go before rtlcss can be dropped.

## Proof (per `.agents/rules/v2.mdc`, phase 4 gate)

- **`core/dist/css/tabler.css`**: diff is *exactly* the property renames. Token-frequency accounting confirms every removed physical property is balanced 1:1 by its logical replacement — every selector and every value unchanged. After un-renaming, byte-identical to the pre-change build.
- **`core/dist/css/tabler.rtl.css`**: the same renames, plus the two inline-axis sweep lines which rtlcss no longer flips because the logical property resolves the direction itself. Rendered output is identical in both directions.
- **`pnpm run html-diff`**: `All 130 pages are byte-identical to the baseline.`
- **RTL preview**: `/layout-rtl` checked visually — spacing, gutters and borders intact.
- **`bundlewatch`**: PASS (`tabler.min.css` 77.49 kB < 78 kB gzip; `tabler.rtl.min.css` 77.54 kB < 78 kB).
- **`pnpm --dir core run lint:scss`** clean · **`lint:scss:vars`** 0 unused · **`test:scss`** 122 passed · full `build:assets` exit 0.
- Changeset: `.changeset/logical-block-axis-utilities.md` (`@tabler/core`: patch).

`v2-policy-reviewer`: no blockers.
