### PR TITLE
Hide the docs "Copy to LLM" button on phones

### DIFF
--- a/docs/components/DocsCopyMarkdownLink.astro
+++ b/docs/components/DocsCopyMarkdownLink.astro
@@ -20,8 +20,8 @@ const askChatGptUrl = prompt && `https://chatgpt.com/?q=${encodeURIComponent(pro
 const askClaudeUrl = prompt && `https://claude.ai/new?q=${encodeURIComponent(prompt)}`
 ---
 
-<div class="btn-group">
-  <button type="button" class:list={['btn btn-sm', className]} data-docs-copy-markdown-link={url}>
+<div class:list={['btn-group', className]}>
+  <button type="button" class="btn btn-sm" data-docs-copy-markdown-link={url}>
     <Icon name="clipboard" />
     <Icon name="check" class="d-none" />
     <span data-docs-copy-markdown-link-label>Copy to LLM</span>

--- a/docs/layouts/DocsLayout.astro
+++ b/docs/layouts/DocsLayout.astro
@@ -370,7 +370,7 @@ const relatedPages = await Promise.all(
 													</ol>
 												</nav>
 											)}
-											{markdownUrl && <DocsCopyMarkdownLink url={markdownUrl} absoluteUrl={canonicalMarkdownUrl} />}
+											{markdownUrl && <DocsCopyMarkdownLink url={markdownUrl} absoluteUrl={canonicalMarkdownUrl} class="ms-auto d-none d-sm-block" />}
 										</div>
 									)
 								}


### PR DESCRIPTION
## Summary

- Hide the docs "Copy to LLM" button on phones. It is now `d-none` by default and `d-sm-block` from the small breakpoint up, so it only shows once there is room for it next to the breadcrumb.
- Push the button to the end of its row with `ms-auto` instead of leaving it inline.
- `DocsCopyMarkdownLink` now puts the passed `class` on the `.btn-group` wrapper instead of the inner `<button>`, so layout classes move the whole control rather than just the button.

## Preview

- **URL:** the Vercel bot posts the `tabler-docs` preview link on this PR once the build finishes.
- **How to test:** open any docs content page (for example `/ui/components/badge`). On a narrow / phone-width viewport the "Copy to LLM" split button should not appear. Widen the window past the `sm` breakpoint and it should show again, aligned to the right of the breadcrumb row. The dropdown and its "View as markdown", "Ask ChatGPT" and "Ask Claude" actions should still work.

## Notes / rollout

- Docs-only, no changeset. The original "Copy to LLM" feature already shipped to `main` in #2952.

