### PR TITLE
Map `.rounded-*` and `--border-radius-*` onto a numeric `$radii` scale

### DIFF
--- a/.changeset/radii-scale.md
+++ b/.changeset/radii-scale.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Fixed `.rounded-4` and `.rounded-5` ignoring the `[data-bs-theme-radius]` scale and de-duplicated border-radius token emission.

--- a/core/scss/_props.scss
+++ b/core/scss/_props.scss
@@ -86,13 +86,17 @@
 
   /** Border radiuses */
   --border-radius-scale: 1;
+  @each $name, $value in $radii {
+    --radius-#{$name}: calc(#{$value} * var(--border-radius-scale, 1));
+  }
   @each $name, $value in $border-radiuses {
     @if $name {
-      --border-radius-#{$name}: calc(#{$value} * var(--border-radius-scale, 1));
+      --border-radius-#{$name}: #{$value};
     } @else {
       --border-radius: #{$value};
     }
   }
+  --border-radius-2xl: var(--border-radius-xxl); // Deprecated in v5.3.0 for consistency
 
   /** Backdrops */
   --backdrop-opacity: #{$backdrop-opacity};

--- a/core/scss/_utilities.scss
+++ b/core/scss/_utilities.scss
@@ -13,6 +13,18 @@ $border-values: (
   0: 0,
 ) !default;
 
+$rounded-values: (
+  null: var(--border-radius),
+  0: 0,
+  1: var(--border-radius-sm),
+  2: var(--border-radius),
+  3: var(--border-radius-lg),
+  4: var(--border-radius-xl),
+  5: var(--border-radius-xxl),
+  circle: 50%,
+  pill: var(--border-radius-pill),
+) !default;
+
 $utilities-border-colors: map-loop(
   (
     'red': red,
@@ -817,77 +829,27 @@ $utilities: map.merge(
     'rounded': (
       property: border-radius,
       class: rounded,
-      values: (
-        null: var(--border-radius),
-        0: 0,
-        1: var(--border-radius-sm),
-        2: var(--border-radius),
-        3: var(--border-radius-lg),
-        4: var(--border-radius-xl),
-        5: var(--border-radius-xxl),
-        circle: 50%,
-        pill: var(--border-radius-pill),
-      ),
+      values: $rounded-values,
     ),
     'rounded-top': (
       property: border-start-start-radius border-start-end-radius,
       class: rounded-top,
-      values: (
-        null: var(--border-radius),
-        0: 0,
-        1: var(--border-radius-sm),
-        2: var(--border-radius),
-        3: var(--border-radius-lg),
-        4: var(--border-radius-xl),
-        5: var(--border-radius-xxl),
-        circle: 50%,
-        pill: var(--border-radius-pill),
-      ),
+      values: $rounded-values,
     ),
     'rounded-end': (
       property: border-end-end-radius border-start-end-radius,
       class: rounded-end,
-      values: (
-        null: var(--border-radius),
-        0: 0,
-        1: var(--border-radius-sm),
-        2: var(--border-radius),
-        3: var(--border-radius-lg),
-        4: var(--border-radius-xl),
-        5: var(--border-radius-xxl),
-        circle: 50%,
-        pill: var(--border-radius-pill),
-      ),
+      values: $rounded-values,
     ),
     'rounded-bottom': (
       property: border-end-end-radius border-end-start-radius,
       class: rounded-bottom,
-      values: (
-        null: var(--border-radius),
-        0: 0,
-        1: var(--border-radius-sm),
-        2: var(--border-radius),
-        3: var(--border-radius-lg),
-        4: var(--border-radius-xl),
-        5: var(--border-radius-xxl),
-        circle: 50%,
-        pill: var(--border-radius-pill),
-      ),
+      values: $rounded-values,
     ),
     'rounded-start': (
       property: border-start-start-radius border-end-start-radius,
       class: rounded-start,
-      values: (
-        null: var(--border-radius),
-        0: 0,
-        1: var(--border-radius-sm),
-        2: var(--border-radius),
-        3: var(--border-radius-lg),
-        4: var(--border-radius-xl),
-        5: var(--border-radius-xxl),
-        circle: 50%,
-        pill: var(--border-radius-pill),
-      ),
+      values: $rounded-values,
     ),
     'visibility': (
       property: visibility,

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -756,14 +756,27 @@ $border-radius-xl: 1rem !default;
 $border-radius-xxl: 2rem !default;
 $border-radius-pill: 100rem !default;
 
-$border-radiuses: (
+$radii: (
   0: 0,
-  xs: $border-radius-xs,
-  sm: $border-radius-sm,
-  md: $border-radius,
-  lg: $border-radius-lg,
+  1: $border-radius-xs,
+  2: $border-radius-sm,
+  3: $border-radius,
+  4: $border-radius-lg,
+  5: $border-radius-xl,
+  6: $border-radius-xxl,
   pill: $border-radius-pill,
-  null: var(--border-radius-md),
+) !default;
+
+$border-radiuses: (
+  0: var(--radius-0),
+  xs: var(--radius-1),
+  sm: var(--radius-2),
+  md: var(--radius-3),
+  lg: var(--radius-4),
+  xl: var(--radius-5),
+  xxl: var(--radius-6),
+  pill: var(--radius-pill),
+  null: var(--radius-3),
 ) !default;
 
 $icon-color: var(--gray-400) !default;

--- a/core/scss/bootstrap/_root.scss
+++ b/core/scss/bootstrap/_root.scss
@@ -122,14 +122,6 @@
   --border-style: #{$border-style};
   --border-color: light-dark(#{$border-color}, #{$border-color-dark});
   --border-color-translucent: light-dark(#{$border-color-translucent}, #{$border-color-translucent-dark});
-
-  --border-radius: #{$border-radius};
-  --border-radius-sm: #{$border-radius-sm};
-  --border-radius-lg: #{$border-radius-lg};
-  --border-radius-xl: #{$border-radius-xl};
-  --border-radius-xxl: #{$border-radius-xxl};
-  --border-radius-2xl: var(--border-radius-xxl); // Deprecated in v5.3.0 for consistency
-  --border-radius-pill: #{$border-radius-pill};
   // scss-docs-end root-border-var
 
   --box-shadow: #{$box-shadow};

--- a/core/vitest.scss.config.mjs
+++ b/core/vitest.scss.config.mjs
@@ -6,5 +6,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['scss/tests/**/*.test.mjs'],
+    // Specs that compile every Sass entry point in parallel need more than the 5s default on CI.
+    testTimeout: 30_000,
   },
 })


### PR DESCRIPTION
## Summary

- Phase 3 (token scales) of `BOOTSTRAP-V6-MIGRATION.md`: add a numeric `$radii` map (`--radius-0`…`--radius-6`, `--radius-pill`) as the single source of the border-radius tokens, the way Bootstrap v6 does. The v5 `.rounded-N` numbering and every `$border-radius-*` value are kept (2.0 policy).
- The named `--border-radius-*` custom properties are now aliases of the numeric ones (`--border-radius-xl: var(--radius-5)`, etc.). Only the `--radius-*` tokens carry the `[data-bs-theme-radius]` scale.
- Radius tokens were emitted from two places: `bootstrap/_root.scss` (plain values) and `_props.scss` (scaled, and winning the cascade). Dropped the `bootstrap/_root.scss` block so `_props.scss` is the only emitter.
- Deduplicated the `.rounded-*` utility value map. It was copy-pasted five times (`rounded`, `-top`, `-end`, `-bottom`, `-start`); it is now one `$rounded-values` map.

## Preview

- **URL:** [preview link](https://tabler-git-feat-gh-2970-radii-scale-tabler-io.vercel.app/)
- **How to test:**
  - Nothing should look different. Diff the compiled `tabler.css` before and after: the only change is inside the `:root` and `:root, :host` token blocks. No selector rule changes, the set of `.rounded-*` classes is the same, and `tabler-themes.css` is byte-identical.
  - Computed values stay `4px 6px 8px 16px 32px 1600px` for `.rounded-1`…`.rounded-5` / `.rounded-pill`.
  - In devtools set `data-bs-theme-radius="0"` and then `"2"` on `<html>`. Every radius, including `.rounded-4` and `.rounded-5`, goes to 0 and then doubles, same as on `v2-dev`.

## Notes / rollout

- Closes #2970.
- No public class or `data-bs-*` attribute changes. No markup changes. The new `--tblr-radius-*` custom properties are additive.
- Internal Sass API: `$border-radiuses` values are now `var(--radius-N)` references instead of Sass lengths. Use the new `$radii` map for compile-time math. A project that overrides the `$border-radiuses` map with its own lengths no longer gets the `--border-radius-scale` multiplier on those entries; override `$border-radius-*` or `$radii` instead. This map is not part of the promised public API (2.0 policy).
- An earlier version of this PR also fixed `.rounded-4` / `.rounded-5` ignoring the radius scale. That fix already reached `v2-dev` through #3110, so it is no longer part of this change.
