### PR TITLE
Let the docs table of contents scroll when it is taller than the viewport

### DIFF
--- a/.changeset/fix-docs-toc-scroll.md
+++ b/.changeset/fix-docs-toc-scroll.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Fixed the docs "On this page" list running past the viewport; the sticky rail now scrolls on its own.

--- a/docs/scss/docs.scss
+++ b/docs/scss/docs.scss
@@ -606,6 +606,10 @@ html {
 }
 
 // The table of contents sticks too, so it has to clear the header (#2421).
+// A long list must not run past the viewport either: the rail is capped at the
+// space below the header and scrolls on its own (#2965).
 .docs-toc-sticky {
   top: var(--docs-header-height);
+  max-height: calc(100vh - var(--docs-header-height));
+  overflow-y: auto;
 }


### PR DESCRIPTION
## Summary

- The sticky "On this page" rail had no height limit, so on a short viewport (a tiled window, ~1500×600) a long list ran past the bottom edge and the last links could not be reached.
- `.docs-toc-sticky` is now capped at the space below the header (`100vh` minus `--docs-header-height`) and scrolls on its own. Pages with a short list are unchanged.

## Preview

- **URL:** [ui/components/card](https://tabler-docs-git-fix-docs-toc-scroll-tabler-io.vercel.app/ui/components/card)
- **How to test:** make the window about 1500×600 (wide enough to show the rail, short enough to cut the list). Scroll inside the "On this page" rail: the last entries are reachable and the rail stays below the header.

## Notes / rollout

- Closes #2965
