### PR TITLE
Keep prettier from reflowing markdown in .agents

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -22,6 +22,13 @@
 			"options": {
 				"parser": "astro"
 			}
+		},
+		{
+			"files": ".agents/**/*.md",
+			"options": {
+				"proseWrap": "preserve",
+				"embeddedLanguageFormatting": "off"
+			}
 		}
 	]
 }


### PR DESCRIPTION
## Summary

- Add a prettier override for `.agents/**/*.md` so `proseWrap` is `preserve` and `embeddedLanguageFormatting` is `off`.
- These skill and agent files are hand-wrapped at a narrow width. With the repo default (`proseWrap: always`, `printWidth: 320`) an accidental `prettier --write` reflowed every paragraph — during the design-system work this turned a 49-line edit into a 300-line diff that had to be reverted and reapplied by hand.
- After this change `prettier --write` on those files no longer reflows prose or reformats fenced code blocks. Markdown table padding and `*` to `_` emphasis markers still change (prettier has no option to disable either), but the full-file reflow is gone.
- `.agents/rules/*.mdc` need no handling — prettier has no parser for `.mdc` and skips them.

## Notes / rollout

- `.agents/**` is still not part of the `lint:prettier` glob; this only changes what a manual or editor-triggered `prettier --write` does. Adding the path to the lint glob is left for later, once table formatting is normalised.
- Closes #3014
