### PR TITLE
Read css escapes in the markup-classes gate

### DIFF
--- a/.build/check-markup-classes.ts
+++ b/.build/check-markup-classes.ts
@@ -6,6 +6,10 @@
 // attributes of every page from a site's sitemap and looks each class up in
 // the css of the given directories.
 //
+// Class selectors can carry css escapes — `.md\:d-none`, `.\32 xl\:d-none` — while the
+// markup spells the same class plainly (`class="md:d-none"`). Selectors are decoded
+// back to that plain form so both sides compare as the same name.
+//
 // Classes that exist only as JavaScript or demo hooks are listed in
 // markup-classes-baseline.txt. Anything not on that list fails the check; so
 // does a name on the list that no longer appears, which keeps the file from
@@ -17,6 +21,16 @@ import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from '
 import { join, resolve } from 'node:path'
 
 const BASELINE = resolve(__dirname, 'markup-classes-baseline.txt')
+
+// A class selector: a dot, then an identifier whose characters may be escaped as
+// `\<char>` or `\<up to six hex digits><optional space>`. The first character must not
+// be a bare digit, which keeps lengths like `.5rem` from reading as class names.
+const ESCAPE = String.raw`\\[0-9a-fA-F]{1,6}[ \t\r\n\f]?|\\[^\n0-9a-fA-F]`
+const CLASS_SELECTOR = new RegExp(String.raw`\.(-?(?:${ESCAPE}|[_a-zA-Z\u00a0-\uffff])(?:${ESCAPE}|[-\w\u00a0-\uffff])*)`, 'g')
+
+const decodeIdent = (ident: string): string => ident.replace(/\\([0-9a-fA-F]{1,6})[ \t\r\n\f]?|\\(.)/g, (_, hex: string | undefined, char: string | undefined) => (hex === undefined ? char! : String.fromCodePoint(parseInt(hex, 16))))
+
+const classNamesIn = (css: string): string[] => [...css.matchAll(CLASS_SELECTOR)].map((m) => decodeIdent(m[1]!))
 
 const args = process.argv.slice(2)
 const htmlTargets: string[] = []
@@ -41,7 +55,7 @@ const walk = (dir: string, ext: string): string[] =>
 const defined = new Set<string>()
 for (const dir of cssDirs) {
   for (const file of walk(resolve(dir), '.css')) {
-    for (const m of readFileSync(file, 'utf8').matchAll(/\.(-?[_a-zA-Z][\w-]*)/g)) defined.add(m[1]!)
+    for (const cls of classNamesIn(readFileSync(file, 'utf8'))) defined.add(cls)
   }
 }
 
@@ -70,7 +84,7 @@ const main = async () => {
       pageCount++
       // Page-level <style> blocks define classes too (demo pages style their own markup).
       const inline = new Set<string>()
-      for (const block of html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)) for (const m of block[1]!.matchAll(/\.(-?[_a-zA-Z][\w-]*)/g)) inline.add(m[1]!)
+      for (const block of html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)) for (const cls of classNamesIn(block[1]!)) inline.add(cls)
       for (const m of html.matchAll(/class="([^"]*)"/g)) {
         for (const cls of m[1]!.split(/\s+/).filter(Boolean)) {
           if (defined.has(cls) || inline.has(cls)) continue


### PR DESCRIPTION
## Summary

- `check-markup-classes` read class selectors out of the css with `/\.(-?[_a-zA-Z][\w-]*)/g`, which stops at a backslash. A selector like `.md\:d-none` was read as the class `md`, so the gate would report every escaped class as undefined while the markup spells it `md:d-none`.
- Both readers (the stylesheets, and the page-level `<style>` blocks) now go through one `classNamesIn()` helper that understands css escapes and decodes the selector back to the name the markup uses: `.md\:d-none` → `md:d-none`, `.\32 xl\:col-6` → `2xl:col-6`, `.w-1\/2` → `w-1/2`.
- The leading-character rule is kept, so lengths like `.5rem` still do not read as class names.
- Groundwork for the infix → prefix discussion: today no shipped stylesheet contains an escaped selector, so this changes nothing now, but the gate would have failed on the first prefixed class. It also unblocks any class carrying a slash.

## How to review

- One file, one helper. There is nothing rendered to look at.
- The old and the new reader produce the **same set of 3760 classes** on the compiled `core/dist/css/tabler.css`, with no entries appearing or disappearing on either side.
- Checked against a fixture stylesheet with `.md\:d-none`, `.\32 xl\:col-6`, `.w-1\/2`, `.-negative` and `.5rem-not-a-class`: the escaped three resolve, the length is ignored, an unknown class still fails the gate, and a class defined only in a page `<style>` block is still recognised.
- `pnpm run type-check:build` and prettier pass.

## Notes / rollout

- No changeset: `.build/` is repo tooling and ships in no package, so there is no published behaviour to note in a changelog.
- `.build/markup-classes-baseline.txt` is unchanged — it holds no breakpoint entries.
