### PR TITLE
Build container and table-mobile infixes with `breakpoint-infix()`

### DIFF
--- a/.changeset/consistent-breakpoint-infix.md
+++ b/.changeset/consistent-breakpoint-infix.md
@@ -1,0 +1,5 @@
+---
+"@tabler/core": patch
+---
+
+Updated `.container-*` and `.table-mobile-*` to build their breakpoint infix with `breakpoint-infix()`.

--- a/core/scss/bootstrap/_containers.scss
+++ b/core/scss/bootstrap/_containers.scss
@@ -14,7 +14,7 @@
 
   // Responsive containers that are 100% wide until a breakpoint
   @each $breakpoint, $container-max-width in $container-max-widths {
-    .container-#{$breakpoint} {
+    .container#{breakpoint-infix($breakpoint, $grid-breakpoints)} {
       @extend .container-fluid;
     }
 

--- a/core/scss/ui/_tables.scss
+++ b/core/scss/ui/_tables.scss
@@ -1,3 +1,5 @@
+@use 'sass:map';
+
 @use '../config' as *;
 
 .table {
@@ -69,9 +71,14 @@
   max-width: 1px;
 }
 
+// Generate a series of `.table-mobile-*` classes for configuring the screen
+// size below which the table stacks into rows. Mirrors `.table-responsive-*`:
+// the infix names the breakpoint the layout applies *below*.
 .table-mobile {
-  @each $breakpoint, $breakpoint-max-widthin in $grid-breakpoints {
-    &#{breakpoint-infix($breakpoint)} {
+  @each $breakpoint in map.keys($grid-breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+    &#{$infix} {
       @include media-breakpoint-down($breakpoint) {
         display: block;
 


### PR DESCRIPTION
## Summary

- `.container-*` built its breakpoint infix by hand (`.container-#{$breakpoint}`), while the loop two lines below already used `breakpoint-infix()`. Both loops now use the function, so the 2.0 move to a Tailwind-style prefix (`sm\:container`) only has to change `breakpoint-infix()` instead of hunting for hardcoded dashes.
- `.table-mobile-*` looped over `$grid-breakpoints` as key/value pairs for a value it never used, and the variable holding it was misspelled (`$breakpoint-max-widthin`). It now loops over `map.keys()` and lifts the infix into `$infix`, matching `.table-responsive-*` in `core/scss/bootstrap/_tables.scss`.
- Added a comment above `.table-mobile` saying that the infix names the breakpoint the layout applies *below*, not above. `.table-mobile-md` and `.navbar-expand-md` read the same but mean the opposite; this is upstream Bootstrap behaviour and the class names are unchanged here.

## How to review

- Read the two diffs; there is no rendered change to look at.
- The compiled `tabler.css` is byte-identical before and after (`sass core/scss/tabler.scss`, `diff` clean). `pnpm --filter @tabler/core test:scss` (141 tests) and `pnpm --filter @tabler/core lint` pass.

## Notes / rollout

- No public class names change. One dormant edge case shifts: if someone added `xs` to `$container-max-widths`, the old code emitted `.container-xs` and the new code emits `.container`, which is what the neighbouring loop already generates. The default map has no `xs`.
