### PR TITLE
Rewrite `ScrollSpy` on an IntersectionObserver activation line

### DIFF
--- a/.changeset/scrollspy-activation-line.md
+++ b/.changeset/scrollspy-activation-line.md
@@ -1,0 +1,6 @@
+---
+"@tabler/core": minor
+"@tabler/preview": patch
+---
+
+Rewrote `ScrollSpy` on an IntersectionObserver activation line with a bottom sentinel and removed the deprecated `offset` option.

--- a/core/js/src/bootstrap/dom/event-handler.ts
+++ b/core/js/src/bootstrap/dom/event-handler.ts
@@ -76,6 +76,7 @@ const nativeEvents = new Set([
   'error',
   'abort',
   'scroll',
+  'scrollend',
 ])
 
 function makeEventUid(element: EventableElement | EventCallback, uid?: string): string | number {

--- a/core/js/src/bootstrap/scrollspy.ts
+++ b/core/js/src/bootstrap/scrollspy.ts
@@ -8,7 +8,7 @@
 import BaseComponent from './base-component'
 import EventHandler from './dom/event-handler'
 import SelectorEngine from './dom/selector-engine'
-import { getElement, isDisabled, isVisible, parseSelector } from './util/index'
+import { getElement, isDisabled, isVisible } from './util/index'
 import type { ComponentConfig, ComponentConfigType } from './types'
 
 const NAME = 'scrollspy'
@@ -18,6 +18,9 @@ const DATA_API_KEY = '.data-api'
 
 const EVENT_ACTIVATE = `activate${EVENT_KEY}`
 const EVENT_CLICK = `click${EVENT_KEY}`
+const EVENT_SCROLL = `scroll${EVENT_KEY}`
+const EVENT_SCROLLEND = `scrollend${EVENT_KEY}`
+const EVENT_RESIZE = `resize${EVENT_KEY}`
 const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_DROPDOWN_ITEM = 'dropdown-item'
@@ -33,45 +36,95 @@ const SELECTOR_LINK_ITEMS = `${SELECTOR_NAV_LINKS}, ${SELECTOR_NAV_ITEMS} > ${SE
 const SELECTOR_DROPDOWN = '.dropdown'
 const SELECTOR_DROPDOWN_TOGGLE = '.dropdown-toggle'
 
+// How long (ms) to wait after the last scroll event before settling a pending
+// smooth-scroll navigation, when the native `scrollend` event is unavailable.
+const SCROLL_IDLE_TIMEOUT = 100
+// Debounce (ms) for rebuilding the observer on resize (px activation lines only).
+const RESIZE_DEBOUNCE = 100
+
 const Default: ComponentConfig = {
-  offset: null,
-  rootMargin: '0px 0px -25%',
+  // `rootMargin` is the raw IntersectionObserver root-box override. When set it
+  // takes precedence over `topMargin` and is passed straight to the observer.
+  // Leave it null and use `topMargin` for everyday use.
+  rootMargin: null,
   smoothScroll: false,
   target: null,
-  threshold: [0.1, 0.5, 1],
+  threshold: [0],
+  // Position of the activation line, measured from the top of the scroll root.
+  // The active section is the deepest one whose top has scrolled to/above it.
+  // Accepts a percentage (`12%`) or pixels (`96px`, e.g. below a sticky navbar).
+  topMargin: '12%',
 }
 
 const DefaultType: ComponentConfigType = {
-  offset: '(number|null)',
-  rootMargin: 'string',
+  rootMargin: '(string|null)',
   smoothScroll: 'boolean',
   target: 'element',
   threshold: 'array',
+  topMargin: 'string',
+}
+
+// Decode a URL fragment id, tolerating malformed escapes (returns it as-is).
+const decodeFragment = (hash: string): string => {
+  try {
+    return decodeURIComponent(hash)
+  } catch {
+    return hash
+  }
 }
 
 class ScrollSpy extends BaseComponent {
-  _targetLinks: Map<string, HTMLElement>
-  _observableSections: Map<string, HTMLElement>
-  _rootElement: HTMLElement | null
+  _sections: HTMLElement[]
+  _linkBySection: Map<HTMLElement, HTMLElement>
+  _sectionByLink: Map<HTMLElement, HTMLElement>
+  _intersecting: Set<HTMLElement>
   _activeTarget: HTMLElement | null
+  _lastActive: HTMLElement | null
+  _sentinelVisible: boolean
+  _bottomScrollHandler: (() => void) | null
+  _bottomScrollFrame: number | null
+  _triggers: number[]
+  _maxScroll: number
+  _rootElement: HTMLElement | null
   _observer: IntersectionObserver | null
-  _previousScrollData: {
-    visibleEntryTop: number
-    parentScrollTop: number
-  }
+  _sentinel: HTMLElement | null
+  _sentinelObserver: IntersectionObserver | null
+  _pendingNavigation: { hash: string; section: HTMLElement } | null
+  _settleTimeout: ReturnType<typeof setTimeout> | null
+  _settleHandler: (() => void) | null
+  _scrollIdleHandler: (() => void) | null
+  _resizeHandler: (() => void) | null
+  _resizeTimeout: ReturnType<typeof setTimeout> | null
 
   constructor(element: HTMLElement | string, config?: Partial<ComponentConfig>) {
     super(element, config)
 
-    this._targetLinks = new Map()
-    this._observableSections = new Map()
-    this._rootElement = getComputedStyle(this._element).overflowY === 'visible' ? null : this._element
+    // this._element is the observablesContainer and config.target the menu links wrapper
+    this._sections = [] // observable section elements, in DOM order
+    this._linkBySection = new Map() // section element -> nav link
+    this._sectionByLink = new Map() // nav link -> section element (for smooth scroll)
+    this._intersecting = new Set() // sections currently crossing the activation line
     this._activeTarget = null
+    this._lastActive = null // last activated section (keep-last across gaps)
+    this._sentinelVisible = false
+    this._bottomScrollHandler = null
+    this._bottomScrollFrame = null
+    this._triggers = [] // scroll position at which each section reaches the line
+    this._maxScroll = 0
+    this._rootElement = getComputedStyle(this._element).overflowY === 'visible' ? null : this._element
+
     this._observer = null
-    this._previousScrollData = {
-      visibleEntryTop: 0,
-      parentScrollTop: 0,
-    }
+    this._sentinel = null
+    this._sentinelObserver = null
+
+    this._pendingNavigation = null
+    this._settleTimeout = null
+    this._settleHandler = null
+    this._scrollIdleHandler = null
+
+    this._resizeHandler = null
+    this._resizeTimeout = null
+
     this.refresh()
   }
 
@@ -91,26 +144,37 @@ class ScrollSpy extends BaseComponent {
     this._initializeTargetsAndObservables()
     this._maybeEnableSmoothScroll()
 
-    if (this._observer) {
-      this._observer.disconnect()
-    } else {
-      this._observer = this._getNewObserver()
-    }
-
-    for (const section of this._observableSections.values()) {
+    // (Re)build the activation observer.
+    this._observer?.disconnect()
+    this._intersecting.clear()
+    this._observer = this._getNewObserver()
+    for (const section of this._sections) {
       this._observer.observe(section)
     }
+
+    // Measure where each section would cross the line, so the tail sections a
+    // short page can't scroll up to the line still get their turn.
+    this._measure()
+
+    // Detect the bottom-of-page case (short trailing sections whose tops never
+    // reach the activation line) via a dedicated sentinel observer.
+    this._setUpSentinel()
+
+    // Keep the measurements (and, for a px line, the observer) current on resize.
+    this._addResizeListener()
   }
 
   dispose(): void {
-    this._observer!.disconnect()
+    this._observer?.disconnect()
+    this._teardownSentinel()
+    this._disarmSettle()
+    this._removeResizeListener()
+    EventHandler.off(this._config.target as HTMLElement, EVENT_CLICK)
     super.dispose()
   }
 
   _configAfterMerge(config: ComponentConfig): ComponentConfig {
     config.target = getElement(config.target) || document.body
-
-    config.rootMargin = config.offset ? `${config.offset}px 0px -30%` : config.rootMargin
 
     if (typeof config.threshold === 'string') {
       config.threshold = config.threshold.split(',').map((value: string) => Number.parseFloat(value))
@@ -119,92 +183,477 @@ class ScrollSpy extends BaseComponent {
     return config
   }
 
-  _maybeEnableSmoothScroll(): void {
-    if (!this._config.smoothScroll) {
-      return
-    }
-
-    EventHandler.off(this._config.target as HTMLElement, EVENT_CLICK)
-
-    EventHandler.on(this._config.target as HTMLElement, EVENT_CLICK, SELECTOR_TARGET_LINKS, (event: Event) => {
-      const observableSection = this._observableSections.get((event.target as HTMLAnchorElement).hash)
-      if (observableSection) {
-        event.preventDefault()
-        const root = this._rootElement || window
-        const height = observableSection.offsetTop - this._element.offsetTop
-        if ('scrollTo' in root) {
-          root.scrollTo({ top: height, behavior: 'smooth' })
-          return
-        }
-
-        ;(root as HTMLElement).scrollTop = height
-      }
-    })
-  }
+  // --- Detection (IntersectionObserver-driven) -----------------------------
 
   _getNewObserver(): IntersectionObserver {
     const options: IntersectionObserverInit = {
       root: this._rootElement,
       threshold: this._config.threshold as number[],
-      rootMargin: this._config.rootMargin as string,
+      rootMargin: (this._config.rootMargin as string | null) ?? this._getDerivedRootMargin(),
     }
 
-    return new IntersectionObserver((entries) => this._observerCallback(entries), options)
+    return new IntersectionObserver((entries) => this._onIntersect(entries), options)
   }
 
-  _observerCallback(entries: IntersectionObserverEntry[]): void {
-    const targetElement = (entry: IntersectionObserverEntry) => this._targetLinks.get(`#${entry.target.id}`)
-    const activate = (entry: IntersectionObserverEntry) => {
-      this._previousScrollData.visibleEntryTop = (entry.target as HTMLElement).offsetTop
-      this._process(targetElement(entry)!)
+  _onIntersect(entries: IntersectionObserverEntry[]): void {
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        this._intersecting.add(entry.target as HTMLElement)
+      } else {
+        this._intersecting.delete(entry.target as HTMLElement)
+      }
     }
 
-    const parentScrollTop = (this._rootElement || document.documentElement).scrollTop
-    const userScrollsDown = parentScrollTop >= this._previousScrollData.parentScrollTop
-    this._previousScrollData.parentScrollTop = parentScrollTop
+    this._computeActive()
+  }
 
-    for (const entry of entries) {
-      if (!entry.isIntersecting) {
-        this._activeTarget = null
-        this._clearActiveClass(targetElement(entry)!)
+  // Single source of truth for active selection. It runs off IO state (the
+  // deepest DOM-order section crossing the activation line; keep-last across a
+  // gap; the first section stays active at the top). Near the bottom, where a
+  // short page can't scroll the trailing sections up to the line, it hands off
+  // to `_tailActiveIndex`, which spreads the leftover scroll across them.
+  _computeActive(): void {
+    // Guard against observer callbacks that outlive a disposed/detached instance.
+    if (!this._element?.isConnected || this._sections.length === 0) {
+      return
+    }
 
-        continue
+    let active: HTMLElement | null = null
+
+    const tailIndex = this._tailActiveIndex()
+    if (tailIndex !== -1) {
+      active = this._sections[tailIndex]
+    } else {
+      for (const section of this._sections) {
+        if (this._intersecting.has(section)) {
+          active = section
+        }
       }
 
-      const entryIsLowerThanPrevious = (entry.target as HTMLElement).offsetTop >= this._previousScrollData.visibleEntryTop
-      if (userScrollsDown && entryIsLowerThanPrevious) {
-        activate(entry)
-        if (!parentScrollTop) {
+      // No section crosses the line: keep the last active (content gap), or fall
+      // back to the first section at the top of the page.
+      active ||= this._lastActive ?? this._sections[0]
+    }
+
+    if (!active) {
+      return
+    }
+
+    this._lastActive = active
+    const link = this._linkBySection.get(active)
+    if (link) {
+      this._process(link)
+    }
+  }
+
+  // Distance of the activation line from the top of the scroll root, in pixels.
+  _lineOffset(): number {
+    const { value, unit } = this._parseTopMargin()
+    if (unit === 'px') {
+      return value
+    }
+
+    const rootHeight = this._rootElement ? this._rootElement.clientHeight : document.documentElement.clientHeight || window.innerHeight
+    return (value / 100) * rootHeight
+  }
+
+  _scroller(): HTMLElement {
+    return this._rootElement || (document.scrollingElement as HTMLElement) || document.documentElement
+  }
+
+  // Record, per section, the scroll position at which its top meets the line,
+  // plus the scroll root's maximum scroll. Read on refresh/resize/approach —
+  // never on the hot path.
+  _measure(): void {
+    if (!this._element?.isConnected) {
+      return
+    }
+
+    const scroller = this._scroller()
+    this._maxScroll = Math.max(scroller.scrollHeight - scroller.clientHeight, 0)
+
+    const offset = this._lineOffset()
+    const base = this._rootElement ? this._rootElement.getBoundingClientRect().top - this._rootElement.scrollTop : -window.scrollY
+
+    this._triggers = this._sections.map((section) => section.getBoundingClientRect().top - base - offset)
+  }
+
+  // When trailing sections can't be scrolled up to the line, IO state alone
+  // would leave them (and often the last one) unreachable. Once we're in that
+  // zone, spread the remaining scroll evenly across them so every link lights
+  // up. Returns -1 whenever normal IO selection should stand.
+  _tailActiveIndex(): number {
+    // Not near the bottom, no sections measured, or nothing actually scrolls.
+    if (!this._bottomScrollHandler || this._triggers.length === 0 || this._maxScroll <= 0) {
+      return -1
+    }
+
+    let firstUnreachable = -1
+    for (const [index, trigger] of this._triggers.entries()) {
+      if (trigger > this._maxScroll + 1) {
+        firstUnreachable = index
+        break
+      }
+    }
+
+    if (firstUnreachable === -1) {
+      return -1
+    }
+
+    const anchor = Math.max(firstUnreachable - 1, 0)
+    const start = Math.min(this._triggers[anchor], this._maxScroll)
+    const scrollTop = this._scroller().scrollTop
+
+    if (scrollTop < start - 1) {
+      return -1
+    }
+
+    const tailCount = this._sections.length - anchor
+    const span = Math.max(this._maxScroll - start, 1)
+    const progress = Math.min(Math.max((scrollTop - start) / span, 0), 1)
+
+    return anchor + Math.min(Math.floor(progress * tailCount), tailCount - 1)
+  }
+
+  // Single source of truth for the `topMargin` option: its numeric value and
+  // whether it's expressed as a percentage of the root height or in pixels.
+  _parseTopMargin(): { value: number; unit: '%' | 'px' } {
+    const value = String(this._config.topMargin)
+    return {
+      value: Number.parseFloat(value) || 0,
+      unit: value.endsWith('%') ? '%' : 'px',
+    }
+  }
+
+  // Collapse the observer root to a strip from the top down to the activation
+  // line, so a section is "intersecting" exactly while it crosses that line.
+  _getDerivedRootMargin(): string {
+    const { value, unit } = this._parseTopMargin()
+    let percent = value
+
+    // Express a pixel activation line as a percentage of the root height.
+    if (unit === 'px') {
+      const rootHeight = this._rootElement ? this._rootElement.clientHeight : document.documentElement.clientHeight || window.innerHeight
+      percent = rootHeight ? (value / rootHeight) * 100 : 12
+    }
+
+    // Clamp so the bottom inset stays a valid (non-negative) rootMargin even if
+    // the line sits outside the root box.
+    const bottom = Math.min(Math.max(100 - percent, 0), 100)
+    return `0px 0px -${bottom}% 0px`
+  }
+
+  // Whether the activation line is derived from a pixel `topMargin` (in which
+  // case it must be recomputed on resize). An explicit `rootMargin` is owned by
+  // the caller, and a `%` topMargin is recomputed by the browser automatically.
+  _usesPixelMargin(): boolean {
+    return !this._config.rootMargin && this._parseTopMargin().unit === 'px'
+  }
+
+  // --- Bottom sentinel -----------------------------------------------------
+
+  // Trailing sections a short page can't scroll up to the activation line would
+  // never activate on IO state alone. The sentinel sits at the end of the
+  // observable container; when it comes into view we re-measure and arm a
+  // bounded scroll listener so `_tailActiveIndex` can hand the trailing links
+  // their turn as the last of the scroll runs out.
+  _setUpSentinel(): void {
+    this._teardownSentinel()
+
+    if (this._sections.length === 0) {
+      return
+    }
+
+    const sentinel = document.createElement('div')
+    sentinel.setAttribute('aria-hidden', 'true')
+    sentinel.style.cssText = 'position:relative;width:0;height:0;margin:0;padding:0;border:0;visibility:hidden;'
+    this._element.append(sentinel)
+    this._sentinel = sentinel
+
+    // Extend the observer root a full viewport upwards so the watch stays armed
+    // through the true scroll end even when up to ~a screenful of unrelated
+    // content sits below the observable container.
+    this._sentinelObserver = new IntersectionObserver((entries) => this._onSentinel(entries), {
+      root: this._rootElement,
+      rootMargin: '100% 0px 0px 0px',
+      threshold: [0],
+    })
+    this._sentinelObserver.observe(sentinel)
+  }
+
+  _onSentinel(entries: IntersectionObserverEntry[]): void {
+    const entry = entries[entries.length - 1]
+    this._sentinelVisible = Boolean(entry?.isIntersecting)
+
+    if (this._sentinelVisible) {
+      this._measure()
+      this._armBottomWatch()
+    } else {
+      this._disarmBottomWatch()
+    }
+
+    this._computeActive()
+  }
+
+  _armBottomWatch(): void {
+    if (this._bottomScrollHandler) {
+      return
+    }
+
+    this._bottomScrollHandler = () => {
+      if (this._bottomScrollFrame !== null) {
+        return
+      }
+
+      this._bottomScrollFrame = requestAnimationFrame(() => {
+        this._bottomScrollFrame = null
+        this._computeActive()
+      })
+    }
+
+    EventHandler.on(this._getScrollTarget(), EVENT_SCROLL, this._bottomScrollHandler)
+  }
+
+  _disarmBottomWatch(): void {
+    if (this._bottomScrollFrame !== null) {
+      cancelAnimationFrame(this._bottomScrollFrame)
+      this._bottomScrollFrame = null
+    }
+
+    if (this._bottomScrollHandler) {
+      EventHandler.off(this._getScrollTarget(), EVENT_SCROLL, this._bottomScrollHandler)
+      this._bottomScrollHandler = null
+    }
+  }
+
+  _teardownSentinel(): void {
+    this._disarmBottomWatch()
+    this._sentinelObserver?.disconnect()
+    this._sentinelObserver = null
+    this._sentinel?.remove()
+    this._sentinel = null
+    this._sentinelVisible = false
+  }
+
+  // --- Resize ------------------------------------------------------------------
+
+  _addResizeListener(): void {
+    this._removeResizeListener()
+
+    this._resizeHandler = () => {
+      if (this._resizeTimeout) {
+        clearTimeout(this._resizeTimeout)
+      }
+
+      this._resizeTimeout = setTimeout(() => {
+        if (!this._element?.isConnected) {
           return
         }
 
-        continue
-      }
+        // A `%` line tracks viewport height on its own, a `px` one doesn't — so
+        // the observer only needs rebuilding in the px case. The tail
+        // measurements always do.
+        if (this._usesPixelMargin()) {
+          this._rebuildObserver()
+        }
 
-      if (!userScrollsDown && !entryIsLowerThanPrevious) {
-        activate(entry)
-      }
+        this._measure()
+        this._computeActive()
+      }, RESIZE_DEBOUNCE)
+    }
+
+    EventHandler.on(window, EVENT_RESIZE, this._resizeHandler)
+  }
+
+  _removeResizeListener(): void {
+    if (this._resizeTimeout) {
+      clearTimeout(this._resizeTimeout)
+      this._resizeTimeout = null
+    }
+
+    if (this._resizeHandler) {
+      EventHandler.off(window, EVENT_RESIZE, this._resizeHandler)
+      this._resizeHandler = null
     }
   }
 
+  _rebuildObserver(): void {
+    if (!this._observer) {
+      return
+    }
+
+    this._observer.disconnect()
+    this._intersecting.clear()
+    this._observer = this._getNewObserver()
+    for (const section of this._sections) {
+      this._observer.observe(section)
+    }
+  }
+
+  // --- Smooth-scroll settle (hash + focus) ---------------------------------
+
+  _maybeEnableSmoothScroll(): void {
+    if (!this._config.smoothScroll) {
+      return
+    }
+
+    // Unregister any previous listener so refresh() doesn't stack them.
+    EventHandler.off(this._config.target as HTMLElement, EVENT_CLICK)
+
+    EventHandler.on(this._config.target as HTMLElement, EVENT_CLICK, SELECTOR_TARGET_LINKS, (event: Event) => {
+      const link = (event.target as HTMLElement).closest<HTMLAnchorElement>(SELECTOR_TARGET_LINKS)
+      const section = link && this._sectionByLink.get(link)
+      if (!section || !this._element) {
+        return
+      }
+
+      event.preventDefault()
+
+      const root = this._rootElement || window
+      const height = section.offsetTop - this._element.offsetTop
+      const currentTop = this._rootElement ? this._rootElement.scrollTop : window.scrollY
+      const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches
+
+      // If we're already there (or motion is reduced), there will be no scroll
+      // — and thus no `scrollend` — to wait for, so settle immediately. This
+      // avoids a stuck pending navigation that never restores hash/focus.
+      if (reduceMotion || Math.abs(currentTop - height) <= 2) {
+        if ('scrollTo' in root) {
+          root.scrollTo({ top: height, behavior: 'auto' })
+        } else {
+          ;(root as HTMLElement).scrollTop = height
+        }
+
+        this._settleNavigation(link.hash, section)
+        return
+      }
+
+      // Defer the URL-hash and focus updates until the scroll settles, so we
+      // don't thrash the address bar mid-animation (and so the native hash
+      // navigation we just prevented is restored once we arrive).
+      this._pendingNavigation = { hash: link.hash, section }
+      this._armSettle()
+
+      if ('scrollTo' in root) {
+        root.scrollTo({ top: height, behavior: 'smooth' })
+      } else {
+        ;(root as HTMLElement).scrollTop = height
+      }
+    })
+  }
+
+  // Arm a one-shot settle for the in-flight smooth scroll. `scrollend` is the
+  // primary signal; a transient scroll-idle timer covers engines without it.
+  // Both are removed on settle, so a later unrelated scroll can't replay it.
+  _armSettle(): void {
+    this._disarmSettle()
+
+    const target = this._getScrollTarget()
+
+    this._settleHandler = () => this._onSettle()
+    this._scrollIdleHandler = () => {
+      if (this._settleTimeout) {
+        clearTimeout(this._settleTimeout)
+      }
+
+      this._settleTimeout = setTimeout(() => this._onSettle(), SCROLL_IDLE_TIMEOUT)
+    }
+
+    EventHandler.on(target, EVENT_SCROLLEND, this._settleHandler)
+    EventHandler.on(target, EVENT_SCROLL, this._scrollIdleHandler)
+  }
+
+  _disarmSettle(): void {
+    if (this._settleTimeout) {
+      clearTimeout(this._settleTimeout)
+      this._settleTimeout = null
+    }
+
+    const target = this._getScrollTarget()
+    if (this._settleHandler) {
+      EventHandler.off(target, EVENT_SCROLLEND, this._settleHandler)
+      this._settleHandler = null
+    }
+
+    if (this._scrollIdleHandler) {
+      EventHandler.off(target, EVENT_SCROLL, this._scrollIdleHandler)
+      this._scrollIdleHandler = null
+    }
+  }
+
+  _getScrollTarget(): EventTarget {
+    return this._rootElement || document
+  }
+
+  _onSettle(): void {
+    this._disarmSettle()
+
+    if (!this._pendingNavigation) {
+      return
+    }
+
+    const { hash, section } = this._pendingNavigation
+    this._settleNavigation(hash, section)
+  }
+
+  _settleNavigation(hash: string, section: HTMLElement): void {
+    this._pendingNavigation = null
+
+    // Restore the URL hash (without adding a history entry) now that we've
+    // arrived, and move focus to the section for keyboard/AT users.
+    if (window.history?.replaceState) {
+      window.history.replaceState(null, '', hash)
+    }
+
+    if (!section.hasAttribute('tabindex')) {
+      section.setAttribute('tabindex', '-1')
+    }
+
+    section.focus({ preventScroll: true })
+  }
+
+  // --- Targets / observables ----------------------------------------------
+
   _initializeTargetsAndObservables(): void {
-    this._targetLinks = new Map()
-    this._observableSections = new Map()
+    this._sections = []
+    this._linkBySection = new Map()
+    this._sectionByLink = new Map()
 
     const targetLinks = SelectorEngine.find(SELECTOR_TARGET_LINKS, this._config.target as HTMLElement)
+    const seen = new Set<HTMLElement>()
 
     for (const anchor of targetLinks) {
-      if (!(anchor as HTMLAnchorElement).hash || isDisabled(anchor)) {
+      const hash = (anchor as HTMLAnchorElement).hash
+      if (!hash || isDisabled(anchor)) {
         continue
       }
 
-      const observableSection = SelectorEngine.findOne(parseSelector(decodeURI((anchor as HTMLAnchorElement).hash)), this._element)
+      // Resolve by id (decoded) rather than building a CSS selector, so any
+      // literal id works — dots, slashes, colons, and percent-encoded chars —
+      // without escaping.
+      const id = decodeFragment(hash.slice(1))
+      if (!id) {
+        continue
+      }
 
-      if (isVisible(observableSection!)) {
-        this._targetLinks.set(decodeURI((anchor as HTMLAnchorElement).hash), anchor)
-        this._observableSections.set((anchor as HTMLAnchorElement).hash, observableSection!)
+      const section = document.getElementById(id)
+      // ensure the section exists, is scoped to this element, and is visible
+      if (!section || !this._element.contains(section) || !isVisible(section)) {
+        continue
+      }
+
+      this._sectionByLink.set(anchor, section)
+      this._linkBySection.set(section, anchor) // last link wins for a section
+
+      if (!seen.has(section)) {
+        seen.add(section)
+        this._sections.push(section)
       }
     }
+
+    // Keep sections in top-to-bottom order so "deepest" selection is
+    // well-defined. Read once here (refresh/resize), never on the hot path.
+    this._sections.sort((a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top)
   }
 
   _process(target: HTMLElement): void {

--- a/core/js/tests/unit/scrollspy.spec.ts
+++ b/core/js/tests/unit/scrollspy.spec.ts
@@ -2,12 +2,15 @@ import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vite
 import ScrollSpy from '../../src/bootstrap/scrollspy'
 import { clearFixture, createEvent, getFixture } from '../helpers/fixture'
 
+const observers: MockIntersectionObserver[] = []
+
 class MockIntersectionObserver implements IntersectionObserver {
   readonly root: Element | Document | null = null
   readonly rootMargin: string = ''
   readonly thresholds: ReadonlyArray<number> = []
   callback: IntersectionObserverCallback
   options: IntersectionObserverInit | undefined
+  observed = new Set<Element>()
 
   constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
     this.callback = callback
@@ -15,16 +18,49 @@ class MockIntersectionObserver implements IntersectionObserver {
     this.root = (options?.root as Element | null) ?? null
     this.rootMargin = options?.rootMargin ?? ''
     this.thresholds = Array.isArray(options?.threshold) ? options!.threshold : [options?.threshold ?? 0]
+    observers.push(this)
   }
 
-  observe = vi.fn()
-  unobserve = vi.fn()
-  disconnect = vi.fn()
+  observe = vi.fn((el: Element) => {
+    this.observed.add(el)
+  })
+
+  unobserve = vi.fn((el: Element) => {
+    this.observed.delete(el)
+  })
+
+  disconnect = vi.fn(() => {
+    this.observed.clear()
+  })
+
   takeRecords = vi.fn().mockReturnValue([])
 }
 
+const entry = (target: Element, isIntersecting: boolean): IntersectionObserverEntry =>
+  ({
+    target,
+    isIntersecting,
+    intersectionRatio: isIntersecting ? 1 : 0,
+  }) as unknown as IntersectionObserverEntry
+
 const getDummyFixture = () =>
   ['<nav id="navBar" class="navbar">', '  <ul class="nav">', '    <li class="nav-item"><a id="li-jsm-1" class="nav-link" href="#div-jsm-1">div 1</a></li>', '  </ul>', '</nav>', '<div class="content" data-bs-target="#navBar" style="overflow-y: auto">', '  <div id="div-jsm-1">div 1</div>', '</div>'].join('')
+
+const getMultiSectionFixture = () =>
+  [
+    '<nav id="navBar" class="navbar">',
+    '  <ul class="nav">',
+    '    <li class="nav-item"><a id="link-1" class="nav-link" href="#section-1">One</a></li>',
+    '    <li class="nav-item"><a id="link-2" class="nav-link" href="#section-2">Two</a></li>',
+    '    <li class="nav-item"><a id="link-3" class="nav-link" href="#section-3">Three</a></li>',
+    '  </ul>',
+    '</nav>',
+    '<div class="content" data-bs-target="#navBar" style="height: 200px; overflow-y: auto">',
+    '  <div id="section-1" style="height: 300px">one</div>',
+    '  <div id="section-2" style="height: 300px">two</div>',
+    '  <div id="section-3" style="height: 300px">three</div>',
+    '</div>',
+  ].join('')
 
 describe('ScrollSpy', () => {
   let fixtureEl: HTMLElement
@@ -34,6 +70,7 @@ describe('ScrollSpy', () => {
   })
 
   beforeEach(() => {
+    observers.length = 0
     vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
   })
 
@@ -41,6 +78,7 @@ describe('ScrollSpy', () => {
     clearFixture()
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
+    vi.useRealTimers()
   })
 
   describe('VERSION', () => {
@@ -52,6 +90,13 @@ describe('ScrollSpy', () => {
   describe('Default', () => {
     it('should return plugin default config', () => {
       expect(typeof ScrollSpy.Default).toBe('object')
+    })
+
+    it('should default topMargin to a percentage and drop the deprecated offset option', () => {
+      expect(ScrollSpy.Default.topMargin).toBe('12%')
+      expect(ScrollSpy.Default.rootMargin).toBeNull()
+      expect('offset' in ScrollSpy.Default).toBe(false)
+      expect('offset' in ScrollSpy.DefaultType).toBe(false)
     })
   })
 
@@ -120,26 +165,43 @@ describe('ScrollSpy', () => {
       expect(scrollSpy._observer!.thresholds).toEqual([0, 0.2, 1])
     })
 
-    it('should initialize with empty maps when sections are not visible', () => {
+    it('should build the observer from the derived activation line', () => {
+      fixtureEl.innerHTML = getDummyFixture()
+
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!, { topMargin: '25%' })
+
+      expect(scrollSpy._observer!.rootMargin).toBe('0px 0px -75% 0px')
+    })
+
+    it('should pass an explicit rootMargin straight through, ignoring topMargin', () => {
+      fixtureEl.innerHTML = getDummyFixture()
+
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!, {
+        rootMargin: '0px 0px -40%',
+        topMargin: '25%',
+      })
+
+      expect(scrollSpy._observer!.rootMargin).toBe('0px 0px -40%')
+    })
+
+    it('should initialize with empty state when sections are not present', () => {
       fixtureEl.innerHTML = [
         '<nav id="navigation" class="navbar">',
         '  <ul class="navbar-nav">',
         '    <li class="nav-item"><a class="nav-link" href="#">One</a></li>',
-        '    <li class="nav-item"><a class="nav-link" href="#two">Two</a></li>',
+        '    <li class="nav-item"><a class="nav-link" href="#missing">Missing</a></li>',
         '  </ul>',
         '</nav>',
-        '<div id="content" style="height: 200px; overflow-y: auto;">',
-        '  <div id="two" style="height: 300px;">test</div>',
-        '</div>',
+        '<div id="content" style="height: 200px; overflow-y: auto;"></div>',
       ].join('')
 
       const scrollSpy = new ScrollSpy(fixtureEl.querySelector('#content')!, {
         target: '#navigation',
       })
 
-      // jsdom elements are not "visible" (getClientRects returns empty), so maps are empty
-      expect(scrollSpy._targetLinks).toBeInstanceOf(Map)
-      expect(scrollSpy._observableSections).toBeInstanceOf(Map)
+      expect(scrollSpy._sections).toEqual([])
+      expect(scrollSpy._linkBySection).toBeInstanceOf(Map)
+      expect(scrollSpy._sectionByLink).toBeInstanceOf(Map)
     })
   })
 
@@ -156,6 +218,15 @@ describe('ScrollSpy', () => {
 
       expect(spy).toHaveBeenCalled()
     })
+
+    it('should observe every section', () => {
+      fixtureEl.innerHTML = getMultiSectionFixture()
+
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!)
+
+      expect(scrollSpy._sections).toHaveLength(3)
+      expect(scrollSpy._observer!.observe).toHaveBeenCalledTimes(3)
+    })
   })
 
   describe('dispose', () => {
@@ -170,6 +241,21 @@ describe('ScrollSpy', () => {
       scrollSpy.dispose()
 
       expect(ScrollSpy.getInstance(el)).toBeNull()
+    })
+
+    it('should remove the bottom sentinel', () => {
+      fixtureEl.innerHTML = getMultiSectionFixture()
+
+      const el = fixtureEl.querySelector('.content')!
+      const scrollSpy = new ScrollSpy(el)
+
+      const sentinel = scrollSpy._sentinel
+      expect(sentinel).not.toBeNull()
+      expect(el.contains(sentinel!)).toBe(true)
+
+      scrollSpy.dispose()
+
+      expect(el.contains(sentinel!)).toBe(false)
     })
   })
 
@@ -217,20 +303,20 @@ describe('ScrollSpy', () => {
 
       const div = fixtureEl.querySelector('.content')!
 
-      const scrollspy = ScrollSpy.getOrCreateInstance(div, { offset: 1 })
+      const scrollspy = ScrollSpy.getOrCreateInstance(div, { topMargin: '30%' })
       expect(scrollspy).toBeInstanceOf(ScrollSpy)
-      expect(scrollspy._config.offset).toBe(1)
+      expect(scrollspy._config.topMargin).toBe('30%')
     })
 
     it('should return existing instance ignoring new config', () => {
       fixtureEl.innerHTML = getDummyFixture()
 
       const div = fixtureEl.querySelector('.content')!
-      const scrollspy = new ScrollSpy(div, { offset: 1 })
+      const scrollspy = new ScrollSpy(div, { topMargin: '30%' })
 
-      const scrollspy2 = ScrollSpy.getOrCreateInstance(div, { offset: 2 })
+      const scrollspy2 = ScrollSpy.getOrCreateInstance(div, { topMargin: '50%' })
       expect(scrollspy2).toBe(scrollspy)
-      expect(scrollspy2._config.offset).toBe(1)
+      expect(scrollspy2._config.topMargin).toBe('30%')
     })
   })
 
@@ -246,141 +332,255 @@ describe('ScrollSpy', () => {
     })
   })
 
-  describe('_observerCallback', () => {
-    it('should activate target on intersecting entry (scroll down)', () => {
+  describe('data-tblr-spy', () => {
+    it('should create scrollspy on window load with data-tblr-spy="scroll"', () => {
+      fixtureEl.innerHTML = ['<div id="nav"></div>', '<div id="wrapper" data-tblr-spy="scroll" data-bs-target="#nav" style="overflow-y: auto"></div>'].join('')
+
+      const scrollSpyEl = fixtureEl.querySelector('#wrapper')!
+
+      window.dispatchEvent(createEvent('load'))
+
+      expect(ScrollSpy.getInstance(scrollSpyEl)).not.toBeNull()
+    })
+  })
+
+  describe('activation line', () => {
+    it('_parseTopMargin should split value and unit', () => {
       fixtureEl.innerHTML = getDummyFixture()
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!)
 
-      const div = fixtureEl.querySelector('.content')!
-      const scrollSpy = new ScrollSpy(div)
+      scrollSpy._config.topMargin = '12%'
+      expect(scrollSpy._parseTopMargin()).toEqual({ value: 12, unit: '%' })
 
-      const link = fixtureEl.querySelector('#li-jsm-1') as HTMLElement
-      const section = fixtureEl.querySelector('#div-jsm-1') as HTMLElement
-      scrollSpy._targetLinks.set('#div-jsm-1', link)
-      scrollSpy._observableSections.set('#div-jsm-1', section)
+      scrollSpy._config.topMargin = '96px'
+      expect(scrollSpy._parseTopMargin()).toEqual({ value: 96, unit: 'px' })
 
-      scrollSpy._previousScrollData.parentScrollTop = 0
-
-      const entry = {
-        isIntersecting: true,
-        target: section,
-        intersectionRatio: 1,
-      } as unknown as IntersectionObserverEntry
-
-      Object.defineProperty(section, 'offsetTop', { value: 100, configurable: true })
-
-      scrollSpy._observerCallback([entry])
-
-      expect(link.classList.contains('active')).toBe(true)
-      expect(scrollSpy._activeTarget).toBe(link)
+      scrollSpy._config.topMargin = 'garbage'
+      expect(scrollSpy._parseTopMargin()).toEqual({ value: 0, unit: 'px' })
     })
 
-    it('should clear active class on non-intersecting entry', () => {
+    it('_getDerivedRootMargin should turn a percentage into a bottom inset', () => {
       fixtureEl.innerHTML = getDummyFixture()
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!)
 
-      const div = fixtureEl.querySelector('.content')!
-      const scrollSpy = new ScrollSpy(div)
-
-      const link = fixtureEl.querySelector('#li-jsm-1') as HTMLElement
-      const section = fixtureEl.querySelector('#div-jsm-1') as HTMLElement
-      link.classList.add('active')
-      scrollSpy._activeTarget = link
-      scrollSpy._targetLinks.set('#div-jsm-1', link)
-
-      const entry = {
-        isIntersecting: false,
-        target: section,
-      } as unknown as IntersectionObserverEntry
-
-      scrollSpy._observerCallback([entry])
-
-      expect(scrollSpy._activeTarget).toBeNull()
+      scrollSpy._config.topMargin = '20%'
+      expect(scrollSpy._getDerivedRootMargin()).toBe('0px 0px -80% 0px')
     })
 
-    it('should activate on scroll up when entry is higher', () => {
+    it('_getDerivedRootMargin should express a pixel line as a percentage of the root height', () => {
       fixtureEl.innerHTML = getDummyFixture()
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!)
 
-      const div = fixtureEl.querySelector('.content')!
-      const scrollSpy = new ScrollSpy(div)
+      scrollSpy._rootElement = { clientHeight: 500 } as HTMLElement
+      scrollSpy._config.topMargin = '50px'
 
-      const link = fixtureEl.querySelector('#li-jsm-1') as HTMLElement
-      const section = fixtureEl.querySelector('#div-jsm-1') as HTMLElement
-      scrollSpy._targetLinks.set('#div-jsm-1', link)
-      scrollSpy._observableSections.set('#div-jsm-1', section)
-
-      scrollSpy._previousScrollData.parentScrollTop = 200
-      scrollSpy._previousScrollData.visibleEntryTop = 300
-
-      Object.defineProperty(section, 'offsetTop', { value: 100, configurable: true })
-      Object.defineProperty(div, 'scrollTop', { value: 100, configurable: true, writable: true })
-
-      const entry = {
-        isIntersecting: true,
-        target: section,
-        intersectionRatio: 1,
-      } as unknown as IntersectionObserverEntry
-
-      scrollSpy._observerCallback([entry])
-
-      expect(link.classList.contains('active')).toBe(true)
+      // 50 / 500 = 10% -> bottom inset 90%
+      expect(scrollSpy._getDerivedRootMargin()).toBe('0px 0px -90% 0px')
     })
 
-    it('should not activate on scroll up when entry is lower', () => {
+    it('_usesPixelMargin should be true only for a px topMargin without an explicit rootMargin', () => {
       fixtureEl.innerHTML = getDummyFixture()
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!)
 
-      const div = fixtureEl.querySelector('.content')!
-      const scrollSpy = new ScrollSpy(div)
+      scrollSpy._config.rootMargin = null
+      scrollSpy._config.topMargin = '96px'
+      expect(scrollSpy._usesPixelMargin()).toBe(true)
 
-      const link = fixtureEl.querySelector('#li-jsm-1') as HTMLElement
-      const section = fixtureEl.querySelector('#div-jsm-1') as HTMLElement
-      scrollSpy._targetLinks.set('#div-jsm-1', link)
-      scrollSpy._observableSections.set('#div-jsm-1', section)
+      scrollSpy._config.topMargin = '12%'
+      expect(scrollSpy._usesPixelMargin()).toBe(false)
 
-      scrollSpy._previousScrollData.parentScrollTop = 200
-      scrollSpy._previousScrollData.visibleEntryTop = 50
-
-      Object.defineProperty(section, 'offsetTop', { value: 100, configurable: true })
-      Object.defineProperty(div, 'scrollTop', { value: 100, configurable: true, writable: true })
-
-      const entry = {
-        isIntersecting: true,
-        target: section,
-        intersectionRatio: 1,
-      } as unknown as IntersectionObserverEntry
-
-      scrollSpy._observerCallback([entry])
-
-      expect(link.classList.contains('active')).toBe(false)
+      scrollSpy._config.rootMargin = '0px 0px -30%'
+      scrollSpy._config.topMargin = '96px'
+      expect(scrollSpy._usesPixelMargin()).toBe(false)
     })
 
-    it('should not re-process if activeTarget is same', () => {
-      fixtureEl.innerHTML = getDummyFixture()
+    it('should register a resize listener that is removed on dispose', () => {
+      fixtureEl.innerHTML = getMultiSectionFixture()
 
-      const div = fixtureEl.querySelector('.content')!
-      const scrollSpy = new ScrollSpy(div)
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!, { topMargin: '12%' })
+      expect(scrollSpy._resizeHandler).not.toBeNull()
 
-      const link = fixtureEl.querySelector('#li-jsm-1') as HTMLElement
-      const section = fixtureEl.querySelector('#div-jsm-1') as HTMLElement
-      scrollSpy._targetLinks.set('#div-jsm-1', link)
-      scrollSpy._observableSections.set('#div-jsm-1', section)
+      scrollSpy.dispose()
+      expect(scrollSpy._resizeHandler).toBeNull()
+    })
 
-      link.classList.add('active')
-      scrollSpy._activeTarget = link
-      scrollSpy._previousScrollData.parentScrollTop = 0
+    it('should re-measure on resize, and rebuild the observer (debounced) for a px line', () => {
+      vi.useFakeTimers()
+      fixtureEl.innerHTML = getMultiSectionFixture()
 
-      Object.defineProperty(section, 'offsetTop', { value: 100, configurable: true })
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!, { topMargin: '80px' })
+      const rebuild = vi.spyOn(scrollSpy, '_rebuildObserver')
+      const measure = vi.spyOn(scrollSpy, '_measure')
 
-      const entry = {
-        isIntersecting: true,
-        target: section,
-        intersectionRatio: 1,
-      } as unknown as IntersectionObserverEntry
+      window.dispatchEvent(createEvent('resize'))
+      window.dispatchEvent(createEvent('resize'))
+      expect(rebuild).not.toHaveBeenCalled()
+
+      vi.runAllTimers()
+      expect(rebuild).toHaveBeenCalledTimes(1)
+      expect(measure).toHaveBeenCalledTimes(1)
+
+      scrollSpy.dispose()
+      vi.useRealTimers()
+    })
+
+    it('should re-measure but not rebuild the observer on resize for a percentage line', () => {
+      vi.useFakeTimers()
+      fixtureEl.innerHTML = getMultiSectionFixture()
+
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!, { topMargin: '12%' })
+      const rebuild = vi.spyOn(scrollSpy, '_rebuildObserver')
+      const measure = vi.spyOn(scrollSpy, '_measure')
+
+      window.dispatchEvent(createEvent('resize'))
+      vi.runAllTimers()
+
+      expect(measure).toHaveBeenCalledTimes(1)
+      expect(rebuild).not.toHaveBeenCalled()
+
+      scrollSpy.dispose()
+      vi.useRealTimers()
+    })
+  })
+
+  describe('_onIntersect / _computeActive', () => {
+    it('should activate the deepest section crossing the line', () => {
+      fixtureEl.innerHTML = getMultiSectionFixture()
+
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!)
+      const [s1, s2] = scrollSpy._sections
+
+      scrollSpy._onIntersect([entry(s1, true), entry(s2, true)])
+
+      expect(fixtureEl.querySelector('#link-2')!.classList.contains('active')).toBe(true)
+      expect(fixtureEl.querySelector('#link-1')!.classList.contains('active')).toBe(false)
+    })
+
+    it('should keep the last active section when nothing crosses the line', () => {
+      fixtureEl.innerHTML = getMultiSectionFixture()
+
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!)
+      const [s1] = scrollSpy._sections
+
+      scrollSpy._onIntersect([entry(s1, true)])
+      expect(fixtureEl.querySelector('#link-1')!.classList.contains('active')).toBe(true)
+
+      scrollSpy._onIntersect([entry(s1, false)])
+      expect(fixtureEl.querySelector('#link-1')!.classList.contains('active')).toBe(true)
+      expect(scrollSpy._lastActive).toBe(s1)
+    })
+
+    it('should fall back to the first section at the top of the page', () => {
+      fixtureEl.innerHTML = getMultiSectionFixture()
+
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!)
+
+      scrollSpy._onIntersect([])
+
+      expect(fixtureEl.querySelector('#link-1')!.classList.contains('active')).toBe(true)
+    })
+
+    it('should not re-process the same target', () => {
+      fixtureEl.innerHTML = getMultiSectionFixture()
+
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!)
+      const [s1] = scrollSpy._sections
 
       const spy = vi.fn()
-      div.addEventListener('activate.bs.scrollspy', spy)
+      scrollSpy._element.addEventListener('activate.bs.scrollspy', spy)
 
-      scrollSpy._observerCallback([entry])
+      scrollSpy._onIntersect([entry(s1, true)])
+      scrollSpy._onIntersect([entry(s1, true)])
 
-      expect(spy).not.toHaveBeenCalled()
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('bottom sentinel', () => {
+    it('should append a hidden sentinel inside the observable container', () => {
+      fixtureEl.innerHTML = getMultiSectionFixture()
+
+      const el = fixtureEl.querySelector('.content')!
+      const scrollSpy = new ScrollSpy(el)
+
+      expect(scrollSpy._sentinel).not.toBeNull()
+      expect(scrollSpy._sentinel!.getAttribute('aria-hidden')).toBe('true')
+      expect(el.lastElementChild).toBe(scrollSpy._sentinel)
+    })
+
+    it('should arm the bottom scroll watch (and re-measure) while the sentinel is visible', () => {
+      fixtureEl.innerHTML = getMultiSectionFixture()
+
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!)
+      const measure = vi.spyOn(scrollSpy, '_measure')
+
+      scrollSpy._onSentinel([entry(scrollSpy._sentinel!, true)])
+      expect(scrollSpy._sentinelVisible).toBe(true)
+      expect(scrollSpy._bottomScrollHandler).not.toBeNull()
+      expect(measure).toHaveBeenCalled()
+
+      scrollSpy._onSentinel([entry(scrollSpy._sentinel!, false)])
+      expect(scrollSpy._sentinelVisible).toBe(false)
+      expect(scrollSpy._bottomScrollHandler).toBeNull()
+    })
+  })
+
+  describe('_tailActiveIndex', () => {
+    const makeSpy = (count: number, { armed = true } = {}) => {
+      fixtureEl.innerHTML = getMultiSectionFixture()
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('.content')!)
+      scrollSpy._sections = Array.from({ length: count }, () => document.createElement('div'))
+      if (armed) {
+        scrollSpy._bottomScrollHandler = () => {}
+      }
+
+      return scrollSpy
+    }
+
+    const atScrollTop = (scrollSpy: ScrollSpy, scrollTop: number) => {
+      vi.spyOn(scrollSpy, '_scroller').mockReturnValue({ scrollTop } as HTMLElement)
+    }
+
+    it('returns -1 when the bottom watch is not armed', () => {
+      const scrollSpy = makeSpy(3, { armed: false })
+      scrollSpy._triggers = [0, 100, 9999]
+      scrollSpy._maxScroll = 500
+
+      expect(scrollSpy._tailActiveIndex()).toBe(-1)
+    })
+
+    it('returns -1 when every section can reach the activation line', () => {
+      const scrollSpy = makeSpy(3)
+      scrollSpy._triggers = [0, 100, 200]
+      scrollSpy._maxScroll = 500
+      atScrollTop(scrollSpy, 480)
+
+      expect(scrollSpy._tailActiveIndex()).toBe(-1)
+    })
+
+    it('returns -1 before the scroll enters the tail zone', () => {
+      const scrollSpy = makeSpy(4)
+      scrollSpy._triggers = [0, 400, 900, 1100]
+      scrollSpy._maxScroll = 800
+      atScrollTop(scrollSpy, 200)
+
+      expect(scrollSpy._tailActiveIndex()).toBe(-1)
+    })
+
+    it('spreads the leftover scroll across the unreachable trailing sections', () => {
+      const scrollSpy = makeSpy(4)
+      // triggers 900 and 1100 sit past the 800px max scroll -> anchor is index 1
+      scrollSpy._triggers = [0, 400, 900, 1100]
+      scrollSpy._maxScroll = 800
+
+      atScrollTop(scrollSpy, 400)
+      expect(scrollSpy._tailActiveIndex()).toBe(1)
+
+      atScrollTop(scrollSpy, 600)
+      expect(scrollSpy._tailActiveIndex()).toBe(2)
+
+      atScrollTop(scrollSpy, 800)
+      expect(scrollSpy._tailActiveIndex()).toBe(3)
     })
   })
 
@@ -430,17 +630,50 @@ describe('ScrollSpy', () => {
       expect(dropToggle.classList.contains('active')).toBe(true)
     })
 
-    it('should activate nav parents for nav-link target', () => {
-      fixtureEl.innerHTML = ['<nav class="navbar">', '  <nav class="nav">', '    <a class="nav-link" id="a1" href="#one">One</a>', '  </nav>', '</nav>', '<div class="content" style="overflow-y: auto">', '  <div id="one">one</div>', '</div>'].join('')
+    it('should activate prev-sibling link for a nav parent', () => {
+      fixtureEl.innerHTML = [
+        '<nav class="navbar">',
+        '  <a class="nav-link" id="parent-link" href="#one">Parent</a>',
+        '  <nav class="nav">',
+        '    <a class="nav-link" id="child-link" href="#one-a">Child</a>',
+        '  </nav>',
+        '</nav>',
+        '<div class="content" style="overflow-y: auto">',
+        '  <div id="one">one</div>',
+        '  <div id="one-a">one a</div>',
+        '</div>',
+      ].join('')
 
       const div = fixtureEl.querySelector('.content')!
       const scrollSpy = new ScrollSpy(div)
-      const link = fixtureEl.querySelector('#a1') as HTMLElement
+      const childLink = fixtureEl.querySelector('#child-link') as HTMLElement
 
-      scrollSpy._activateParents(link)
+      scrollSpy._activateParents(childLink)
 
-      // nav-link itself is handled by _process, parents via SelectorEngine.prev
-      expect(link).toBeDefined()
+      expect(fixtureEl.querySelector('#parent-link')!.classList.contains('active')).toBe(true)
+    })
+
+    it('should activate prev-sibling link for a list-group parent', () => {
+      fixtureEl.innerHTML = [
+        '<nav class="navbar">',
+        '  <a class="list-group-item" id="lg-parent" href="#one">Parent</a>',
+        '  <div class="list-group">',
+        '    <a class="list-group-item" id="lg-child" href="#one-a">Child</a>',
+        '  </div>',
+        '</nav>',
+        '<div class="content" style="overflow-y: auto">',
+        '  <div id="one">one</div>',
+        '  <div id="one-a">one a</div>',
+        '</div>',
+      ].join('')
+
+      const div = fixtureEl.querySelector('.content')!
+      const scrollSpy = new ScrollSpy(div)
+      const childLink = fixtureEl.querySelector('#lg-child') as HTMLElement
+
+      scrollSpy._activateParents(childLink)
+
+      expect(fixtureEl.querySelector('#lg-parent')!.classList.contains('active')).toBe(true)
     })
   })
 
@@ -461,22 +694,15 @@ describe('ScrollSpy', () => {
   })
 
   describe('_initializeTargetsAndObservables', () => {
-    it('should populate maps when sections are visible', () => {
-      fixtureEl.innerHTML = getDummyFixture()
+    it('should collect visible sections in DOM order', () => {
+      fixtureEl.innerHTML = getMultiSectionFixture()
 
       const div = fixtureEl.querySelector('.content')!
       const scrollSpy = new ScrollSpy(div)
-      const section = fixtureEl.querySelector('#div-jsm-1') as HTMLElement
 
-      Object.defineProperty(section, 'getClientRects', {
-        value: () => [{ width: 100, height: 100 }],
-        configurable: true,
-      })
-
-      scrollSpy._initializeTargetsAndObservables()
-
-      expect(scrollSpy._targetLinks.size).toBe(1)
-      expect(scrollSpy._observableSections.size).toBe(1)
+      expect(scrollSpy._sections.map((section) => section.id)).toEqual(['section-1', 'section-2', 'section-3'])
+      expect(scrollSpy._linkBySection.size).toBe(3)
+      expect(scrollSpy._sectionByLink.size).toBe(3)
     })
 
     it('should skip disabled anchors', () => {
@@ -496,32 +722,27 @@ describe('ScrollSpy', () => {
       const div = fixtureEl.querySelector('.content')!
       const scrollSpy = new ScrollSpy(div)
 
-      expect(scrollSpy._targetLinks.size).toBe(0)
+      expect(scrollSpy._sections).toEqual([])
     })
-  })
 
-  describe('_activateParents (nav prev)', () => {
-    it('should activate prev sibling nav-link in list-group', () => {
+    it('should ignore anchors whose section is outside the observable container', () => {
       fixtureEl.innerHTML = [
-        '<nav class="navbar">',
-        '  <div class="list-group">',
-        '    <a class="list-group-item" id="a1" href="#one">One</a>',
-        '    <a class="list-group-item" id="a2" href="#two">Two</a>',
-        '  </div>',
+        '<nav id="navBar" class="navbar">',
+        '  <ul class="nav">',
+        '    <a class="nav-link" href="#inside">Inside</a>',
+        '    <a class="nav-link" href="#outside">Outside</a>',
+        '  </ul>',
         '</nav>',
         '<div class="content" style="overflow-y: auto">',
-        '  <div id="one">one</div>',
-        '  <div id="two">two</div>',
+        '  <div id="inside">inside</div>',
         '</div>',
+        '<div id="outside">outside</div>',
       ].join('')
 
       const div = fixtureEl.querySelector('.content')!
       const scrollSpy = new ScrollSpy(div)
-      const link2 = fixtureEl.querySelector('#a2') as HTMLElement
 
-      scrollSpy._activateParents(link2)
-      // list-group-item doesn't have .dropdown-item, so it goes through nav parents path
-      expect(link2).toBeDefined()
+      expect(scrollSpy._sections.map((section) => section.id)).toEqual(['inside'])
     })
   })
 
@@ -532,7 +753,7 @@ describe('ScrollSpy', () => {
       const div = fixtureEl.querySelector('.content') as HTMLElement
       div.scrollTo = vi.fn()
 
-      new ScrollSpy(div, { offset: 1 })
+      new ScrollSpy(div)
 
       const link = fixtureEl.querySelector('[href="#div-jsm-1"]') as HTMLElement
       link.click()
@@ -546,14 +767,7 @@ describe('ScrollSpy', () => {
       const div = fixtureEl.querySelector('.content') as HTMLElement
       div.scrollTo = vi.fn()
 
-      const section = fixtureEl.querySelector('#div-jsm-1') as HTMLElement
-      Object.defineProperty(section, 'getClientRects', {
-        value: () => [{ width: 100, height: 100 }],
-        configurable: true,
-      })
-
-      const scrollSpy = new ScrollSpy(div, { offset: 1, smoothScroll: true })
-      scrollSpy._initializeTargetsAndObservables()
+      new ScrollSpy(div, { smoothScroll: true })
 
       const link = fixtureEl.querySelector('[href="#div-jsm-1"]') as HTMLElement
       link.click()
@@ -561,31 +775,20 @@ describe('ScrollSpy', () => {
       expect(div.scrollTo).toHaveBeenCalled()
     })
 
-    it('should fallback to scrollTop if scrollTo is not available', () => {
+    it('should fall back to scrollTop if scrollTo is not available', () => {
       fixtureEl.innerHTML = getDummyFixture()
 
       const div = fixtureEl.querySelector('.content') as HTMLElement
-      const section = fixtureEl.querySelector('#div-jsm-1') as HTMLElement
-      Object.defineProperty(section, 'getClientRects', {
-        value: () => [{ width: 100, height: 100 }],
-        configurable: true,
-      })
 
-      // Manually set _rootElement to a plain object without scrollTo
-      const scrollSpy = new ScrollSpy(div, { offset: 1, smoothScroll: true })
-      scrollSpy._initializeTargetsAndObservables()
+      const scrollSpy = new ScrollSpy(div, { smoothScroll: true })
 
-      // Remove scrollTo to test fallback
       delete (div as any).scrollTo
       scrollSpy._rootElement = div
-
-      // Re-enable smoothScroll handler
       scrollSpy._maybeEnableSmoothScroll()
 
       const link = fixtureEl.querySelector('[href="#div-jsm-1"]') as HTMLElement
       link.click()
 
-      // Should not throw - scrollTop assignment is the fallback
       expect(ScrollSpy.getInstance(div)).not.toBeNull()
     })
 
@@ -605,30 +808,125 @@ describe('ScrollSpy', () => {
       const div = fixtureEl.querySelector('.content') as HTMLElement
       div.scrollTo = vi.fn()
 
-      new ScrollSpy(div, { offset: 1, smoothScroll: true })
+      new ScrollSpy(div, { smoothScroll: true })
 
       const anchor2 = fixtureEl.querySelector('#anchor-2') as HTMLElement
       anchor2.click()
       expect(div.scrollTo).not.toHaveBeenCalled()
     })
-  })
 
-  describe('data-tblr-spy', () => {
-    it('should create scrollspy on window load with data-tblr-spy="scroll"', () => {
-      fixtureEl.innerHTML = ['<div id="nav"></div>', '<div id="wrapper" data-tblr-spy="scroll" data-bs-target="#nav" style="overflow-y: auto"></div>'].join('')
+    it('should settle a pending navigation on the scrollend event', () => {
+      fixtureEl.innerHTML = getDummyFixture()
 
-      const scrollSpyEl = fixtureEl.querySelector('#wrapper')!
+      const div = fixtureEl.querySelector('.content') as HTMLElement
+      div.scrollTo = vi.fn()
+      const section = fixtureEl.querySelector('#div-jsm-1') as HTMLElement
+      const replaceState = vi.spyOn(window.history, 'replaceState')
 
-      window.dispatchEvent(createEvent('load'))
+      const scrollSpy = new ScrollSpy(div, { smoothScroll: true })
+      scrollSpy._rootElement = div
+      scrollSpy._pendingNavigation = { hash: '#div-jsm-1', section }
+      scrollSpy._armSettle()
 
-      expect(ScrollSpy.getInstance(scrollSpyEl)).not.toBeNull()
+      div.dispatchEvent(createEvent('scrollend'))
+
+      expect(replaceState).toHaveBeenCalledWith(null, '', '#div-jsm-1')
+      expect(scrollSpy._pendingNavigation).toBeNull()
+    })
+
+    it('should restore the hash and focus the section once the scroll settles', () => {
+      fixtureEl.innerHTML = getDummyFixture()
+
+      const div = fixtureEl.querySelector('.content') as HTMLElement
+      div.scrollTo = vi.fn()
+      const section = fixtureEl.querySelector('#div-jsm-1') as HTMLElement
+      const replaceState = vi.spyOn(window.history, 'replaceState')
+      const focus = vi.spyOn(section, 'focus')
+
+      const scrollSpy = new ScrollSpy(div, { smoothScroll: true })
+      scrollSpy._settleNavigation('#div-jsm-1', section)
+
+      expect(replaceState).toHaveBeenCalledWith(null, '', '#div-jsm-1')
+      expect(section.getAttribute('tabindex')).toBe('-1')
+      expect(focus).toHaveBeenCalledWith({ preventScroll: true })
     })
   })
+
+  describe('real IntersectionObserver — full-page scroll', () => {
+    beforeEach(() => {
+      vi.unstubAllGlobals()
+      window.scrollTo(0, 0)
+    })
+
+    afterEach(() => {
+      document.getElementById('rio')?.remove()
+      window.scrollTo(0, 0)
+    })
+
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 60))
+    const activeHref = () => document.querySelector('#rio-nav .nav-link.active')?.getAttribute('href') ?? null
+
+    it('walks sections near the bottom instead of jumping straight to the last one', async () => {
+      const wrap = document.createElement('div')
+      wrap.id = 'rio'
+      wrap.innerHTML = [
+        '<nav><ul class="nav" id="rio-nav">',
+        [1, 2, 3, 4, 5].map((i) => `<li class="nav-item"><a class="nav-link" href="#rio-s${i}">S${i}</a></li>`).join(''),
+        '</ul></nav>',
+        '<div id="rio-content">',
+        [1, 2, 3, 4].map((i) => `<h3 id="rio-s${i}" style="margin:0">S${i}</h3><div style="height:400px"></div>`).join(''),
+        '<h3 id="rio-s5" style="margin:0">S5</h3><div style="height:24px"></div>',
+        '</div>',
+        '<div style="height:280px">page footer below the spied container</div>',
+      ].join('')
+      document.body.prepend(wrap)
+
+      const content = document.getElementById('rio-content') as HTMLElement
+      const scrollSpy = new ScrollSpy(content, { target: '#rio-nav', topMargin: '12%' })
+
+      const scroller = document.scrollingElement || document.documentElement
+      const maxScroll = scroller.scrollHeight - scroller.clientHeight
+      expect(maxScroll).toBeGreaterThan(1200)
+
+      await settle()
+      expect(activeHref()).toBe('#rio-s1')
+
+      const s3Top = document.getElementById('rio-s3')!.getBoundingClientRect().top + window.scrollY
+      window.scrollTo(0, s3Top - 8)
+      await settle()
+      expect(activeHref()).toBe('#rio-s3')
+
+      // Near the bottom the sentinel is on screen and the trailing sections
+      // (s4, s5) can't be scrolled up to the line — but a mid-list link must
+      // still be active here rather than snapping straight to the last one.
+      window.scrollTo(0, maxScroll - 250)
+      await settle()
+      expect(scrollSpy._sentinelVisible).toBe(true)
+      expect(activeHref()).not.toBe('#rio-s5')
+      expect(['#rio-s3', '#rio-s4']).toContain(activeHref())
+
+      // All the way down: the short last section wins.
+      window.scrollTo(0, maxScroll)
+      await settle()
+      expect(activeHref()).toBe('#rio-s5')
+
+      scrollSpy.dispose()
+    })
+  })
+
   describe('target ids', () => {
     it('should accept anchors whose target id starts with a digit', () => {
       fixtureEl.innerHTML = ['<ul id="navigation" class="navbar">', '   <a class="nav-link" href="#1-intro">Intro</a>', '</ul>', '<div id="content">', '  <div id="1-intro">test</div>', '</div>'].join('')
 
       expect(() => new ScrollSpy('#content', { target: '#navigation' })).not.toThrow()
+    })
+
+    it('should accept anchors whose target id contains special characters', () => {
+      fixtureEl.innerHTML = ['<ul id="navigation" class="navbar">', '   <a class="nav-link" href="#a.b:c">Dotted</a>', '</ul>', '<div id="content">', '  <div id="a.b:c">test</div>', '</div>'].join('')
+
+      const scrollSpy = new ScrollSpy('#content', { target: '#navigation' })
+
+      expect(scrollSpy._sections.map((section) => section.id)).toEqual(['a.b:c'])
     })
   })
 })

--- a/preview/pages/scroll-spy.astro
+++ b/preview/pages/scroll-spy.astro
@@ -79,7 +79,7 @@ const articles: [string, string[]][] = [
         </nav>
       </div>
     </div>
-    <div class="col-sm" data-bs-spy="scroll" data-bs-target="#pills" data-bs-offset="0">
+    <div class="col-sm" data-bs-spy="scroll" data-bs-target="#pills">
       <div class="card card-lg">
         <div class="card-body">
           {


### PR DESCRIPTION
## Summary

- Port Bootstrap v6's ScrollSpy (twbs/bootstrap#42557) into the core port. The active section is now chosen from an **activation line** set by `topMargin` (default `12%`, also accepts px like `96px`) instead of a fixed `rootMargin` / `threshold` pair. A raw `rootMargin` still works as an override.
- Remove the deprecated `offset` option. `data-bs-offset` no longer does anything — use `topMargin` / `data-bs-top-margin`.
- Fix the bottom of a full-page-scroll list: on a short page the last sections can't be scrolled up to the line, so they used to be skipped (the active link jumped straight to the last one). A sentinel now arms a bounded, rAF-throttled scroll watch near the end, and the leftover scroll is spread across the trailing sections so every link lights up, ending on the last section at the very bottom.
- Smooth scroll settles on the `scrollend` event (with an idle-timeout fallback), then restores the URL hash and moves focus to the section with `preventScroll`. `scrollend` is added to `EventHandler`'s native event set, matching upstream.
- Public surface is unchanged: class name, instance API, the `activate` / `click` / `load` events and their payloads, `data-bs-*` and `data-tblr-*` attributes, and nav / list-group / dropdown parent activation.
- Spec rewritten around the new internals (57 tests), including a real `IntersectionObserver` test for the full-page-scroll case. `data-bs-offset` dropped from the scroll-spy preview page.

## Preview

- **URL:** https://tabler-git-feat-gh-2973-scrollspy-intersection-85a143-tabler-io.vercel.app/scroll-spy.html
- **How to test:** Scroll the page slowly. Each pill in the left menu should activate as its heading passes the top of the viewport, step through the last few sections (About → Contact → Services → Team) near the bottom, and land on **Work** at the very end. Resize the window while scrolled down — the active pill should stay correct. Click a pill with smooth scroll on and the URL hash should update once the scroll stops.

## Notes / rollout

- Closes #2973 (Phase 5 of the Bootstrap v6 migration).
- Breaking: the `offset` option / `data-bs-offset` attribute is removed. Called out in the changeset (`@tabler/core` minor).
