### PR TITLE
Fix several descriptions on the avatars preview page

### DIFF
--- a/.changeset/avatar-page-descriptions.md
+++ b/.changeset/avatar-page-descriptions.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": patch
+---
+
+Updated the avatar list and brand card descriptions on the avatars preview page.

--- a/preview/pages/avatars.astro
+++ b/preview/pages/avatars.astro
@@ -169,7 +169,7 @@ const brands = ['netflix', 'amazon', 'messenger', 'figma', 'twitch']
       <Card>
         <CardBody>
           <CardTitle>Avatar brands</CardTitle>
-          <CardSubtitle>Show a recognizable brand icon instead of a person.</CardSubtitle>
+          <CardSubtitle>Add a recognizable brand icon on top of an avatar.</CardSubtitle>
           {brands.map((brand, i) => <Avatar person={personById(i + 1)} brand={brand} />)}
         </CardBody>
       </Card>

--- a/preview/pages/avatars.astro
+++ b/preview/pages/avatars.astro
@@ -119,7 +119,7 @@ const brands = ['netflix', 'amazon', 'messenger', 'figma', 'twitch']
       <Card>
         <CardBody>
           <CardTitle>Avatar lists</CardTitle>
-          <CardSubtitle>Stack avatars with <code>&lt;AvatarList&gt;</code> to show a group at a glance.</CardSubtitle>
+          <CardSubtitle>Stack avatars inside an <code>.avatar-list</code> container to show a group at a glance.</CardSubtitle>
           <div class="row g-3">
             {
               listSizes.map((size) => (


### PR DESCRIPTION
The current Avatars page has a description that refers to an `<AvatarList>`, that was presumably intended to be rewritten as part of https://github.com/tabler/tabler/pull/2995, but was missed.

Also, the description next to the 'avatar brands' preview is inaccurate and this PR includes a suggested rewriting. Let me know if you want me to adjust it.
