### PR TITLE
Fix folded sidebar flashing the active submenu as a flyout on reload

### DIFF
--- a/.changeset/fix-folded-sidebar-flicker.md
+++ b/.changeset/fix-folded-sidebar-flicker.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed the folded sidebar flashing the active submenu as a flyout on reload before `tabler.js` closed it.

--- a/core/scss/layout/_navbar.scss
+++ b/core/scss/layout/_navbar.scss
@@ -622,6 +622,16 @@ Navbar vertical
   // a bare :where()/[…] selector would lose to it and never take effect.
   html[data-bs-sidebar^='folded'] {
     --sidebar-width: var(--sidebar-folded-width);
+
+    // The sidebar is rendered for the expanded state, so the active submenu can
+    // arrive open (.show). Folded, it would paint as a flyout until sidebar.ts
+    // closes it on DOMContentLoaded — a flicker on every reload. Menus opened by
+    // the Dropdown plugin carry a popper data attribute (data-tblr-popper from
+    // tabler.js, data-bs-popper from Bootstrap's own js), so only the
+    // server-rendered ones hide.
+    .navbar-vertical .dropdown-menu.show:not([data-bs-popper]):not([data-tblr-popper]) {
+      display: none;
+    }
   }
 
   .navbar-vertical:is(.navbar-folded, .navbar-folded-hover) {


### PR DESCRIPTION
## Summary

- The sidebar is server-rendered for the expanded state, so the active submenu ships with `.show`. When the folded mode comes from `localStorage` (`data-bs-sidebar="folded"` / `"folded-hover"` on `<html>`, set by `tabler-theme.js` in `<head>`), that submenu painted as a flyout until `sidebar.ts` closed it on `DOMContentLoaded`. `tabler.js` is deferred, so the flyout showed for a few frames on some reloads.
- A CSS rule in the `html[data-bs-sidebar^='folded']` block now hides `.navbar-vertical .dropdown-menu.show` that has no popper data attribute. Menus opened by the Dropdown plugin carry `data-tblr-popper` (or `data-bs-popper` with Bootstrap's own js), so flyouts opened by the user are not affected. The JS cleanup on `DOMContentLoaded` stays as is.

Checked on `layout-vertical` with `?sidebar=folded-hover`, `?sidebar=folded` and `?sidebar=default`: flyouts open in both folded variants, and the default sidebar still shows the active submenu inline. A render with JavaScript disabled (the pre-`DOMContentLoaded` state) shows no flyout with the new CSS and an open "Layout" flyout with the 1.5.0 CSS.

## Preview

- **URL:** [layout-vertical.html?sidebar=folded-hover](https://tabler-git-fix-folded-sidebar-flicker-tabler-io.vercel.app/layout-vertical.html?sidebar=folded-hover)
- **How to test:** open the page and reload it a few times, also with `?sidebar=folded`. The "Layout" submenu no longer flashes next to the rail. Click a rail icon: its flyout opens as before. Then open it with `?sidebar=default`: the "Layout" submenu is expanded inline on load.

## Notes / rollout

- Closes #2986
