### PR TITLE
Show the version in the footer on preview.tabler.io

### DIFF
--- a/.changeset/footer-version-on-production.md
+++ b/.changeset/footer-version-on-production.md
@@ -1,0 +1,5 @@
+---
+"@tabler/preview": patch
+---
+
+Fixed the footer on `preview.tabler.io` to show the version link instead of the `Generated` build stamp.

--- a/shared/components/layout/Footer.astro
+++ b/shared/components/layout/Footer.astro
@@ -3,8 +3,10 @@ import Icon from '@ui/Icon.astro'
 import { site } from '@shared/lib/site'
 import { formatUtcTimestamp } from '@shared/lib/date-format'
 
-// Set to "preview" on the branch deploys, same as robots.txt and sitemap.xml.
-const environment = process.env.NODE_ENV || 'production'
+// Vercel sets VERCEL_ENV to "production" on preview.tabler.io and to "preview"
+// on branch deploys. Only branch deploys get the build stamp next to the
+// version; production and local/packaged builds stay byte-stable.
+const isBranchDeploy = process.env.VERCEL_ENV === 'preview'
 
 const now = new Date()
 ---
@@ -41,16 +43,11 @@ const now = new Date()
             <a href="." class="link-secondary">{site.title}</a>. All rights reserved.
           </li>
           <li class="list-inline-item">
-            {
-              environment === 'preview' ? (
-                `Generated ${formatUtcTimestamp(now)}`
-              ) : (
-                <a href="./changelog.html" class="link-secondary" rel="noopener">
-                  v{site.version}
-                </a>
-              )
-            }
+            <a href="./changelog.html" class="link-secondary" rel="noopener">
+              v{site.version}
+            </a>
           </li>
+          {isBranchDeploy && <li class="list-inline-item">Generated {formatUtcTimestamp(now)}</li>}
         </ul>
       </div>
     </div>

--- a/turbo.json
+++ b/turbo.json
@@ -1,62 +1,28 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": [
-    "NODE_ENV",
-    "NEXT_PUBLIC_POSTHOG_KEY",
-    "NEXT_PUBLIC_POSTHOG_HOST",
-    "DOCSEARCH_API_KEY",
-    "DOCSEARCH_APP_ID",
-    "DOCSEARCH_INDEX_NAME"
-  ],
+  "globalEnv": ["NODE_ENV", "VERCEL_ENV", "NEXT_PUBLIC_POSTHOG_KEY", "NEXT_PUBLIC_POSTHOG_HOST", "DOCSEARCH_API_KEY", "DOCSEARCH_APP_ID", "DOCSEARCH_INDEX_NAME"],
   "tasks": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "dist/**"
-      ],
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
       "cache": true
     },
     "@tabler/preview#build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/shared/**"
-      ],
-      "outputs": [
-        "dist/**",
-        "tmp-assets/**"
-      ],
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/shared/**"],
+      "outputs": ["dist/**", "tmp-assets/**"],
       "cache": true
     },
     "@tabler/docs#build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/shared/**"
-      ],
-      "outputs": [
-        "dist/**",
-        "tmp-assets/**"
-      ],
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/shared/**"],
+      "outputs": ["dist/**", "tmp-assets/**"],
       "cache": true
     },
     "@tabler/screenshots#build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/shared/**"
-      ],
-      "outputs": [
-        "dist/**"
-      ],
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/shared/**"],
+      "outputs": ["dist/**"],
       "cache": true
     },
     "dev": {
@@ -67,56 +33,39 @@
       "cache": false
     },
     "@tabler/preview#dev:prepare": {
-      "dependsOn": [
-        "@tabler/core#dev:prepare"
-      ],
+      "dependsOn": ["@tabler/core#dev:prepare"],
       "cache": false
     },
     "@tabler/core#dev": {
-      "dependsOn": [
-        "@tabler/core#dev:prepare"
-      ],
+      "dependsOn": ["@tabler/core#dev:prepare"],
       "cache": false,
       "persistent": true
     },
     "@tabler/preview#dev": {
-      "dependsOn": [
-        "@tabler/preview#dev:prepare"
-      ],
+      "dependsOn": ["@tabler/preview#dev:prepare"],
       "cache": false,
       "persistent": true
     },
     "@tabler/screenshots#dev": {
-      "dependsOn": [
-        "@tabler/core#dev:prepare"
-      ],
+      "dependsOn": ["@tabler/core#dev:prepare"],
       "cache": false,
       "persistent": true
     },
     "@tabler/docs#dev": {
-      "dependsOn": [
-        "@tabler/core#dev:prepare",
-        "@tabler/preview#dev:prepare"
-      ],
+      "dependsOn": ["@tabler/core#dev:prepare", "@tabler/preview#dev:prepare"],
       "cache": false,
       "persistent": true
     },
     "clean": {
-      "dependsOn": [
-        "^clean"
-      ],
+      "dependsOn": ["^clean"],
       "cache": false
     },
     "bundlewatch": {
-      "dependsOn": [
-        "build"
-      ],
+      "dependsOn": ["build"],
       "cache": true
     },
     "type-check": {
-      "dependsOn": [
-        "^type-check"
-      ],
+      "dependsOn": ["^type-check"],
       "cache": true
     },
     "test": {


### PR DESCRIPTION
## Summary

- The footer on `preview.tabler.io` shows `Generated <date>` instead of the version. The Vercel project sets `NODE_ENV=preview` for every deploy, so the check from #2884 treats the production site like a branch deploy.
- `Footer.astro` now reads `VERCEL_TARGET_ENV` (with `VERCEL_ENV` as fallback). The version link to `changelog.html` is always shown. Every deploy that is not `production` also gets the `Generated <date>` stamp as a second item: branch deploys and custom environments such as `v2` (the `v2-dev` site). Reviewers can still tell which build they are looking at.
- `VERCEL_ENV` and `VERCEL_TARGET_ENV` are added to `globalEnv` in `turbo.json`, so turbo passes it to the build and does not reuse a branch-deploy cache for production.
- `robots.txt` and `sitemap.xml` keep using `NODE_ENV` and are not touched.

## Preview

- **URL:** [preview link](https://tabler-git-footer-version-on-production-tabler-io.vercel.app/)
- **How to test:** on the branch deploy the footer should show `v1.5.0` (linked to the changelog) followed by `Generated <date>`. After merge and the next production deploy, `preview.tabler.io` should show only `v1.5.0`. A local `pnpm run build` in `preview/` also gives the version only.