### PR TITLE
Fix invisible `.form-switch` knob in light mode

### DIFF
--- a/.changeset/fix-form-switch-knob-light.md
+++ b/.changeset/fix-form-switch-knob-light.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed the invisible `.form-switch` knob in light mode by restoring a gray `$form-switch-color`.

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -1987,14 +1987,14 @@ $form-select-font-size-lg: $input-font-size-lg !default;
 $form-select-border-radius-lg: $input-border-radius-lg !default;
 $form-select-transition: $input-transition !default;
 
-$form-switch-color: $white !default;
+$form-switch-color: $gray-200 !default;
 $form-switch-width: 2rem !default;
 $form-switch-height: 1.25rem !default;
 $form-switch-padding-start: $form-switch-width + 0.5rem !default;
 $form-switch-bg-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color}'/></svg>") !default;
 $form-switch-border-radius: $form-switch-width !default;
 $form-switch-transition: background-position 0.15s ease-in-out !default;
-$form-switch-focus-color: $white !default;
+$form-switch-focus-color: $input-focus-border-color !default;
 $form-switch-focus-bg-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-focus-color}'/></svg>") !default;
 $form-switch-checked-color: $white !default;
 $form-switch-checked-bg-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-checked-color}'/></svg>") !default;


### PR DESCRIPTION
## Summary

- In light mode the unchecked `.form-switch` knob was white on the white `--tblr-bg-forms` track, so the switch looked like an empty pill.
- Restored `$form-switch-color` to `$gray-200` and `$form-switch-focus-color` to `$input-focus-border-color`, the values 1.4.0 shipped. `$border-color` is now `var(--gray-200)`, which cannot be used inside the SVG data URL, so the literal gray is used instead.
- Dark mode keeps its own `$form-switch-color-dark` override and is unchanged.

## Preview

- **URL:** [form-elements.html](https://tabler-git-fix-form-switch-knob-light-tabler-io.vercel.app/form-elements.html)
- **How to test:** open the page in light mode and scroll to **Toggle switches**. Unchecked switches (Option 2, Option 3) show a gray knob on the left. Click one: the knob turns white on the blue track, and unchecking brings the gray knob back. Switch to dark mode: nothing changes there.

## Notes / rollout

- Closes #2982
