### PR TITLE
Fix `.dropdown-menu-arrow` border color, replace `clip` with `clip-path`

### DIFF
--- a/.changeset/fix-dropdown-arrow-border.md
+++ b/.changeset/fix-dropdown-arrow-border.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed the `.dropdown-menu-arrow` border color and replaced the deprecated `clip` with `clip-path`.

--- a/core/scss/ui/_dropdowns.scss
+++ b/core/scss/ui/_dropdowns.scss
@@ -86,11 +86,12 @@
     display: block;
     width: 14px;
     height: 14px;
-    clip: rect(0, 9px, 9px, 0);
+    clip-path: inset(0 5px 5px 0);
     content: '';
     background: inherit;
-    border: 1px solid;
-    border-color: inherit;
+    // The menu draws its edge with the 1px ring in --dropdown-box-shadow and has
+    // no border, so `inherit` would give the arrow the text color.
+    border: 1px solid var(--dropdown-border-color);
 
     /* rtl:ignore */
     transform: rotate(45deg);


### PR DESCRIPTION
## Summary

- The `.dropdown-menu-arrow` outline was drawn in the text color. Since #2839 the menu has no `border` (its edge is the 1px ring in `--tblr-shadow-dropdown`), so `border-color: inherit` on the arrow resolved to `currentColor`. The arrow now uses `var(--tblr-dropdown-border-color)`, which also follows `.dropdown-menu-dark` and the dark theme.
- The arrow is cut with `clip-path: inset(0 5px 5px 0)` instead of the deprecated `clip: rect()`. Same shape, same RTL output.

Checked in Chromium and Firefox 150, light and dark. The extra lines from the report could not be reproduced in Firefox 150; the `clip` replacement removes the one deprecated property the arrow relied on.

## Preview

- **URL:** [dropdowns.html](https://tabler-git-fix-dropdown-arrow-border-tabler-io.vercel.app/dropdowns.html)
- **How to test:** open the user menu in the top-right navbar, or look at the two dark dropdowns with an arrow in the right column. The arrow outline matches the menu edge instead of being a dark line. Switch to dark mode and check the same menus.

## Notes / rollout

- Closes #2962
