### PR TITLE
Fix `.card-code` corners inside a rounded card

### DIFF
--- a/.changeset/fix-card-code-radius.md
+++ b/.changeset/fix-card-code-radius.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed `.card-code` so the code block follows the card corners instead of drawing its own `border-radius`.

--- a/core/scss/ui/_cards.scss
+++ b/core/scss/ui/_cards.scss
@@ -535,6 +535,17 @@ Card code
  */
 .card-code {
   padding: 0;
+  overflow: hidden;
+
+  // The code block is a dark box, so it follows the card's corners: rounded at
+  // the card's top or bottom edge, square when another section sits next to it.
+  &:first-child {
+    @include border-top-radius(var(--card-border-radius));
+  }
+
+  &:last-child {
+    @include border-bottom-radius(var(--card-border-radius));
+  }
 
   .highlight {
     margin: 0;
@@ -544,6 +555,7 @@ Card code
   pre {
     margin: 0 !important;
     border: 0 !important;
+    @include border-radius(0);
   }
 }
 


### PR DESCRIPTION
## Summary

- `.card-code` reset the margin and border of its `pre`, but not its `border-radius`, so the dark code block kept its own rounded corners inside the card and showed a gap under the card header.
- The `pre` now has square corners, and `.card-code` itself is rounded at the card's top or bottom edge (`:first-child` / `:last-child`) with `overflow: hidden`, the same way `.card-footer` follows the card corners. A code block between two other sections stays square.

## Preview

- **URL:** [ui/components/card#code-in-a-card](https://tabler-docs-git-fix-card-code-radius-tabler-io.vercel.app/ui/components/card#code-in-a-card)
- **How to test:** in the "Code in a card" example the code block sits flush under the card header, with no rounded corners inside the card, and its bottom corners match the card's radius.

## Notes / rollout

- Closes #2964
