### PR TITLE
Run the release workflow on `dev` only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-      - v2-dev
 
 permissions:
   contents: read
@@ -34,15 +33,12 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      # Both branches get their own "chore: update versions" PR. Only `dev` publishes:
-      # `v2-dev` carries a major changeset, and an empty publish-script keeps the action
-      # from shipping 2.0.0 to npm as `latest` once that PR is merged.
       - name: Create release Pull Request or publish to NPM
         id: changesets
         uses: changesets/action@v2
         with:
           version-script: pnpm run version
-          publish-script: ${{ github.ref_name == 'dev' && 'pnpm run publish' || '' }}
+          publish-script: pnpm run publish
           commit-message: "chore: update versions"
           pr-title: "chore: update versions"
         env:


### PR DESCRIPTION
## Summary

- The release workflow no longer runs on `v2-dev`. This reverts #2988: the `v2-dev` trigger and the conditional `publish-script` are gone, and the file is identical to the one on `dev` again.
- `changesets/action` stops maintaining a second "chore: update versions" PR for 2.0. The changesets on `v2-dev` stay in `.changeset/` and get versioned when the 2.0 release is prepared.

## Preview

No visual changes. Review `.github/workflows/release.yml`: the `branches` list has `dev` only and `publish-script` is `pnpm run publish` again.

## Notes / rollout

- The bot PR #2989 (`changeset-release/v2-dev`) will not be refreshed any more and can be closed, with its branch deleted.
- No changeset: CI only.
