### PR TITLE
Run the release workflow on `v2-dev` without publishing to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev
+      - v2-dev
 
 permissions:
   contents: read
@@ -33,12 +34,15 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      # Both branches get their own "chore: update versions" PR. Only `dev` publishes:
+      # `v2-dev` carries a major changeset, and an empty publish-script keeps the action
+      # from shipping 2.0.0 to npm as `latest` once that PR is merged.
       - name: Create release Pull Request or publish to NPM
         id: changesets
         uses: changesets/action@v2
         with:
           version-script: pnpm run version
-          publish-script: pnpm run publish
+          publish-script: ${{ github.ref_name == 'dev' && 'pnpm run publish' || '' }}
           commit-message: "chore: update versions"
           pr-title: "chore: update versions"
         env:


### PR DESCRIPTION
## Summary

- The release workflow now also runs on pushes to `v2-dev`. `changesets/action` opens a separate "chore: update versions" PR for that branch, so the 2.0 changelog and version bump build up as changesets land.
- Publishing stays limited to `dev`. On `v2-dev` the `publish-script` input is an empty string, which the action treats as "do not publish". This keeps the pending `major` changeset from shipping `@tabler/core@2.0.0` to npm as `latest` once the version PR is merged.
- The zip upload and release notes steps are already gated on `published == 'true'`, so they do not run on `v2-dev`.

## Preview

- **How to test:** Read `.github/workflows/release.yml`. Check the `branches` list and the `publish-script` expression. After merge, a push to `v2-dev` should open a `changeset-release/v2-dev` PR and nothing should be published to npm.

## Notes / rollout

- The version PR on `v2-dev` will bump core, preview and docs to `2.0.0`. Keep it open until the 2.0 release, because merging it removes the changesets.
- `baseBranch` in `.changeset/config.json` still points to `dev`. It only affects `changeset status` and `changeset add`, so it is left as is.
- Related: #2987 (2.0 umbrella PR).
