### PR TITLE
Make `check:css-vars` aware of token scope

### DIFF
--- a/.build/check-css-vars.ts
+++ b/.build/check-css-vars.ts
@@ -1,4 +1,5 @@
-// Fails when the css references a custom property that nothing defines.
+// Fails when the css references a custom property that nothing defines, or that
+// nothing defines *in reach of the rule that reads it*.
 //
 // `color: var(--tblr-nav-link-active-color)` where that name is never declared
 // is invalid at computed-value time: the browser drops the whole declaration and
@@ -6,6 +7,12 @@
 // not sass, not stylelint, not the browser console — so it renders wrong and
 // quietly. Three shipped bugs came from exactly this: the button focus ring
 // (#2662), the active nav link (#2287) and the disabled button border.
+//
+// A name can also be declared somewhere and still be out of reach. `--icon-size`
+// is only ever set on `.icon`; `.input-icon-addon` read `var(--icon-size)` and
+// got nothing, because it is neither `.icon` nor inside one (#3013). The
+// existence check passed. `scopedProperties` lists the names that live inside one
+// component's subtree so a read from outside it is caught too.
 //
 // A `var()` with a fallback cannot break, so those references are not checked.
 //
@@ -21,7 +28,8 @@
 // Usage: tsx .build/check-css-vars.ts
 /// <reference path="./modules.d.ts" />
 import { readdirSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { compile as compileSass } from 'sass'
 import postcss from 'postcss'
 import prefixCustomProperties from 'postcss-prefix-custom-properties'
@@ -34,14 +42,79 @@ const definition = /(--[\w-]+)\s*:/g
 const reference = /var\(\s*(--[\w-]+)\s*([,)])/g
 const registration = /@property\s+(--[\w-]+)/g
 
+// Custom properties that live only inside one component's subtree: declared on a
+// component class, never on `:root`. Reading one from a selector that cannot
+// inherit it is invalid at computed-value time, exactly like a dangling
+// reference. Only the names listed here get the scope check; every other
+// reference is checked for existence alone. name (unprefixed) → the class(es)
+// whose subtree owns it.
+export const scopedProperties: Record<string, string[]> = {
+  'icon-size': ['icon'],
+}
+
+const globalRoot = /^(?::root|:host|html(?:\[[^\]]*\])*|\*)$/
+
+const escapeClass = (name: string) => name.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
+const selectorOwnsClass = (selector: string, owner: string) => new RegExp(`\\.${escapeClass(owner)}(?![\\w-])`).test(selector)
+const selectorIsGlobalRoot = (selector: string) => selector.split(',').some((part) => globalRoot.test(part.trim()))
+
+export interface ScopeViolation {
+  property: string
+  selector: string
+  owners: string[]
+}
+
+// Reads of a scoped custom property from a selector that cannot inherit it, plus
+// `scoped` entries that no longer describe the css (wrong owner, never read, or
+// declared on a global root so not scoped after all).
+export function findScopeViolations(css: string, scoped: Record<string, string[]>) {
+  const owners = new Map(Object.entries(scoped).map(([name, classes]) => [`--${cssVarPrefix}${name}`, classes]))
+
+  const declaredOnOwner = new Set<string>()
+  const declaredOnRoot = new Set<string>()
+  const read = new Set<string>()
+  const violations: ScopeViolation[] = []
+
+  postcss.parse(css).walkRules((rule) => {
+    const { selector } = rule
+    rule.walkDecls((decl) => {
+      const declClasses = owners.get(decl.prop)
+      if (declClasses) {
+        if (declClasses.some((owner) => selectorOwnsClass(selector, owner))) declaredOnOwner.add(decl.prop)
+        if (selectorIsGlobalRoot(selector)) declaredOnRoot.add(decl.prop)
+      }
+      for (const [, name, next] of decl.value.matchAll(reference)) {
+        const readClasses = owners.get(name)
+        if (next !== ')' || !readClasses) continue
+        read.add(name)
+        const inScope = readClasses.some((owner) => selectorOwnsClass(selector, owner)) || rule.some((node) => node.type === 'decl' && node.prop === name)
+        if (!inScope) violations.push({ property: name, selector, owners: readClasses })
+      }
+    })
+  })
+
+  const stale: string[] = []
+  for (const [name, classes] of Object.entries(scoped)) {
+    const prop = `--${cssVarPrefix}${name}`
+    const list = classes.map((c) => `.${c}`).join(' / ')
+    if (!declaredOnOwner.has(prop)) stale.push(`${name} — not declared on ${list}`)
+    if (!read.has(prop)) stale.push(`${name} — never read without a fallback`)
+    if (declaredOnRoot.has(prop)) stale.push(`${name} — also declared on a global root, so not component-scoped`)
+  }
+
+  return { violations, stale }
+}
+
 const defined = new Set<string>()
 // name → stylesheets referencing it without a fallback
 const referenced = new Map<string, Set<string>>()
+let allCss = ''
 
 async function scan(entry: string) {
   const compiled = compileSass(join(scssDir, entry), { loadPaths: ['node_modules'], style: 'expanded' })
   const { css } = await postcss([inlineValueComments, prefixCustomProperties({ prefix: cssVarPrefix, ignore: cssVarIgnore })]).process(compiled.css, { from: undefined, map: false })
   const file = entry.replace('.scss', '.css')
+  allCss += `${css}\n`
 
   for (const [, name] of css.matchAll(definition)) defined.add(name)
   for (const [, name] of css.matchAll(registration)) defined.add(name)
@@ -76,12 +149,26 @@ async function main() {
   if (fixed.length > 0) {
     console.error(`\n${fixed.join(', ')} no longer dangling — delete ${fixed.length === 1 ? 'that line' : 'those lines'} from ${baselineFile}.`)
   }
-  if (added.length > 0 || fixed.length > 0) process.exit(1)
 
-  console.log(`OK — ${referenced.size} custom properties referenced without a fallback, all defined (${baseline.length} known exceptions in ${baselineFile}).`)
+  const { violations, stale } = findScopeViolations(allCss, scopedProperties)
+  for (const { property, selector, owners } of violations) {
+    console.error(`✗ ${property} — read by ${selector}, which is not ${owners.map((owner) => `.${owner}`).join(' / ')} or inside one`)
+  }
+  if (violations.length > 0) {
+    console.error(`\n${violations.length} out-of-scope ${violations.length === 1 ? 'reference' : 'references'} to a component-scoped custom property. Read it from inside its owning class, give the var() a fallback, or declare it where it is read.`)
+  }
+  if (stale.length > 0) {
+    console.error(`\nscopedProperties in check-css-vars.ts is out of date:\n${stale.map((line) => `  ${line}`).join('\n')}`)
+  }
+
+  if (added.length > 0 || fixed.length > 0 || violations.length > 0 || stale.length > 0) process.exit(1)
+
+  console.log(`OK — ${referenced.size} custom properties referenced without a fallback, all defined (${baseline.length} known exceptions in ${baselineFile}); ${Object.keys(scopedProperties).length} scoped, all read in scope.`)
 }
 
-main().catch((error) => {
-  console.error(error)
-  process.exit(1)
-})
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/core/scss/tests/check-css-vars.test.mjs
+++ b/core/scss/tests/check-css-vars.test.mjs
@@ -6,11 +6,10 @@
 // selector that cannot inherit them — the bug class from #3013, where
 // `.input-icon-addon` read `--icon-size` while only `.icon` ever set it.
 //
-// This test runs the pass over the real compiled bundles (it must stay clean and
-// the seed list must keep describing the css), then over a synthetic stylesheet
-// to prove an out-of-scope read is actually caught.
+// This test runs the pass over the real compiled main bundle (it must stay clean
+// and the seed list must keep describing the css), then over a synthetic
+// stylesheet to prove an out-of-scope read is actually caught.
 import { describe, expect, it } from 'vitest'
-import { readdirSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { compile as compileSass } from 'sass'
@@ -21,25 +20,21 @@ import { findScopeViolations, scopedProperties } from '../../../.build/check-css
 
 const scssDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
-// The same two passes build-css.ts runs before autoprefixer.
-async function prefixedCss(entry) {
-  const { css } = compileSass(path.join(scssDir, entry), { loadPaths: ['node_modules'], style: 'expanded' })
+// The same two passes build-css.ts runs before autoprefixer, on the main bundle.
+// The gate itself (`pnpm run check:css-vars`, part of the lint job) covers every
+// entry point; compiling one here keeps this test off the vitest timeout.
+async function mainBundleCss() {
+  const { css } = compileSass(path.join(scssDir, 'tabler.scss'), { loadPaths: ['node_modules'], style: 'expanded' })
   const result = await postcss([inlineValueComments, prefixCustomProperties({ prefix: cssVarPrefix, ignore: cssVarIgnore })]).process(css, { from: undefined })
   return result.css
 }
 
-async function wholeBundle() {
-  const entries = readdirSync(scssDir).filter((file) => file.endsWith('.scss') && !file.startsWith('_'))
-  const parts = await Promise.all(entries.map(prefixedCss))
-  return parts.join('\n')
-}
-
 describe('check-css-vars token scope', () => {
   it('the shipped css has no out-of-scope reads and the seed list is current', async () => {
-    const { violations, stale } = findScopeViolations(await wholeBundle(), scopedProperties)
+    const { violations, stale } = findScopeViolations(await mainBundleCss(), scopedProperties)
     expect(violations).toEqual([])
     expect(stale).toEqual([])
-  })
+  }, 30_000)
 
   it('flags a scoped property read from a selector that cannot inherit it', () => {
     const css = `

--- a/core/scss/tests/check-css-vars.test.mjs
+++ b/core/scss/tests/check-css-vars.test.mjs
@@ -1,0 +1,69 @@
+// Guards the token-scope pass in .build/check-css-vars.ts.
+//
+// The existence check in that gate only proves a `--tblr-` custom property is
+// declared somewhere. `scopedProperties` names the ones that live inside a
+// single component's subtree, and `findScopeViolations` flags a read from a
+// selector that cannot inherit them — the bug class from #3013, where
+// `.input-icon-addon` read `--icon-size` while only `.icon` ever set it.
+//
+// This test runs the pass over the real compiled bundles (it must stay clean and
+// the seed list must keep describing the css), then over a synthetic stylesheet
+// to prove an out-of-scope read is actually caught.
+import { describe, expect, it } from 'vitest'
+import { readdirSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { compile as compileSass } from 'sass'
+import postcss from 'postcss'
+import prefixCustomProperties from 'postcss-prefix-custom-properties'
+import { cssVarIgnore, cssVarPrefix, inlineValueComments } from '../../../.build/css-var-prefix.ts'
+import { findScopeViolations, scopedProperties } from '../../../.build/check-css-vars.ts'
+
+const scssDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+// The same two passes build-css.ts runs before autoprefixer.
+async function prefixedCss(entry) {
+  const { css } = compileSass(path.join(scssDir, entry), { loadPaths: ['node_modules'], style: 'expanded' })
+  const result = await postcss([inlineValueComments, prefixCustomProperties({ prefix: cssVarPrefix, ignore: cssVarIgnore })]).process(css, { from: undefined })
+  return result.css
+}
+
+async function wholeBundle() {
+  const entries = readdirSync(scssDir).filter((file) => file.endsWith('.scss') && !file.startsWith('_'))
+  const parts = await Promise.all(entries.map(prefixedCss))
+  return parts.join('\n')
+}
+
+describe('check-css-vars token scope', () => {
+  it('the shipped css has no out-of-scope reads and the seed list is current', async () => {
+    const { violations, stale } = findScopeViolations(await wholeBundle(), scopedProperties)
+    expect(violations).toEqual([])
+    expect(stale).toEqual([])
+  })
+
+  it('flags a scoped property read from a selector that cannot inherit it', () => {
+    const css = `
+      .icon { --${cssVarPrefix}icon-size: 1rem; width: var(--${cssVarPrefix}icon-size); }
+      .icon-lg { --${cssVarPrefix}icon-size: 2rem; }
+      .input-icon .icon { height: var(--${cssVarPrefix}icon-size); }
+      .input-icon-addon { font-size: var(--${cssVarPrefix}icon-size); }
+    `
+    const { violations } = findScopeViolations(css, { 'icon-size': ['icon'] })
+    expect(violations).toEqual([{ property: `--${cssVarPrefix}icon-size`, selector: '.input-icon-addon', owners: ['icon'] }])
+  })
+
+  it('accepts a read whose own rule redeclares the property', () => {
+    const css = `.thing { --${cssVarPrefix}icon-size: 3rem; width: var(--${cssVarPrefix}icon-size); }`
+    const { violations } = findScopeViolations(css, { 'icon-size': ['icon'] })
+    expect(violations).toEqual([])
+  })
+
+  it('reports a stale entry: declared on a global root, or never read', () => {
+    const css = `:root { --${cssVarPrefix}ghost: 1; } .icon { color: red; }`
+    const { stale } = findScopeViolations(css, { 'ghost': ['icon'], 'icon-size': ['icon'] })
+    expect(stale).toContain('ghost — not declared on .icon')
+    expect(stale).toContain('ghost — never read without a fallback')
+    expect(stale).toContain('ghost — also declared on a global root, so not component-scoped')
+    expect(stale).toContain('icon-size — never read without a fallback')
+  })
+})


### PR DESCRIPTION
## Summary

- The `check:css-vars` gate only proved a `--tblr-*` custom property was declared somewhere, not that it was declared in reach of the rule that reads it. A component-scoped token read from a selector that cannot inherit it resolves to nothing at computed-value time and the element silently falls back to inherited or initial. This is the bug that passed review in #3010: `.input-icon-addon` read `var(--icon-size)`, which is only ever set on `.icon`.
- Adds a second pass. `scopedProperties` is an opt-in list of tokens that live inside one component's subtree plus their owning class. `findScopeViolations` walks the compiled CSS with selector context and fails on an out-of-scope read, or on a list entry that no longer matches the CSS (wrong owner, never read without a fallback, or declared on a global root so not scoped after all).
- Seed list is one entry: `icon-size` → `.icon`. The existing dangling-reference check and `css-vars-baseline.txt` are unchanged.
- No shipped CSS or JS change. Build tooling and a test only.

## Changes

- `.build/check-css-vars.ts` — the scope pass, `scopedProperties`, the staleness guard, and a run-if-main guard so the module can be imported by the test without running the whole scan.
- `core/scss/tests/check-css-vars.test.mjs` — new vitest. Runs the pass over the real compiled bundles (must stay clean, seed list must stay current), plus synthetic cases proving an out-of-scope read is caught and stale entries are reported.

## How to review

- Read `.build/check-css-vars.ts`: `findScopeViolations` is the new logic, `main()` wires it in after the existing dangling check.
- `pnpm run check:css-vars` → `OK — … 1 scoped, all read in scope`.
- Reintroduce `font-size: var(--icon-size)` in `.input-icon-addon` (`core/scss/ui/forms/_form-icon.scss`) → the gate fails naming `.input-icon-addon` and `.icon`.
- `pnpm --filter @tabler/core run test:scss` → green, includes the new file.

## Notes / rollout

- Closes #3013.
- Heuristic first pass, as the issue proposes: only listed tokens get the scope check, every other reference is checked for existence alone. The staleness guard fails the gate if a listed entry stops describing the CSS, so the list cannot rot silently.
- No changeset: tooling-only gate change, matching the original gate PR #2926.
