### PR TITLE
Remove `scrollbar-gutter: stable` to fix the gap right of the navbar

### DIFF
--- a/.changeset/fix-navbar-scrollbar-gutter-gap.md
+++ b/.changeset/fix-navbar-scrollbar-gutter-gap.md
@@ -1,0 +1,6 @@
+---
+"@tabler/core": patch
+"@tabler/docs": patch
+---
+
+Fixed the empty gutter to the right of the navbar on non-scrolling pages by dropping `scrollbar-gutter: stable` from `html`.

--- a/core/scss/layout/_core.scss
+++ b/core/scss/layout/_core.scss
@@ -2,14 +2,6 @@
 
 @use '../config' as *;
 
-html {
-  scrollbar-gutter: stable;
-
-  @supports not (scrollbar-gutter: stable) {
-    overflow-y: scroll;
-  }
-}
-
 // stylelint-disable property-no-vendor-prefix
 body {
   position: relative;

--- a/docs/content/ui/getting-started/upgrade.mdx
+++ b/docs/content/ui/getting-started/upgrade.mdx
@@ -273,7 +273,7 @@ These changes are not breaking, but they change how a page looks. Check your scr
 - **Links**: in dark mode, links use a lighter tint of the primary color, so they meet the 4.5:1 contrast ratio on dark surfaces. Override `--tblr-link-color` to change it.
 - **Sizes**: `.form-control`, `.btn` and `.input-group` now agree on `sm` and `lg` sizes, `.btn-icon` is square, and `.icon-sm` uses a `1.5` stroke width.
 - **Cards**: `--tblr-card-header-bg` and `--tblr-card-footer-bg` can be set on their own, and the card status bar is `3px`.
-- **Layout**: `scrollbar-gutter: stable` on `html` removes the white gap next to the scrollbar.
+- **Layout**: the `margin-inline-start: calc(100vw - 100%)` hack on the root element is gone, so there is no white gap on the left when a scrollbar is present.
 - **Trending**: the component uses the `arrow-up` and `arrow-down` icons instead of `trending-up` and `trending-down`.
 
 ## RTL


### PR DESCRIPTION
## Summary

- On pages with no vertical scrollbar, `scrollbar-gutter: stable` on `html` kept ~15px reserved on the right. The navbar and page content stopped short of the viewport edge, leaving a visible empty strip (most obvious in dark mode, where the navbar colour differs from the body). Reported in #3009.
- Removed the `html { scrollbar-gutter: stable }` block and its `@supports not (...) { overflow-y: scroll }` fallback. This restores the Bootstrap default.
- #2548 (white gap on the left when a scrollbar is present) stays fixed. Its real cause — the `margin-inline-start: calc(100vw - 100%)` hack — was removed in that same PR and does not come back.
- Trade-off: centred content shifts about 7px when navigating between a scrolling and a non-scrolling page. This is standard browser behaviour and is hard to notice in a dashboard where almost every page scrolls.
- Updated the matching "Layout" note on the upgrade docs page.

## Preview

- **URL:** [/logs.html](https://tabler-git-fix-3009-tabler-io.vercel.app/logs.html) (short page, no scrollbar)
- **How to test:**
  - Open [/logs.html](https://tabler-git-fix-3009-tabler-io.vercel.app/logs.html) — the top navbar and the menu row now reach the right edge, with no empty strip. Check light and dark mode.
  - Open [/form-elements.html](https://tabler-git-fix-3009-tabler-io.vercel.app/form-elements.html) — the vertical scrollbar takes its normal ~15px on the right, there is no white gap on the left, and no horizontal scrollbar appears.
  - Docs note: [ui/getting-started/upgrade](https://tabler-docs-git-fix-3009-tabler-io.vercel.app/ui/getting-started/upgrade) → "Visual changes" → "Layout".

## Notes / rollout

- Closes #3009
- `@tabler/core` and `@tabler/docs` patch bump (changeset included).