### PR TITLE
Style the `email-inbox` message list with a list group

### DIFF
--- a/.build/markup-classes-baseline.txt
+++ b/.build/markup-classes-baseline.txt
@@ -1,7 +1,6 @@
 # Classes used in the rendered html that no stylesheet defines on purpose:
 # JavaScript hooks and demo-only markers. One per line; delete a line when the hook goes.
 callout-note
-checkbox-wrapper-mail
 datagrid-content
 datagrid-item
 datatable
@@ -11,17 +10,7 @@ docs-search
 docs-theme-toggle
 dropzone-msg-desc
 dropzone-msg-title
-email-action-icons
-email-action-icons-item
-email-border
-email-content
-email-date
-email-list
-email-sender-info
-email-subject
-email-title
 fallback
-file-offcanvas
 github-dark
 icon-tabler
 icon-tabler-pencil
@@ -47,7 +36,6 @@ sort-score
 sort-status
 sort-tags
 sort-type
-star-toggle
 table-tbody
 tblr-illustrations-computer-fix-a
 tblr-illustrations-computer-fix-b

--- a/.changeset/fix-email-inbox-list.md
+++ b/.changeset/fix-email-inbox-list.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": patch
+---
+
+Fixed the unstyled message list on the `email-inbox` page: a hoverable list group with label dots, dates and row actions.

--- a/preview/pages/email-inbox.astro
+++ b/preview/pages/email-inbox.astro
@@ -10,14 +10,20 @@ import Progress from '@ui/Progress.astro'
 import Modal from '@shared/components/modals/Modal.astro'
 import CaptureModal from '@shared/components/CaptureModal.astro'
 import NewEmailModalContent from '@shared/components/modals/NewEmailModalContent.astro'
+import ListGroup from '@ui/ListGroup.astro'
+import ListGroupItem from '@ui/ListGroupItem.astro'
+import { formatShortDate } from '@shared/lib/date-format'
 import mails from '@data/mails.json'
+
+// Label colors shared by the folder sidebar and the dots in the message list.
+const labelColors: Record<string, string> = { Updates: 'info', Friends: 'warning', Family: 'success', Social: 'primary', Important: 'danger', Promotions: 'purple' }
 ---
 
 <DefaultLayout title="Email inbox" pageHeader="Inbox" pageMenu="extra.email-inbox" pageLibs={['hugerte']}>
   <Card>
     <div class="row g-0">
-      <div class="col-xxl-3 email-border border-end">
-        <Offcanvas responsive="xxl" direction="start" class="h-100 file-offcanvas" tabindex="-1" id="emailSidebaroffcanvas">
+      <div class="col-xxl-3 border-end">
+        <Offcanvas responsive="xxl" direction="start" class="h-100" tabindex="-1" id="emailSidebaroffcanvas">
           <div class="card-body h-100">
             <div>
               <Button icon="pencil" text="Compose" color="primary" class="d-none d-sm-block" modalId="new-email" />
@@ -40,24 +46,13 @@ import mails from '@data/mails.json'
             <div class="mt-4">
               <Subheader as="h6">Labels</Subheader>
               <div class="mt-2 nav nav-vertical">
-                <a href="#" class="nav-link">
-                  <div class="badge bg-info me-2"></div> Updates
-                </a>
-                <a href="#" class="nav-link">
-                  <div class="badge bg-warning me-2"></div> Friends
-                </a>
-                <a href="#" class="nav-link">
-                  <div class="badge bg-success me-2"></div> Family
-                </a>
-                <a href="#" class="nav-link">
-                  <div class="badge bg-primary me-2"></div> Social
-                </a>
-                <a href="#" class="nav-link">
-                  <div class="badge bg-danger me-2"></div> Important
-                </a>
-                <a href="#" class="nav-link">
-                  <div class="badge bg-purple me-2"></div> Promotions
-                </a>
+                {
+                  Object.entries(labelColors).map(([label, color]) => (
+                    <a href="#" class="nav-link">
+                      <span class={`badge bg-${color} me-2`} /> {label}
+                    </a>
+                  ))
+                }
               </div>
             </div>
 
@@ -126,67 +121,61 @@ import mails from '@data/mails.json'
             </ButtonGroup>
           </div>
 
-          <div class="mt-3">
-            <ul class="email-list">
-              {
-                mails && mails.length > 0 ? (
-                  mails.map((mail) => (
-                    <li>
-                      <div class="email-sender-info">
-                        <div class="checkbox-wrapper-mail">
-                          <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id={`mail-${mail.id}`} />
-                            <label class="form-check-label" for={`mail-${mail.id}`} />
-                          </div>
-                        </div>
-                        <span class="star-toggle">
-                          <Icon name="star" />
-                        </span>
-                        <a href="#" class="email-title">
+          <ListGroup flush hoverable class="mt-3 border-top">
+            {
+              mails.length > 0 ? (
+                mails.map((mail) => (
+                  <ListGroupItem class="px-0">
+                    <div class="row align-items-center g-2">
+                      <div class="col-auto">
+                        <input type="checkbox" class="form-check-input m-0" aria-label={`Select "${mail.subject}"`} />
+                      </div>
+                      <div class="col-auto">
+                        <a href="#" class:list={['list-group-item-actions', mail.starred && 'show']} aria-label={mail.starred ? 'Remove star' : 'Add star'}>
+                          <Icon name="star" color={mail.starred ? 'yellow' : 'muted'} />
+                        </a>
+                      </div>
+                      <div class="col-3 col-lg-2 text-truncate">
+                        <a href="#" class="text-body">
                           {mail.sender}
                         </a>
                       </div>
-
-                      <div class="email-content">
-                        <a href="#" class="email-subject">
-                          {mail.subject} &nbsp;–&nbsp;
-                          <span>{mail.preview}</span>
+                      <div class="col text-truncate">
+                        <a href="#" class="text-body">
+                          {mail.subject}
                         </a>
-                        <div class="email-date">{mail.date}</div>
+                        <span class="text-secondary"> – {mail.preview}</span>
                       </div>
-
-                      <div class="email-action-icons">
-                        <ul class="list-inline">
-                          <li class="list-inline-item">
-                            <a href="#" aria-label="Archive">
-                              <Icon name="archive" />
-                            </a>
-                          </li>
-                          <li class="list-inline-item">
-                            <a href="#" aria-label="Delete">
-                              <Icon name="trash" />
-                            </a>
-                          </li>
-                          <li class="list-inline-item">
-                            <a href="#" aria-label="Mark as read">
-                              <Icon name="mail-opened" class="email-action-icons-item" />
-                            </a>
-                          </li>
-                          <li class="list-inline-item">
-                            <a href="#" aria-label="Snooze">
-                              <Icon name="clock" />
-                            </a>
-                          </li>
-                        </ul>
+                      <div class="col-auto d-none d-lg-block">
+                        {mail.labels.map((label) => (
+                          <span class={`badge bg-${labelColors[label] ?? 'secondary'}`} title={label} aria-label={label} />
+                        ))}
                       </div>
-                    </li>
-                  ))
-                ) : (
-                  <li class="text-muted">No emails</li>
-                )
-              }
-            </ul>
-          </div>
+                      <div class="col-auto d-none d-md-block">
+                        <div class="list-group-item-actions d-flex gap-2">
+                          <a href="#" class="text-secondary" aria-label="Archive">
+                            <Icon name="archive" />
+                          </a>
+                          <a href="#" class="text-secondary" aria-label="Delete">
+                            <Icon name="trash" />
+                          </a>
+                          <a href="#" class="text-secondary" aria-label="Mark as read">
+                            <Icon name="mail-opened" />
+                          </a>
+                          <a href="#" class="text-secondary" aria-label="Snooze">
+                            <Icon name="clock" />
+                          </a>
+                        </div>
+                      </div>
+                      <div class="col-auto text-secondary text-end">{formatShortDate(new Date(mail.date))}</div>
+                    </div>
+                  </ListGroupItem>
+                ))
+              ) : (
+                <ListGroupItem class="text-secondary">No emails</ListGroupItem>
+              )
+            }
+          </ListGroup>
 
           <div class="row">
             <div class="col-7 mt-1">

--- a/preview/pages/email-inbox.astro
+++ b/preview/pages/email-inbox.astro
@@ -26,17 +26,17 @@ const labelColors: Record<string, string> = { Updates: 'info', Friends: 'warning
         <Offcanvas responsive="xxl" direction="start" class="h-100" tabindex="-1" id="emailSidebaroffcanvas">
           <div class="card-body h-100">
             <div>
-              <Button icon="pencil" text="Compose" color="primary" class="d-none d-sm-block" modalId="new-email" />
+              <Button icon="pencil" text="Compose" color="primary" block class="d-none d-sm-block" modalId="new-email" />
             </div>
 
-            <div class="mt-3 nav nav-vertical">
-              <a href="#" class="nav-link text-danger fw-bold">
+            <div class="mt-3 nav nav-vertical nav-pills">
+              <a href="#" class="nav-link active">
                 <Icon name="inbox" class="me-2" />
-                Inbox<span class="badge bg-danger ms-auto">{mails.length}</span>
+                Inbox<span class="badge bg-primary-lt ms-auto">{mails.length}</span>
               </a>
               <a href="#" class="nav-link"><Icon name="star" class="me-2" />Starred</a>
               <a href="#" class="nav-link"><Icon name="clock" class="me-2" />Snoozed</a>
-              <a href="#" class="nav-link"><Icon name="file" class="me-2" />Draft<span class="badge bg-info ms-auto">32</span></a>
+              <a href="#" class="nav-link"><Icon name="file" class="me-2" />Draft<span class="badge bg-info-lt ms-auto">32</span></a>
               <a href="#" class="nav-link"><Icon name="mail-up" class="me-2" />Sent Mail</a>
               <a href="#" class="nav-link"><Icon name="trash" class="me-2" />Trash</a>
               <a href="#" class="nav-link"><Icon name="tag" class="me-2" />Important</a>
@@ -45,7 +45,7 @@ const labelColors: Record<string, string> = { Updates: 'info', Friends: 'warning
 
             <div class="mt-4">
               <Subheader as="h6">Labels</Subheader>
-              <div class="mt-2 nav nav-vertical">
+              <div class="mt-2 nav nav-vertical nav-pills">
                 {
                   Object.entries(labelColors).map(([label, color]) => (
                     <a href="#" class="nav-link">
@@ -107,12 +107,11 @@ const labelColors: Record<string, string> = { Updates: 'info', Friends: 'warning
               </div>
             </ButtonGroup>
 
-            <ButtonGroup>
+            <ButtonGroup class="ms-auto">
               <button type="button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
                 <Icon name="dots" /> More
               </button>
-              <div class="dropdown-menu">
-                <span class="dropdown-header">More Options :</span>
+              <div class="dropdown-menu dropdown-menu-end">
                 <a class="dropdown-item" href="#">Mark as Unread</a>
                 <a class="dropdown-item" href="#">Add to Tasks</a>
                 <a class="dropdown-item" href="#">Add Star</a>
@@ -120,12 +119,14 @@ const labelColors: Record<string, string> = { Updates: 'info', Friends: 'warning
               </div>
             </ButtonGroup>
           </div>
+		</div>
+		<div class="card-body p-0">
 
-          <ListGroup flush hoverable class="mt-3 border-top">
+          <ListGroup flush hoverable>
             {
               mails.length > 0 ? (
                 mails.map((mail) => (
-                  <ListGroupItem class="px-0">
+                  <ListGroupItem>
                     <div class="row align-items-center g-2">
                       <div class="col-auto">
                         <input type="checkbox" class="form-check-input m-0" aria-label={`Select "${mail.subject}"`} />
@@ -176,8 +177,10 @@ const labelColors: Record<string, string> = { Updates: 'info', Friends: 'warning
               )
             }
           </ListGroup>
+		</div>
+		<div class="card-body">
 
-          <div class="row">
+          <div class="row align-items-center">
             <div class="col-7 mt-1">
               Showing 1 - {mails.length} of {mails.length}
             </div>

--- a/preview/pages/email-inbox.astro
+++ b/preview/pages/email-inbox.astro
@@ -119,9 +119,8 @@ const labelColors: Record<string, string> = { Updates: 'info', Friends: 'warning
               </div>
             </ButtonGroup>
           </div>
-		</div>
-		<div class="card-body p-0">
-
+        </div>
+        <div class="card-body p-0">
           <ListGroup flush hoverable>
             {
               mails.length > 0 ? (
@@ -177,9 +176,8 @@ const labelColors: Record<string, string> = { Updates: 'info', Friends: 'warning
               )
             }
           </ListGroup>
-		</div>
-		<div class="card-body">
-
+        </div>
+        <div class="card-body">
           <div class="row align-items-center">
             <div class="col-7 mt-1">
               Showing 1 - {mails.length} of {mails.length}

--- a/shared/lib/date-format.test.ts
+++ b/shared/lib/date-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatCommitDate, formatLongDate, formatUtcTimestamp, toUnixSeconds } from './date-format'
+import { formatCommitDate, formatShortDate, formatLongDate, formatUtcTimestamp, toUnixSeconds } from './date-format'
 
 describe('formatCommitDate', () => {
   it('reformats a full timestamp to "D Mon YYYY"', () => {
@@ -34,5 +34,12 @@ describe('formatUtcTimestamp', () => {
   it('formats a date as "YYYY-MM-DD HH:MM +0000"', () => {
     const date = new Date(Date.UTC(2025, 10, 28, 8, 5))
     expect(formatUtcTimestamp(date)).toBe('2025-11-28 08:05 +0000')
+  })
+})
+
+describe('formatShortDate', () => {
+  it('formats the UTC day and short month', () => {
+    expect(formatShortDate(new Date('2025-08-27T11:49:00Z'))).toBe('27 Aug')
+    expect(formatShortDate(new Date('2025-01-01T00:30:00Z'))).toBe('1 Jan')
   })
 })

--- a/shared/lib/date-format.ts
+++ b/shared/lib/date-format.ts
@@ -1,6 +1,7 @@
 // Demo data date formatting quirks:
 // - unix seconds are shifted by local timezone offset (not the true epoch)
 // - long-date format uses UTC wall-clock components
+const SHORT_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
 
 /** Unix seconds shifted by the local timezone offset (not the true epoch). */
@@ -11,6 +12,11 @@ export function toUnixSeconds(date: Date): number {
 /** Formats a date as "Month DD, YYYY" using its UTC components. */
 export function formatLongDate(date: Date): string {
   return `${MONTHS[date.getUTCMonth()]} ${String(date.getUTCDate()).padStart(2, '0')}, ${date.getUTCFullYear()}`
+}
+
+/** Formats a date as "D Mon" using its UTC components, e.g. "27 Aug". */
+export function formatShortDate(date: Date): string {
+  return `${date.getUTCDate()} ${SHORT_MONTHS[date.getUTCMonth()]}`
 }
 
 /** Reformats a commit-style timestamp ("Thu Nov 28 08:48:33 2025 +0100") to "28 Nov 2025". */


### PR DESCRIPTION
## Summary

- The message list on `email-inbox` used classes (`email-list`, `email-title`, `email-date`, `star-toggle`, …) that no stylesheet defines, so it rendered as a plain bulleted list with raw ISO dates. The report calls this "email templates", but the screenshot is this preview page.
- The list is now a flush, hoverable list group: checkbox, star (yellow and always visible when starred, otherwise shown on hover), sender, subject with the truncated preview, one colored dot per label, row actions (archive, delete, mark as read, snooze) revealed on hover, and a short date on the right. Labels and the list dots share one color map, and the folder sidebar renders its label links from it too.
- Dates are formatted with a new `formatShortDate()` helper in `shared/lib/date-format.ts` ("27 Aug"), covered by a test.
- The dead classes were removed from the page and from `.build/markup-classes-baseline.txt`, so the markup gate would catch them if they came back.

Checked at 1400×900 in light and dark mode, on hover, and at 375px, where the label dots and row actions are hidden and the row keeps checkbox, star, sender, subject and date. `astro check` for preview and shared, and the shared unit tests, pass.

## Preview

- **URL:** [email-inbox.html](https://tabler-git-fix-email-inbox-list-tabler-io.vercel.app/email-inbox.html)
- **How to test:** open the page. Each row is a single line with a colored label dot and a date on the right. Hover a row: the archive, delete, mark-as-read and snooze icons appear next to the date. Toggle dark mode and shrink the window below 768px.

## Notes / rollout

- Closes #2961
