### PR TITLE
Show diagonal pattern on the card background-pattern docs example

### DIFF
--- a/.changeset/fix-background-pattern-docs-example.md
+++ b/.changeset/fix-background-pattern-docs-example.md
@@ -1,0 +1,5 @@
+---
+"@tabler/docs": patch
+---
+
+Fixed the "Card on a background pattern" docs example so the preview shows the `.bg-pattern-diagonal` background.

--- a/docs/content/ui/utilities/background-patterns.mdx
+++ b/docs/content/ui/utilities/background-patterns.mdx
@@ -162,13 +162,13 @@ Use opacity utilities to control how strong the texture is:
 
 Look at the following examples to see how background patterns can be used in real layouts.
 
-### Card with background pattern
+### Card on a background pattern
 
-Card with a background pattern in the body can be used to add a decorative touch to the card. This is useful when you want to add a subtle pattern to the card without affecting the readability of the content.
+Placing a card on a patterned background adds a decorative touch to the surrounding area while keeping the card itself clean. Wrap the card in an element with a `.bg-pattern-*` class so the pattern shows around the card without affecting the readability of its content.
 
 <Example hideCode class="bg-pattern-diagonal">
   <div class="card">
-    <div class="card-body">Here is example of a card with a background pattern.</div>
+    <div class="card-body">Here is an example of a card placed on a background pattern.</div>
   </div>
 </Example>
 <Example codeOnly>

--- a/docs/content/ui/utilities/background-patterns.mdx
+++ b/docs/content/ui/utilities/background-patterns.mdx
@@ -81,7 +81,7 @@ Use `.bg-pattern-transparent` when you need a checkerboard-style transparent bac
   <Illustration image="boy-with-key.svg" class="d-block mx-auto mw-100" height={200} />
 </Example>
 <Example codeOnly>
-<div class="bg-pattern-transparent p-4"></div>
+  <div class="bg-pattern-transparent p-4"></div>
 </Example>
 
 ## Pattern sizes
@@ -96,30 +96,30 @@ Use size utilities to control pattern density:
 Look at the following examples to see how the pattern sizes work:
 
 <Example hideCode>
-<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-3">
-  <div class="col">
-    <div class="bg-pattern-circles bg-pattern-sm border rounded mb-2" style="height: 6rem;"></div>
-    <code>.bg-pattern-sm</code>
+  <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-3">
+    <div class="col">
+      <div class="bg-pattern-circles bg-pattern-sm border rounded mb-2" style="height: 6rem;"></div>
+      <code>.bg-pattern-sm</code>
+    </div>
+    <div class="col">
+      <div class="bg-pattern-circles bg-pattern-md border rounded mb-2" style="height: 6rem;"></div>
+      <code>.bg-pattern-md</code>
+    </div>
+    <div class="col">
+      <div class="bg-pattern-circles bg-pattern-lg border rounded mb-2" style="height: 6rem;"></div>
+      <code>.bg-pattern-lg</code>
+    </div>
+    <div class="col">
+      <div class="bg-pattern-circles bg-pattern-xl border rounded mb-2" style="height: 6rem;"></div>
+      <code>.bg-pattern-xl</code>
+    </div>
   </div>
-  <div class="col">
-    <div class="bg-pattern-circles bg-pattern-md border rounded mb-2" style="height: 6rem;"></div>
-    <code>.bg-pattern-md</code>
-  </div>
-  <div class="col">
-    <div class="bg-pattern-circles bg-pattern-lg border rounded mb-2" style="height: 6rem;"></div>
-    <code>.bg-pattern-lg</code>
-  </div>
-  <div class="col">
-    <div class="bg-pattern-circles bg-pattern-xl border rounded mb-2" style="height: 6rem;"></div>
-    <code>.bg-pattern-xl</code>
-  </div>
-</div>
 </Example>
 <Example codeOnly>
-<div class="bg-pattern-circles bg-pattern-sm"></div>
-<div class="bg-pattern-circles bg-pattern-md"></div>
-<div class="bg-pattern-circles bg-pattern-lg"></div>
-<div class="bg-pattern-circles bg-pattern-xl"></div>
+  <div class="bg-pattern-circles bg-pattern-sm"></div>
+  <div class="bg-pattern-circles bg-pattern-md"></div>
+  <div class="bg-pattern-circles bg-pattern-lg"></div>
+  <div class="bg-pattern-circles bg-pattern-xl"></div>
 </Example>
 
 ## Pattern opacity
@@ -132,30 +132,30 @@ Use opacity utilities to control how strong the texture is:
 - `.bg-pattern-opacity-darker`
 
 <Example hideCode>
-<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-3">
-  <div class="col">
-    <div class="bg-pattern-circles bg-pattern-opacity-lighter border rounded mb-2" style="height: 6rem;"></div>
-    <code>.bg-pattern-opacity-lighter</code>
+  <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-3">
+    <div class="col">
+      <div class="bg-pattern-circles bg-pattern-opacity-lighter border rounded mb-2" style="height: 6rem;"></div>
+      <code>.bg-pattern-opacity-lighter</code>
+    </div>
+    <div class="col">
+      <div class="bg-pattern-circles bg-pattern-opacity-light border rounded mb-2" style="height: 6rem;"></div>
+      <code>.bg-pattern-opacity-light</code>
+    </div>
+    <div class="col">
+      <div class="bg-pattern-circles bg-pattern-opacity-dark border rounded mb-2" style="height: 6rem;"></div>
+      <code>.bg-pattern-opacity-dark</code>
+    </div>
+    <div class="col">
+      <div class="bg-pattern-circles bg-pattern-opacity-darker border rounded mb-2" style="height: 6rem;"></div>
+      <code>.bg-pattern-opacity-darker</code>
+    </div>
   </div>
-  <div class="col">
-    <div class="bg-pattern-circles bg-pattern-opacity-light border rounded mb-2" style="height: 6rem;"></div>
-    <code>.bg-pattern-opacity-light</code>
-  </div>
-  <div class="col">
-    <div class="bg-pattern-circles bg-pattern-opacity-dark border rounded mb-2" style="height: 6rem;"></div>
-    <code>.bg-pattern-opacity-dark</code>
-  </div>
-  <div class="col">
-    <div class="bg-pattern-circles bg-pattern-opacity-darker border rounded mb-2" style="height: 6rem;"></div>
-    <code>.bg-pattern-opacity-darker</code>
-  </div>
-</div>
 </Example>
 <Example codeOnly>
-<div class="bg-pattern-circles bg-pattern-opacity-lighter"></div>
-<div class="bg-pattern-circles bg-pattern-opacity-light"></div>
-<div class="bg-pattern-circles bg-pattern-opacity-dark"></div>
-<div class="bg-pattern-circles bg-pattern-opacity-darker"></div>
+  <div class="bg-pattern-circles bg-pattern-opacity-lighter"></div>
+  <div class="bg-pattern-circles bg-pattern-opacity-light"></div>
+  <div class="bg-pattern-circles bg-pattern-opacity-dark"></div>
+  <div class="bg-pattern-circles bg-pattern-opacity-darker"></div>
 </Example>
 
 ## Examples
@@ -166,15 +166,15 @@ Look at the following examples to see how background patterns can be used in rea
 
 Card with a background pattern in the body can be used to add a decorative touch to the card. This is useful when you want to add a subtle pattern to the card without affecting the readability of the content.
 
-<Example hideCode>
-<div class="card">
-  <div class="card-body">Here is example of a card with a background pattern.</div>
-</div>
+<Example hideCode class="bg-pattern-diagonal">
+  <div class="card">
+    <div class="card-body">Here is example of a card with a background pattern.</div>
+  </div>
 </Example>
 <Example codeOnly>
-<div class="bg-pattern-diagonal">
-  <div class="card">...</div>
-</div>
+  <div class="bg-pattern-diagonal">
+    <div class="card">...</div>
+  </div>
 </Example>
 
 ## Accessibility


### PR DESCRIPTION
## Summary

- The live “Card with background pattern” example now uses `.bg-pattern-diagonal` on the example wrapper, so the preview matches the snippet.
- Docs examples on the background patterns page use consistent indentation.

## Preview

- **URL:** [Background patterns](https://tabler-docs-git-fix-3032-tabler-io.vercel.app/ui/utilities/background-patterns#card-on-a-background-pattern)
- **How to test:** Open that page and check that the live card sits on a diagonal pattern. Confirm the code snippet still wraps the card in `.bg-pattern-diagonal`.

## Notes / rollout

- Closes #3032