### PR TITLE
Rebuild Modal on the native `<dialog>` element

### DIFF
--- a/.changeset/modal-native-dialog.md
+++ b/.changeset/modal-native-dialog.md
@@ -1,0 +1,7 @@
+---
+"@tabler/core": major
+"@tabler/preview": patch
+"@tabler/docs": patch
+---
+
+Updated `Modal` to use the native `<dialog>` element instead of `<div>`, replacing `.modal-backdrop` and the focus trap.

--- a/BOOTSTRAP-V6-MIGRATION.md
+++ b/BOOTSTRAP-V6-MIGRATION.md
@@ -487,6 +487,15 @@ Decided:
     soft `.badge.bg-{color}-lt` variant without a role of its own, and `.agents/rules/main.mdc`
     already forbade it. This is a deliberate exception to "every 1.x class stays": upgrade-guide
     line, no replacement class — markup moves to `.badge.bg-{color}-lt`.
+15. Modal on native `<dialog>` (phase 6, decided 2026-09-11): the `.modal-backdrop` DOM element is
+    dropped, not aliased — its styling (including the `--backdrop-*` custom properties, now
+    `--modal-backdrop-*`) moves to `.modal`'s native `::backdrop`, matching upstream's own removal
+    of `util/backdrop.js`. Anyone overriding `.modal-backdrop` in custom CSS must retarget
+    `.modal::backdrop`. The `focus` JS config option is dropped (native `showModal()` always moves
+    focus in; no in-repo usage found, and upstream v6 dropped it too). `data-bs-backdrop="false"`
+    keeps its meaning for click-to-dismiss but can no longer suppress the backdrop itself or keep
+    the rest of the page interactive — `showModal()`'s top layer is inert regardless of the config.
+    `.modal-open` moves from `<body>` to `<html>` to pair with `scrollbar-gutter: stable`.
 
 Open:
 

--- a/BOOTSTRAP-V6-MIGRATION.md
+++ b/BOOTSTRAP-V6-MIGRATION.md
@@ -496,6 +496,10 @@ Decided:
     keeps its meaning for click-to-dismiss but can no longer suppress the backdrop itself or keep
     the rest of the page interactive — `showModal()`'s top layer is inert regardless of the config.
     `.modal-open` moves from `<body>` to `<html>` to pair with `scrollbar-gutter: stable`.
+    Overlays appended to `<body>` (Tom Select's `dropdownParent: 'body'`, Litepicker's default
+    container, tooltips and popovers with `container: 'body'`) render underneath the top layer
+    while a modal is open — inside a modal they must stay in the modal's subtree. The shared
+    `Select` and `Datepicker` components detect `.closest('.modal')` and do that on their own.
 
 Open:
 

--- a/core/js/src/bootstrap/modal.ts
+++ b/core/js/src/bootstrap/modal.ts
@@ -8,11 +8,8 @@
 import BaseComponent from './base-component'
 import EventHandler from './dom/event-handler'
 import SelectorEngine from './dom/selector-engine'
-import Backdrop from './util/backdrop'
 import { enableDismissTrigger } from './util/component-functions'
-import FocusTrap from './util/focustrap'
-import { isRTL, isVisible, reflow } from './util/index'
-import ScrollBarHelper from './util/scrollbar'
+import { isVisible } from './util/index'
 
 /**
  * Constants
@@ -22,17 +19,13 @@ const NAME = 'modal'
 const DATA_KEY = 'bs.modal'
 const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
-const ESCAPE_KEY = 'Escape'
 
 const EVENT_HIDE = `hide${EVENT_KEY}`
 const EVENT_HIDE_PREVENTED = `hidePrevented${EVENT_KEY}`
 const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
-const EVENT_RESIZE = `resize${EVENT_KEY}`
-const EVENT_CLICK_DISMISS = `click.dismiss${EVENT_KEY}`
-const EVENT_MOUSEDOWN_DISMISS = `mousedown.dismiss${EVENT_KEY}`
-const EVENT_KEYDOWN_DISMISS = `keydown.dismiss${EVENT_KEY}`
+const EVENT_CLICK_DISMISS = `click${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
 const CLASS_NAME_OPEN = 'modal-open'
@@ -40,7 +33,7 @@ const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
 const CLASS_NAME_STATIC = 'modal-static'
 
-const OPEN_SELECTOR = '.modal.show'
+const OPEN_SELECTOR = '.modal[open]'
 const SELECTOR_DIALOG = '.modal-dialog'
 const SELECTOR_MODAL_BODY = '.modal-body'
 const SELECTOR_DATA_TOGGLE = '[data-bs-toggle="modal"], [data-tblr-toggle="modal"]'
@@ -55,13 +48,11 @@ interface ComponentConfigType {
 
 const Default: ComponentConfig = {
   backdrop: true,
-  focus: true,
   keyboard: true,
 }
 
 const DefaultType: ComponentConfigType = {
   backdrop: '(boolean|string)',
-  focus: 'boolean',
   keyboard: 'boolean',
 }
 
@@ -70,22 +61,16 @@ const DefaultType: ComponentConfigType = {
  */
 
 class Modal extends BaseComponent {
+  declare _element: HTMLDialogElement
   _dialog: HTMLElement | null
-  _backdrop: Backdrop
-  _focustrap: FocusTrap
-  _isShown: boolean
   _isTransitioning: boolean
-  _scrollBar: ScrollBarHelper
+  _cancelHandler: (event: Event) => void
 
   constructor(element: HTMLElement | string, config?: Partial<ComponentConfig>) {
     super(element, config)
 
     this._dialog = SelectorEngine.findOne(SELECTOR_DIALOG, this._element)
-    this._backdrop = this._initializeBackDrop()
-    this._focustrap = this._initializeFocusTrap()
-    this._isShown = false
     this._isTransitioning = false
-    this._scrollBar = new ScrollBarHelper()
 
     this._addEventListeners()
   }
@@ -103,11 +88,11 @@ class Modal extends BaseComponent {
   }
 
   toggle(relatedTarget?: HTMLElement): void {
-    return this._isShown ? this.hide() : this.show(relatedTarget)
+    return this._element.open ? this.hide() : this.show(relatedTarget)
   }
 
   show(relatedTarget?: HTMLElement): void {
-    if (this._isShown || this._isTransitioning) {
+    if (this._element.open || this._isTransitioning) {
       return
     }
 
@@ -119,20 +104,39 @@ class Modal extends BaseComponent {
       return
     }
 
-    this._isShown = true
     this._isTransitioning = true
 
-    this._scrollBar.hide()
+    // showModal() throws on a dialog that isn't connected to the document.
+    if (!document.body.contains(this._element)) {
+      document.body.append(this._element)
+    }
 
-    document.body.classList.add(CLASS_NAME_OPEN)
+    document.documentElement.classList.add(CLASS_NAME_OPEN)
 
-    this._adjustDialog()
+    this._element.showModal()
+    this._element.scrollTop = 0
 
-    this._backdrop.show(() => this._showElement(relatedTarget))
+    const modalBody = SelectorEngine.findOne(SELECTOR_MODAL_BODY, this._dialog)
+    if (modalBody) {
+      modalBody.scrollTop = 0
+    }
+
+    this._element.classList.add(CLASS_NAME_SHOW)
+
+    this._queueCallback(
+      () => {
+        this._isTransitioning = false
+        EventHandler.trigger(this._element, EVENT_SHOWN, {
+          relatedTarget,
+        })
+      },
+      this._element,
+      this._isAnimated(),
+    )
   }
 
   hide(): void {
-    if (!this._isShown || this._isTransitioning) {
+    if (!this._element.open || this._isTransitioning) {
       return
     }
 
@@ -142,131 +146,74 @@ class Modal extends BaseComponent {
       return
     }
 
-    this._isShown = false
     this._isTransitioning = true
-    this._focustrap.deactivate()
-
     this._element.classList.remove(CLASS_NAME_SHOW)
 
-    this._queueCallback(() => this._hideModal(), this._element, this._isAnimated())
+    this._queueCallback(() => this._closeAndCleanup(), this._element, this._isAnimated())
   }
 
   dispose(): void {
-    EventHandler.off(window, EVENT_KEY)
-    EventHandler.off(this._dialog, EVENT_KEY)
+    EventHandler.off(this._element, 'cancel', this._cancelHandler)
 
-    this._backdrop.dispose()
-    this._focustrap.deactivate()
+    if (this._element.open) {
+      this._closeAndCleanup()
+    }
 
     super.dispose()
   }
 
   handleUpdate(): void {
-    this._adjustDialog()
+    // Provided for API consistency — the native dialog handles its own positioning.
   }
 
-  _initializeBackDrop(): Backdrop {
-    return new Backdrop({
-      isVisible: Boolean(this._config.backdrop),
-      isAnimated: this._isAnimated(),
-    })
-  }
-
-  _initializeFocusTrap(): FocusTrap {
-    return new FocusTrap({
-      trapElement: this._element,
-    })
-  }
-
-  _showElement(relatedTarget?: HTMLElement): void {
-    if (!document.body.contains(this._element)) {
-      document.body.append(this._element)
-    }
-
-    this._element.style.display = 'block'
-    this._element.removeAttribute('aria-hidden')
-    this._element.setAttribute('aria-modal', 'true')
-    this._element.setAttribute('role', 'dialog')
-    this._element.scrollTop = 0
-
-    const modalBody = SelectorEngine.findOne(SELECTOR_MODAL_BODY, this._dialog)
-    if (modalBody) {
-      modalBody.scrollTop = 0
-    }
-
-    reflow(this._element)
-
-    this._element.classList.add(CLASS_NAME_SHOW)
-
-    const transitionComplete = () => {
-      if (this._config.focus) {
-        this._focustrap.activate()
-      }
-
-      this._isTransitioning = false
-      EventHandler.trigger(this._element, EVENT_SHOWN, {
-        relatedTarget,
-      })
-    }
-
-    this._queueCallback(transitionComplete, this._dialog!, this._isAnimated())
-  }
-
-  _addEventListeners(): void {
-    EventHandler.on(this._element, EVENT_KEYDOWN_DISMISS, (event: Event) => {
-      if ((event as KeyboardEvent).key !== ESCAPE_KEY) {
-        return
-      }
-
-      if (this._config.keyboard) {
-        this.hide()
-        return
-      }
-
-      this._triggerBackdropTransition()
-    })
-
-    EventHandler.on(window, EVENT_RESIZE, () => {
-      if (this._isShown && !this._isTransitioning) {
-        this._adjustDialog()
-      }
-    })
-
-    EventHandler.on(this._element, EVENT_MOUSEDOWN_DISMISS, (event: Event) => {
-      EventHandler.one(this._element, EVENT_CLICK_DISMISS, (event2: Event) => {
-        if (this._element !== event.target || this._element !== event2.target) {
-          return
-        }
-
-        if (this._config.backdrop === 'static') {
-          this._triggerBackdropTransition()
-          return
-        }
-
-        if (this._config.backdrop) {
-          this.hide()
-        }
-      })
-    })
-  }
-
-  _hideModal(): void {
-    this._element.style.display = 'none'
-    this._element.setAttribute('aria-hidden', 'true')
-    this._element.removeAttribute('aria-modal')
-    this._element.removeAttribute('role')
+  _closeAndCleanup(): void {
+    this._element.close()
     this._isTransitioning = false
 
-    this._backdrop.hide(() => {
-      document.body.classList.remove(CLASS_NAME_OPEN)
-      this._resetAdjustments()
-      this._scrollBar.reset()
-      EventHandler.trigger(this._element, EVENT_HIDDEN)
-    })
+    if (!SelectorEngine.findOne(OPEN_SELECTOR)) {
+      document.documentElement.classList.remove(CLASS_NAME_OPEN)
+    }
+
+    EventHandler.trigger(this._element, EVENT_HIDDEN)
   }
 
   _isAnimated(): boolean {
     return this._element.classList.contains(CLASS_NAME_FADE)
+  }
+
+  _addEventListeners(): void {
+    // The native `cancel` event fires on Escape for dialogs opened with
+    // showModal(). Intercept it so hide() can run the exit transition instead
+    // of letting the browser close the dialog (and drop its ::backdrop) instantly.
+    this._cancelHandler = (event: Event) => {
+      event.preventDefault()
+
+      if (!this._config.keyboard) {
+        this._triggerBackdropTransition()
+        return
+      }
+
+      this.hide()
+    }
+
+    EventHandler.on(this._element, 'cancel', this._cancelHandler)
+
+    EventHandler.on(this._element, EVENT_CLICK_DISMISS, (event: Event) => {
+      // A click anywhere inside .modal-dialog/.modal-content bubbles with that
+      // element as the target; only a click on ::backdrop targets the dialog itself.
+      if (event.target !== this._element) {
+        return
+      }
+
+      if (this._config.backdrop === 'static') {
+        this._triggerBackdropTransition()
+        return
+      }
+
+      if (this._config.backdrop) {
+        this.hide()
+      }
+    })
   }
 
   _triggerBackdropTransition(): void {
@@ -275,46 +222,10 @@ class Modal extends BaseComponent {
       return
     }
 
-    const isModalOverflowing = this._element.scrollHeight > document.documentElement.clientHeight
-    const initialOverflowY = this._element.style.overflowY
-    if (initialOverflowY === 'hidden' || this._element.classList.contains(CLASS_NAME_STATIC)) {
-      return
-    }
-
-    if (!isModalOverflowing) {
-      this._element.style.overflowY = 'hidden'
-    }
-
     this._element.classList.add(CLASS_NAME_STATIC)
     this._queueCallback(() => {
       this._element.classList.remove(CLASS_NAME_STATIC)
-      this._queueCallback(() => {
-        this._element.style.overflowY = initialOverflowY
-      }, this._dialog!)
-    }, this._dialog!)
-
-    this._element.focus()
-  }
-
-  _adjustDialog(): void {
-    const isModalOverflowing = this._element.scrollHeight > document.documentElement.clientHeight
-    const scrollbarWidth = this._scrollBar.getWidth()
-    const isBodyOverflowing = scrollbarWidth > 0
-
-    if (isBodyOverflowing && !isModalOverflowing) {
-      const property = isRTL() ? 'paddingLeft' : 'paddingRight'
-      this._element.style[property] = `${scrollbarWidth}px`
-    }
-
-    if (!isBodyOverflowing && isModalOverflowing) {
-      const property = isRTL() ? 'paddingRight' : 'paddingLeft'
-      this._element.style[property] = `${scrollbarWidth}px`
-    }
-  }
-
-  _resetAdjustments(): void {
-    this._element.style.paddingLeft = ''
-    this._element.style.paddingRight = ''
+    }, this._element)
   }
 }
 
@@ -336,7 +247,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
 
     EventHandler.one(target, EVENT_HIDDEN, () => {
       if (isVisible(this)) {
-        this.focus()
+        this.focus({ preventScroll: true })
       }
     })
   })

--- a/core/js/tests/unit/modal.spec.ts
+++ b/core/js/tests/unit/modal.spec.ts
@@ -12,15 +12,12 @@ describe('Modal', () => {
   afterEach(() => {
     clearFixture()
     vi.restoreAllMocks()
-    document.body.classList.remove('modal-open')
-    for (const el of document.querySelectorAll('.modal-backdrop')) {
-      el.remove()
-    }
+    document.documentElement.classList.remove('modal-open')
   })
 
   const createModalHTML = () =>
     [
-      '<div class="modal" tabindex="-1">',
+      '<dialog class="modal">',
       '  <div class="modal-dialog">',
       '    <div class="modal-content">',
       '      <div class="modal-header">',
@@ -30,8 +27,10 @@ describe('Modal', () => {
       '      <div class="modal-body"><p>Content</p></div>',
       '    </div>',
       '  </div>',
-      '</div>',
+      '</dialog>',
     ].join('')
+
+  const dispatchCancel = (element: Element) => element.dispatchEvent(new Event('cancel', { cancelable: true, bubbles: true }))
 
   describe('VERSION', () => {
     it('should return plugin version', () => {
@@ -43,7 +42,6 @@ describe('Modal', () => {
     it('should return plugin default config', () => {
       expect(Modal.Default).toBeDefined()
       expect(Modal.Default.backdrop).toBe(true)
-      expect(Modal.Default.focus).toBe(true)
       expect(Modal.Default.keyboard).toBe(true)
     })
   })
@@ -84,11 +82,11 @@ describe('Modal', () => {
     it('should show when hidden', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl)
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          expect(modal._isShown).toBe(true)
+          expect(modalEl.open).toBe(true)
           resolve()
         })
 
@@ -99,12 +97,12 @@ describe('Modal', () => {
     it('should hide when shown', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl)
 
         modalEl.addEventListener('shown.bs.modal', () => {
           modalEl.addEventListener('hidden.bs.modal', () => {
-            expect(modal._isShown).toBe(false)
+            expect(modalEl.open).toBe(false)
             resolve()
           })
 
@@ -120,15 +118,13 @@ describe('Modal', () => {
     it('should show modal', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl)
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          expect(modal._isShown).toBe(true)
+          expect(modalEl.open).toBe(true)
           expect(modalEl.classList.contains('show')).toBe(true)
-          expect(modalEl.getAttribute('aria-modal')).toBe('true')
-          expect(modalEl.getAttribute('role')).toBe('dialog')
-          expect(document.body.classList.contains('modal-open')).toBe(true)
+          expect(document.documentElement.classList.contains('modal-open')).toBe(true)
           resolve()
         })
 
@@ -139,13 +135,13 @@ describe('Modal', () => {
     it('should not show if already shown', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl)
 
         modalEl.addEventListener('shown.bs.modal', () => {
           modal.show()
           setTimeout(() => {
-            expect(modal._isShown).toBe(true)
+            expect(modalEl.open).toBe(true)
             resolve()
           }, 30)
         })
@@ -157,13 +153,13 @@ describe('Modal', () => {
     it('should not show if show event is prevented', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl)
 
         modalEl.addEventListener('show.bs.modal', (event) => {
           event.preventDefault()
           setTimeout(() => {
-            expect(modal._isShown).toBe(false)
+            expect(modalEl.open).toBe(false)
             resolve()
           }, 30)
         })
@@ -193,7 +189,7 @@ describe('Modal', () => {
     it('should hide modal', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl)
 
         modalEl.addEventListener('shown.bs.modal', () => {
@@ -201,9 +197,8 @@ describe('Modal', () => {
         })
 
         modalEl.addEventListener('hidden.bs.modal', () => {
-          expect(modal._isShown).toBe(false)
-          expect(modalEl.style.display).toBe('none')
-          expect(modalEl.getAttribute('aria-hidden')).toBe('true')
+          expect(modalEl.open).toBe(false)
+          expect(modalEl.classList.contains('show')).toBe(false)
           resolve()
         })
 
@@ -213,24 +208,24 @@ describe('Modal', () => {
 
     it('should not hide if not shown', () => {
       fixtureEl.innerHTML = createModalHTML()
-      const modalEl = fixtureEl.querySelector('.modal')!
+      const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
       const modal = new Modal(modalEl)
 
       modal.hide()
-      expect(modal._isShown).toBe(false)
+      expect(modalEl.open).toBe(false)
     })
 
     it('should not hide if hide event is prevented', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl)
 
         modalEl.addEventListener('shown.bs.modal', () => {
           modalEl.addEventListener('hide.bs.modal', (event) => {
             event.preventDefault()
             setTimeout(() => {
-              expect(modal._isShown).toBe(true)
+              expect(modalEl.open).toBe(true)
               resolve()
             }, 30)
           })
@@ -252,23 +247,38 @@ describe('Modal', () => {
       modal.dispose()
       expect(Modal.getInstance(modalEl)).toBeNull()
     })
+
+    it('should close the dialog and restore scroll when disposed while open', () => {
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = createModalHTML()
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
+        const modal = new Modal(modalEl)
+
+        modalEl.addEventListener('shown.bs.modal', () => {
+          modal.dispose()
+          expect(modalEl.open).toBe(false)
+          expect(document.documentElement.classList.contains('modal-open')).toBe(false)
+          resolve()
+        })
+
+        modal.show()
+      })
+    })
   })
 
   describe('handleUpdate', () => {
-    it('should call _adjustDialog', () => {
+    it('should not throw', () => {
       fixtureEl.innerHTML = createModalHTML()
       const modalEl = fixtureEl.querySelector('.modal')!
       const modal = new Modal(modalEl)
 
-      const spy = vi.spyOn(modal, '_adjustDialog')
-      modal.handleUpdate()
-      expect(spy).toHaveBeenCalled()
+      expect(() => modal.handleUpdate()).not.toThrow()
     })
   })
 
   describe('_isAnimated', () => {
     it('should return true when fade class is present', () => {
-      fixtureEl.innerHTML = '<div class="modal fade"><div class="modal-dialog"></div></div>'
+      fixtureEl.innerHTML = '<dialog class="modal fade"><div class="modal-dialog"></div></dialog>'
       const modalEl = fixtureEl.querySelector('.modal')!
       const modal = new Modal(modalEl)
 
@@ -285,36 +295,36 @@ describe('Modal', () => {
   })
 
   describe('keyboard', () => {
-    it('should close on Escape when keyboard is true', () => {
+    it('should close on native cancel (Escape) when keyboard is true', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl, { keyboard: true })
 
         modalEl.addEventListener('shown.bs.modal', () => {
           modalEl.addEventListener('hidden.bs.modal', () => {
-            expect(modal._isShown).toBe(false)
+            expect(modalEl.open).toBe(false)
             resolve()
           })
 
-          modalEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+          dispatchCancel(modalEl)
         })
 
         modal.show()
       })
     })
 
-    it('should not close on Escape when keyboard is false', () => {
+    it('should not close on cancel when keyboard is false', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl, { keyboard: false })
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          modalEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+          dispatchCancel(modalEl)
 
           setTimeout(() => {
-            expect(modal._isShown).toBe(true)
+            expect(modalEl.open).toBe(true)
             resolve()
           }, 30)
         })
@@ -323,19 +333,18 @@ describe('Modal', () => {
       })
     })
 
-    it('should ignore non-Escape keys', () => {
+    it('should always preventDefault on cancel so the browser never closes the dialog itself', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl)
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          modalEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+          const cancelEvent = new Event('cancel', { cancelable: true, bubbles: true })
+          modalEl.dispatchEvent(cancelEvent)
 
-          setTimeout(() => {
-            expect(modal._isShown).toBe(true)
-            resolve()
-          }, 30)
+          expect(cancelEvent.defaultPrevented).toBe(true)
+          resolve()
         })
 
         modal.show()
@@ -379,17 +388,19 @@ describe('Modal', () => {
     it('should add and remove modal-static class', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl, { keyboard: false })
 
         modalEl.addEventListener('shown.bs.modal', () => {
           modalEl.addEventListener('hidePrevented.bs.modal', () => {
             setTimeout(() => {
+              expect(modalEl.classList.contains('modal-static')).toBe(false)
               resolve()
             }, 30)
           })
 
-          modalEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+          dispatchCancel(modalEl)
+          expect(modalEl.classList.contains('modal-static')).toBe(true)
         })
 
         modal.show()
@@ -399,65 +410,20 @@ describe('Modal', () => {
     it('should not transition if hidePrevented is prevented', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl, { keyboard: false })
 
         modalEl.addEventListener('shown.bs.modal', () => {
           modalEl.addEventListener('hidePrevented.bs.modal', (event) => {
             event.preventDefault()
             setTimeout(() => {
-              expect(modal._isShown).toBe(true)
+              expect(modalEl.open).toBe(true)
+              expect(modalEl.classList.contains('modal-static')).toBe(false)
               resolve()
             }, 30)
           })
 
-          modalEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
-        })
-
-        modal.show()
-      })
-    })
-
-    it('should early return if overflowY is hidden', () => {
-      return new Promise<void>((resolve) => {
-        fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
-        const modal = new Modal(modalEl, { keyboard: false })
-
-        modalEl.addEventListener('shown.bs.modal', () => {
-          modalEl.style.overflowY = 'hidden'
-
-          modalEl.addEventListener('hidePrevented.bs.modal', () => {
-            setTimeout(() => {
-              expect(modal._isShown).toBe(true)
-              resolve()
-            }, 30)
-          })
-
-          modalEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
-        })
-
-        modal.show()
-      })
-    })
-
-    it('should early return if already has modal-static class', () => {
-      return new Promise<void>((resolve) => {
-        fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
-        const modal = new Modal(modalEl, { keyboard: false })
-
-        modalEl.addEventListener('shown.bs.modal', () => {
-          modalEl.classList.add('modal-static')
-
-          modalEl.addEventListener('hidePrevented.bs.modal', () => {
-            setTimeout(() => {
-              expect(modal._isShown).toBe(true)
-              resolve()
-            }, 30)
-          })
-
-          modalEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+          dispatchCancel(modalEl)
         })
 
         modal.show()
@@ -466,19 +432,18 @@ describe('Modal', () => {
   })
 
   describe('backdrop click', () => {
-    it('should hide when clicking outside dialog with backdrop true', () => {
+    it('should hide when the click targets the dialog itself (::backdrop click)', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl, { backdrop: true })
 
         modalEl.addEventListener('shown.bs.modal', () => {
           modalEl.addEventListener('hidden.bs.modal', () => {
-            expect(modal._isShown).toBe(false)
+            expect(modalEl.open).toBe(false)
             resolve()
           })
 
-          modalEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
           modalEl.dispatchEvent(new MouseEvent('click', { bubbles: true }))
         })
 
@@ -486,22 +451,18 @@ describe('Modal', () => {
       })
     })
 
-    it('should not hide when click starts inside dialog', () => {
+    it('should not hide when the click targets content inside the dialog', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
-        const dialog = modalEl.querySelector('.modal-dialog')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
+        const content = modalEl.querySelector('.modal-content')!
         const modal = new Modal(modalEl)
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          const mousedownEvent = new MouseEvent('mousedown', { bubbles: true })
-          Object.defineProperty(mousedownEvent, 'target', { value: dialog })
-          modalEl.dispatchEvent(mousedownEvent)
-
-          modalEl.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+          content.dispatchEvent(new MouseEvent('click', { bubbles: true }))
 
           setTimeout(() => {
-            expect(modal._isShown).toBe(true)
+            expect(modalEl.open).toBe(true)
             resolve()
           }, 50)
         })
@@ -513,17 +474,35 @@ describe('Modal', () => {
     it('should trigger backdrop transition with static backdrop', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const modal = new Modal(modalEl, { backdrop: 'static' })
 
         modalEl.addEventListener('shown.bs.modal', () => {
           modalEl.addEventListener('hidePrevented.bs.modal', () => {
-            expect(modal._isShown).toBe(true)
+            expect(modalEl.open).toBe(true)
             resolve()
           })
 
-          modalEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
           modalEl.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        })
+
+        modal.show()
+      })
+    })
+
+    it('should not hide when backdrop is false', () => {
+      return new Promise<void>((resolve) => {
+        fixtureEl.innerHTML = createModalHTML()
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
+        const modal = new Modal(modalEl, { backdrop: false })
+
+        modalEl.addEventListener('shown.bs.modal', () => {
+          modalEl.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+          setTimeout(() => {
+            expect(modalEl.open).toBe(true)
+            resolve()
+          }, 30)
         })
 
         modal.show()
@@ -531,11 +510,10 @@ describe('Modal', () => {
     })
   })
 
-  describe('_showElement', () => {
+  describe('show behavior', () => {
     it('should append to body if not already in DOM', () => {
-      const modalEl = document.createElement('div')
+      const modalEl = document.createElement('dialog')
       modalEl.classList.add('modal')
-      modalEl.setAttribute('tabindex', '-1')
       modalEl.innerHTML = '<div class="modal-dialog"><div class="modal-content"></div></div>'
 
       const modal = new Modal(modalEl)
@@ -552,14 +530,16 @@ describe('Modal', () => {
       })
     })
 
-    it('should scroll modal body to top', () => {
+    it('should scroll the modal and its body to top', () => {
       return new Promise<void>((resolve) => {
         fixtureEl.innerHTML = createModalHTML()
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
+        const body = modalEl.querySelector('.modal-body') as HTMLElement
         const modal = new Modal(modalEl)
 
         modalEl.addEventListener('shown.bs.modal', () => {
           expect(modalEl.scrollTop).toBe(0)
+          expect(body.scrollTop).toBe(0)
           resolve()
         })
 
@@ -571,14 +551,13 @@ describe('Modal', () => {
   describe('data-tblr-toggle', () => {
     it('should open modal via data-tblr-toggle="modal"', () => {
       return new Promise<void>((resolve) => {
-        fixtureEl.innerHTML = ['<button data-tblr-toggle="modal" data-bs-target="#testModal">Open</button>', '<div class="modal" id="testModal" tabindex="-1">', '  <div class="modal-dialog"><div class="modal-content"></div></div>', '</div>'].join('')
+        fixtureEl.innerHTML = ['<button data-tblr-toggle="modal" data-bs-target="#testModal">Open</button>', '<dialog class="modal" id="testModal">', '  <div class="modal-dialog"><div class="modal-content"></div></div>', '</dialog>'].join('')
 
-        const modalEl = fixtureEl.querySelector('#testModal')!
+        const modalEl = fixtureEl.querySelector('#testModal')! as HTMLDialogElement
         const btn = fixtureEl.querySelector('[data-tblr-toggle="modal"]') as HTMLElement
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          const modal = Modal.getInstance(modalEl) as Modal
-          expect(modal._isShown).toBe(true)
+          expect(modalEl.open).toBe(true)
           resolve()
         })
 
@@ -588,14 +567,13 @@ describe('Modal', () => {
 
     it('should open modal via data-tblr-toggle with data-tblr-target', () => {
       return new Promise<void>((resolve) => {
-        fixtureEl.innerHTML = ['<button data-tblr-toggle="modal" data-tblr-target="#testModal">Open</button>', '<div class="modal" id="testModal" tabindex="-1">', '  <div class="modal-dialog"><div class="modal-content"></div></div>', '</div>'].join('')
+        fixtureEl.innerHTML = ['<button data-tblr-toggle="modal" data-tblr-target="#testModal">Open</button>', '<dialog class="modal" id="testModal">', '  <div class="modal-dialog"><div class="modal-content"></div></div>', '</dialog>'].join('')
 
-        const modalEl = fixtureEl.querySelector('#testModal')!
+        const modalEl = fixtureEl.querySelector('#testModal')! as HTMLDialogElement
         const btn = fixtureEl.querySelector('[data-tblr-toggle="modal"]') as HTMLElement
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          const modal = Modal.getInstance(modalEl) as Modal
-          expect(modal._isShown).toBe(true)
+          expect(modalEl.open).toBe(true)
           resolve()
         })
 
@@ -607,9 +585,9 @@ describe('Modal', () => {
   describe('data-tblr-dismiss', () => {
     it('should close modal via data-tblr-dismiss="modal"', () => {
       return new Promise<void>((resolve) => {
-        fixtureEl.innerHTML = ['<div class="modal" tabindex="-1">', '  <div class="modal-dialog">', '    <div class="modal-content">', '      <button type="button" class="btn-close" data-tblr-dismiss="modal"></button>', '    </div>', '  </div>', '</div>'].join('')
+        fixtureEl.innerHTML = ['<dialog class="modal">', '  <div class="modal-dialog">', '    <div class="modal-content">', '      <button type="button" class="btn-close" data-tblr-dismiss="modal"></button>', '    </div>', '  </div>', '</dialog>'].join('')
 
-        const modalEl = fixtureEl.querySelector('.modal')!
+        const modalEl = fixtureEl.querySelector('.modal')! as HTMLDialogElement
         const dismissBtn = fixtureEl.querySelector('[data-tblr-dismiss="modal"]') as HTMLElement
         const modal = new Modal(modalEl)
 
@@ -618,7 +596,7 @@ describe('Modal', () => {
         })
 
         modalEl.addEventListener('hidden.bs.modal', () => {
-          expect(modal._isShown).toBe(false)
+          expect(modalEl.open).toBe(false)
           resolve()
         })
 

--- a/core/js/tests/visual/modal.html
+++ b/core/js/tests/visual/modal.html
@@ -38,7 +38,7 @@
     <div class="container mt-3">
       <h1>Modal <small>Bootstrap Visual Test</small></h1>
 
-      <div class="modal fade" id="myModal" tabindex="-1" aria-labelledby="myModalLabel" aria-hidden="true">
+      <dialog class="modal fade" id="myModal" aria-labelledby="myModalLabel">
         <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">
@@ -121,9 +121,9 @@
             </div>
           </div>
         </div>
-      </div>
+      </dialog>
 
-      <div class="modal fade" id="firefoxModal" tabindex="-1" aria-labelledby="firefoxModalLabel" aria-hidden="true">
+      <dialog class="modal fade" id="firefoxModal" aria-labelledby="firefoxModalLabel">
         <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">
@@ -145,10 +145,10 @@
             </div>
           </div>
         </div>
-      </div>
+      </dialog>
 
-      <div class="modal fade" id="slowModal" tabindex="-1" aria-labelledby="slowModalLabel" aria-hidden="true" style="transition-duration: 5s;">
-        <div class="modal-dialog" style="transition-duration: inherit;">
+      <dialog class="modal fade" id="slowModal" aria-labelledby="slowModalLabel" style="transition-duration: 5s;">
+        <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">
               <h1 class="modal-title fs-4" id="slowModalLabel">Lorem slowly</h1>
@@ -163,7 +163,7 @@
             </div>
           </div>
         </div>
-      </div>
+      </dialog>
 
       <button type="button" class="btn btn-primary btn-lg" data-bs-toggle="modal" data-bs-target="#myModal">
         Launch demo modal
@@ -192,7 +192,7 @@
         Tall body content to force the page to have a scrollbar.
       </div>
 
-      <button type="button" class="btn btn-secondary btn-lg" data-bs-toggle="modal" data-bs-target="&#x3C;div class=&#x22;modal fade the-bad&#x22; tabindex=&#x22;-1&#x22;&#x3E;&#x3C;div class=&#x22;modal-dialog&#x22;&#x3E;&#x3C;div class=&#x22;modal-content&#x22;&#x3E;&#x3C;div class=&#x22;modal-header&#x22;&#x3E;&#x3C;button type=&#x22;button&#x22; class=&#x22;btn-close&#x22; data-bs-dismiss=&#x22;modal&#x22; aria-label=&#x22;Close&#x22;&#x3E;&#x3C;span aria-hidden=&#x22;true&#x22;&#x3E;&#x26;times;&#x3C;/span&#x3E;&#x3C;/button&#x3E;&#x3C;h1 class=&#x22;modal-title fs-4&#x22;&#x3E;The Bad Modal&#x3C;/h1&#x3E;&#x3C;/div&#x3E;&#x3C;div class=&#x22;modal-body&#x22;&#x3E;This modal&#x27;s HTTML source code is declared inline, inside the data-bs-target attribute of it&#x27;s show-button&#x3C;/div&#x3E;&#x3C;/div&#x3E;&#x3C;/div&#x3E;&#x3C;/div&#x3E;">
+      <button type="button" class="btn btn-secondary btn-lg" data-bs-toggle="modal" data-bs-target="&#x3C;dialog class=&#x22;modal fade the-bad&#x22;&#x3E;&#x3C;div class=&#x22;modal-dialog&#x22;&#x3E;&#x3C;div class=&#x22;modal-content&#x22;&#x3E;&#x3C;div class=&#x22;modal-header&#x22;&#x3E;&#x3C;button type=&#x22;button&#x22; class=&#x22;btn-close&#x22; data-bs-dismiss=&#x22;modal&#x22; aria-label=&#x22;Close&#x22;&#x3E;&#x3C;span aria-hidden=&#x22;true&#x22;&#x3E;&#x26;times;&#x3C;/span&#x3E;&#x3C;/button&#x3E;&#x3C;h1 class=&#x22;modal-title fs-4&#x22;&#x3E;The Bad Modal&#x3C;/h1&#x3E;&#x3C;/div&#x3E;&#x3C;div class=&#x22;modal-body&#x22;&#x3E;This modal&#x27;s HTTML source code is declared inline, inside the data-bs-target attribute of it&#x27;s show-button&#x3C;/div&#x3E;&#x3C;/div&#x3E;&#x3C;/div&#x3E;&#x3C;/dialog&#x3E;">
         Modal with an XSS inside the data-bs-target
       </button>
 

--- a/core/scss/bootstrap/_modal.scss
+++ b/core/scss/bootstrap/_modal.scss
@@ -2,13 +2,16 @@
 
 @use 'sass:map';
 
-// .modal-open      - body class for killing the scroll
-// .modal           - container to scroll within
+// .modal-open      - root class for killing the scroll
+// .modal           - the native <dialog> element: container to scroll within, top layer, ::backdrop
 // .modal-dialog    - positioning shell for the actual modal
 // .modal-content   - actual modal w/ bg and corners and stuff
 
-// Container that the modal scrolls within
 @use '../config' as *;
+
+:root.modal-open {
+  overflow: hidden;
+}
 
 .modal {
   // scss-docs-start modal-css-vars
@@ -33,23 +36,67 @@
   --modal-footer-bg: #{$modal-footer-bg};
   --modal-footer-border-color: #{$modal-footer-border-color};
   --modal-footer-border-width: #{$modal-footer-border-width};
+  --modal-backdrop-zindex: #{$zindex-modal-backdrop};
+  --modal-backdrop-bg: #{$modal-backdrop-bg};
+  --modal-backdrop-opacity: #{$modal-backdrop-opacity};
+  --modal-backdrop-blur: #{$modal-backdrop-blur};
   // scss-docs-end modal-css-vars
 
   position: fixed;
   inset-inline-start: 0;
   top: 0;
   z-index: var(--modal-zindex);
-  display: none;
   width: 100%;
   height: 100%;
+  padding: 0;
+  margin: 0;
   overflow-x: hidden;
   overflow-y: auto;
+  color: inherit;
+  background-color: transparent;
+  border: 0;
+  // `display` can't be transitioned, so override the UA's [open]-toggled
+  // display: none/block and use `visibility` for the hidden state instead.
+  display: block;
+  visibility: hidden;
   // Prevent Chrome on Windows from adding a focus outline. For details, see
   // https://github.com/twbs/bootstrap/pull/10951.
   outline: 0;
   // We deliberately don't use `-webkit-overflow-scrolling: touch;` due to a
   // gnarly iOS Safari bug: https://bugs.webkit.org/show_bug.cgi?id=158342
   // See also https://github.com/twbs/bootstrap/issues/17695
+
+  &[open] {
+    visibility: visible;
+  }
+
+  &::backdrop {
+    z-index: var(--modal-backdrop-zindex);
+    background-color: var(--modal-backdrop-bg);
+    opacity: 0;
+  }
+
+  &.fade::backdrop {
+    @include transition($transition-fade);
+  }
+
+  &.show::backdrop {
+    opacity: var(--modal-backdrop-opacity);
+  }
+
+  @starting-style {
+    &.show::backdrop {
+      opacity: 0;
+    }
+  }
+
+  @include media-print() {
+    display: none !important;
+  }
+}
+
+.modal-blur::backdrop {
+  backdrop-filter: blur(var(--modal-backdrop-blur));
 }
 
 // Shell div to position the modal with bottom padding
@@ -110,17 +157,6 @@
   @include box-shadow(var(--modal-box-shadow));
   // Remove focus outline from opened modal
   outline: 0;
-}
-
-// Modal background
-.modal-backdrop {
-  // scss-docs-start modal-backdrop-css-vars
-  --backdrop-zindex: #{$zindex-modal-backdrop};
-  --backdrop-bg: #{$modal-backdrop-bg};
-  --backdrop-opacity: #{$modal-backdrop-opacity};
-  // scss-docs-end modal-backdrop-css-vars
-
-  @include overlay-backdrop(var(--backdrop-zindex), var(--backdrop-bg), var(--backdrop-opacity));
 }
 
 // Modal header

--- a/core/scss/layout/_root.scss
+++ b/core/scss/layout/_root.scss
@@ -4,6 +4,8 @@
 :host {
   // No fixed root font-size: rem sizing must track the user's browser preference (WCAG 1.4.4)
   height: 100%;
+  // Pairs with .modal-open's overflow: hidden — see bootstrap/_modal.scss
+  scrollbar-gutter: stable;
 }
 
 :root,

--- a/core/scss/ui/_modals.scss
+++ b/core/scss/ui/_modals.scss
@@ -61,10 +61,6 @@
   padding-bottom: var(--modal-footer-padding-y);
 }
 
-.modal-blur {
-  backdrop-filter: blur($modal-backdrop-blur);
-}
-
 .modal-full-width {
   max-width: none;
   margin: 0 $modal-dialog-margin;

--- a/docs/content/ui/components/modal.mdx
+++ b/docs/content/ui/components/modal.mdx
@@ -47,31 +47,31 @@ import Example from '@components/Example.astro';
 import Icon from '@ui/Icon.astro';
 import CodeDocs from '@components/CodeDocs.astro';
 
-Modals are built with HTML, CSS, and JavaScript. They're positioned over everything else in the document and remove scroll from the `<body>` so that modal content scrolls instead.
+Modals are built on the native `<dialog>` element. The browser positions them over everything else in the document, and opening one locks page scroll so modal content scrolls instead.
 
 ## Default markup
 
-To create a modal, you need to add a `.modal` element to the document. Inside the `.modal`, you need to add a `.modal-dialog` element, which contains a `.modal-content` element. The `.modal-content` element contains the modal's header, body, and footer.
+To create a modal, add a `.modal` class to a native `<dialog>` element. Inside it, add a `.modal-dialog` element, which contains a `.modal-content` element. The `.modal-content` element contains the modal's header, body, and footer. Bootstrap opens the dialog with the browser's own `showModal()`, so the backdrop, focus trap and Escape key all come from the browser, not from JavaScript.
 
 ```html
-<div class="modal" tabindex="-1">
-  <div class="modal-dialog" role="document">
+<dialog class="modal">
+  <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">...</div>
       <div class="modal-body">...</div>
       <div class="modal-footer">...</div>
     </div>
   </div>
-</div>
+</dialog>
 ```
 
 <Example centered>
 <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">Launch demo modal</button>
-<div class="modal" id="exampleModal" tabindex="-1">
-  <div class="modal-dialog" role="document">
+<dialog class="modal" id="exampleModal" aria-labelledby="exampleModalTitle">
+  <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Modal title</h5>
+        <h5 class="modal-title" id="exampleModalTitle">Modal title</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body"> Lorem ipsum dolor sit amet, consectetur adipisicing elit. Adipisci animi beatae delectus deleniti dolorem eveniet facere fuga iste nemo nesciunt nihil odio perspiciatis, quia quis reprehenderit sit tempora totam unde. </div>
@@ -81,16 +81,17 @@ To create a modal, you need to add a `.modal` element to the document. Inside th
       </div>
     </div>
   </div>
-</div>
+</dialog>
 </Example>
 
 ## Prompt and alert
 
 A modal also works as a prompt or an alert: a short message with one or two buttons.
 
-<Example raw>
-<div class="modal" id="exampleModal2" tabindex="-1">
-  <div class="modal-dialog modal-sm" role="document">
+<Example centered>
+<button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#exampleModal2">Launch delete prompt</button>
+<dialog class="modal" id="exampleModal2" aria-labelledby="exampleModal2Title">
+  <div class="modal-dialog modal-sm">
     <div class="modal-content">
       <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       <div class="modal-status bg-danger"></div>
@@ -100,7 +101,7 @@ A modal also works as a prompt or an alert: a short message with one or two butt
           <path d="M12 9v2m0 4v.01" />
           <path d="M5 19h14a2 2 0 0 0 1.84 -2.75l-7.1 -12.25a2 2 0 0 0 -3.5 0l-7.1 12.25a2 2 0 0 0 1.75 2.75" />
         </svg>
-        <h3>Are you sure?</h3>
+        <h3 id="exampleModal2Title">Are you sure?</h3>
         <div class="text-secondary">Do you really want to remove 84 files? What you've done cannot be undone.</div>
       </div>
       <div class="modal-footer">
@@ -117,18 +118,19 @@ A modal also works as a prompt or an alert: a short message with one or two butt
       </div>
     </div>
   </div>
-</div>
+</dialog>
 </Example>
 
-<Example raw>
-<div class="modal" id="exampleModal3" tabindex="-1">
-  <div class="modal-dialog modal-sm" role="document">
+<Example centered>
+<button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#exampleModal3">Launch success prompt</button>
+<dialog class="modal" id="exampleModal3" aria-labelledby="exampleModal3Title">
+  <div class="modal-dialog modal-sm">
     <div class="modal-content">
       <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       <div class="modal-status bg-success"></div>
       <div class="modal-body text-center py-4">
         <Icon name="circle-check" class="mb-2 text-green icon-lg" />
-        <h3>Payment succeeded</h3>
+        <h3 id="exampleModal3Title">Payment succeeded</h3>
         <div class="text-secondary">Your payment of $290 has been successfully submitted. Your invoice has been sent to support@tabler.io.</div>
       </div>
       <div class="modal-footer">
@@ -145,19 +147,20 @@ A modal also works as a prompt or an alert: a short message with one or two butt
       </div>
     </div>
   </div>
-</div>
+</dialog>
 </Example>
 
 ## Modal with form
 
 A form inside a modal keeps the user on the page. Put the fields in the body and the submit button in the footer.
 
-<Example raw class="px-5">
-<div class="modal" id="exampleModal4" tabindex="-1">
-  <div class="modal-dialog modal-lg" role="document">
+<Example centered>
+<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal4">Launch report modal</button>
+<dialog class="modal" id="exampleModal4" aria-labelledby="exampleModal4Title">
+  <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">New report</h5>
+        <h5 class="modal-title" id="exampleModal4Title">New report</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
@@ -242,7 +245,7 @@ A form inside a modal keeps the user on the page. Put the fields in the body and
       </div>
     </div>
   </div>
-</div>
+</dialog>
 </Example>
 
 ## Blurred backdrop
@@ -250,15 +253,9 @@ A form inside a modal keeps the user on the page. Put the fields in the body and
 Add `modal-blur` next to `modal` to blur the page behind the dialog instead of only dimming it.
 
 ```html
-<div
-  class="modal modal-blur fade"
-  id="modal-blurred"
-  tabindex="-1"
-  role="dialog"
-  aria-hidden="true"
->
+<dialog class="modal modal-blur fade" id="modal-blurred">
   <!-- modal-dialog -->
-</div>
+</dialog>
 ```
 
 ## Full width modal
@@ -268,23 +265,31 @@ Add `modal-full-width` to the `modal-dialog` to let the dialog use the whole vie
 The Bootstrap size classes cover the smaller steps: `modal-sm`, `modal-lg` and `modal-xl`.
 
 ```html
-<div class="modal-dialog modal-full-width modal-dialog-centered" role="document">
-  <div class="modal-content">
-    <div class="modal-header">
-      <h5 class="modal-title">Full width modal</h5>
-      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+<dialog class="modal">
+  <div class="modal-dialog modal-full-width modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Full width modal</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">Content</div>
     </div>
-    <div class="modal-body">Content</div>
   </div>
-</div>
+</dialog>
 ```
+
+## Upgrading from a `<div>` modal
+
+- The root element must be a `<dialog>`, not a `<div>` — `showModal()` throws on anything else. Everything below it (`.modal-dialog`, `.modal-content`, …) is unchanged.
+- `.modal-backdrop` no longer exists as an element. The dimmed/blurred layer is now the dialog's native `::backdrop`, styled through `.modal`'s own `--modal-backdrop-*` custom properties. Custom CSS targeting `.modal-backdrop` needs to target `.modal::backdrop` instead.
+- `data-bs-backdrop="false"` still skips closing the modal on an outside click, but it can no longer keep the backdrop from showing or leave the rest of the page interactive — a `showModal()` dialog is always in the browser's inert top layer.
 
 ## Accessibility
 
-- Set `tabindex="-1"` on the modal and point `aria-labelledby` at the title. Bootstrap then moves focus into the dialog, traps it while the dialog is open, and returns it to the trigger on close.
+- Point `aria-labelledby` at the title. The browser opens the dialog with `showModal()`, which moves focus into it, traps focus while it's open, and returns focus to the trigger on close — no `tabindex="-1"`, `role="dialog"` or manual focus handling needed.
 - Give every modal a visible title. A dialog with no accessible name is announced as just "dialog".
 - Keep the close button labelled. `btn-close` has no text of its own, so it needs `aria-label="Close"`.
-- Do not open a modal from inside another modal. Bootstrap supports one dialog at a time and the focus trap follows the last one opened.
+- Do not open a modal from inside another modal. Bootstrap closes the previously open dialog when a `data-bs-toggle="modal"` trigger opens a new one, but the browser itself allows several `<dialog>` elements to be modal at once, and the focus trap only follows the last one opened.
 - A modal that must not be dismissed by accident takes `data-bs-backdrop="static"`, but never remove the close control entirely - <kbd>Escape</kbd> is the only way out for many keyboard users.
 
 ## SCSS variables

--- a/docs/content/ui/plugins/advanced-select.mdx
+++ b/docs/content/ui/plugins/advanced-select.mdx
@@ -181,7 +181,7 @@ These are the options you will need most often. Tom Select has more, and they ar
 | Option | What it does |
 | --- | --- |
 | `copyClassesToDropdown` | Copies the `<select>` classes onto the dropdown. Tabler keeps this `false` and styles the dropdown itself. |
-| `dropdownParent` | Where the dropdown is appended in the DOM, for example `'body'` so it is not clipped by a card or modal. |
+| `dropdownParent` | Where the dropdown is appended in the DOM, for example `'body'` so it is not clipped by a card. Do not use it inside a modal: the modal is a native `<dialog>` in the top layer, and anything appended to `<body>` renders underneath it. Leave the option out there, so the dropdown stays next to the select. |
 | `maxItems` | Maximum number of selected items on a multi-value select. |
 | `create` | `true` lets users type a value that is not in the option list. |
 | `plugins` | List of Tom Select plugins to enable, for example `remove_button`. |

--- a/docs/content/ui/plugins/date-picker.mdx
+++ b/docs/content/ui/plugins/date-picker.mdx
@@ -124,6 +124,7 @@ These are the options you will need most often. Litepicker has more, and they ar
 | `lockDays` | List of dates users cannot pick. |
 | `numberOfColumns` / `numberOfMonths` | Shows more than one month at a time. |
 | `buttonText` | HTML for the previous/next month and other buttons. |
+| `parentEl` | The element the calendar popover is appended to. Litepicker appends to `<body>` by default, which renders underneath a modal (a native `<dialog>` in the top layer). Inside a modal pass the modal element here and reposition the calendar relative to it on the `show` event, as Tabler's `Datepicker` component does. |
 
 ## Accessibility
 

--- a/preview/pages/all-elements.astro
+++ b/preview/pages/all-elements.astro
@@ -623,11 +623,11 @@ function greetUser(name) {
           </ButtonList>
 
           <!-- Demo Modal -->
-          <div class="modal modal-blur fade" id="modal-demo" tabindex="-1" role="dialog" aria-hidden="true">
-            <div class="modal-dialog modal-dialog-centered" role="document">
+          <dialog class="modal modal-blur fade" id="modal-demo" aria-labelledby="modal-demo-title">
+            <div class="modal-dialog modal-dialog-centered">
               <div class="modal-content">
                 <div class="modal-header">
-                  <h5 class="modal-title">Modal title</h5>
+                  <h5 class="modal-title" id="modal-demo-title">Modal title</h5>
                   <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
@@ -639,15 +639,15 @@ function greetUser(name) {
                 </div>
               </div>
             </div>
-          </div>
+          </dialog>
 
           <!-- Success Modal -->
-          <div class="modal modal-blur fade" id="modal-success" tabindex="-1" role="dialog" aria-hidden="true">
-            <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+          <dialog class="modal modal-blur fade" id="modal-success" aria-labelledby="modal-success-title">
+            <div class="modal-dialog modal-sm modal-dialog-centered">
               <div class="modal-content">
                 <div class="modal-body text-center py-4">
                   <Icon name="circle-check" color="success" size="lg" class="mb-2" />
-                  <h3>Success!</h3>
+                  <h3 id="modal-success-title">Success!</h3>
                   <div class="text-secondary">Your action was completed successfully.</div>
                 </div>
                 <div class="modal-footer">
@@ -664,7 +664,7 @@ function greetUser(name) {
                 </div>
               </div>
             </div>
-          </div>
+          </dialog>
         </CardBody>
       </Card>
     </div>

--- a/preview/pages/emails.astro
+++ b/preview/pages/emails.astro
@@ -49,7 +49,7 @@ const emailEntries = Object.entries(emails)
     </div>
   </div>
 
-  <div class="modal fade" id="email-modal" aria-hidden="true" aria-labelledby="email-modal-label" tabindex="-1">
+  <dialog class="modal fade" id="email-modal" aria-labelledby="email-modal-label">
     <div class="modal-dialog modal-xl modal-dialog-centered">
       <div class="modal-content">
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -76,7 +76,7 @@ const emailEntries = Object.entries(emails)
         </div>
       </div>
     </div>
-  </div>
+  </dialog>
   <CaptureScript>
     <!-- BEGIN EMAIL MODAL SCRIPT -->
     <script is:inline>

--- a/preview/pages/signatures.astro
+++ b/preview/pages/signatures.astro
@@ -127,7 +127,7 @@ document.querySelector("#signature-advanced-png").addEventListener("click", func
   </div>
 
   <CaptureModal>
-    <div class="modal" tabindex="-1" id="modal-signature" role="dialog" aria-modal="true" aria-labelledby="modal-signature-save-title">
+    <dialog class="modal" id="modal-signature" aria-labelledby="modal-signature-save-title">
       <div class="modal-dialog">
         <div class="modal-content">
           <div class="modal-body">
@@ -142,6 +142,6 @@ document.querySelector("#signature-advanced-png").addEventListener("click", func
           </div>
         </div>
       </div>
-    </div>
+    </dialog>
   </CaptureModal>
 </DefaultLayout>

--- a/shared/components/modals/Modal.astro
+++ b/shared/components/modals/Modal.astro
@@ -17,11 +17,11 @@ const dialogClass = ['modal-dialog', size && `modal-${size}`, !top && 'modal-dia
 ---
 
 <!-- BEGIN MODAL -->
-<div class={modalClass} id={`modal-${modalId}`} tabindex="-1" role="dialog" aria-modal="true" aria-labelledby={titleId} aria-hidden="true">
+<dialog class={modalClass} id={`modal-${modalId}`} aria-labelledby={titleId}>
   <div class={dialogClass}>
     <div class="modal-content">
       <slot />
     </div>
   </div>
-</div>
+</dialog>
 <!-- END MODAL -->

--- a/shared/components/modals/ModalInline.astro
+++ b/shared/components/modals/ModalInline.astro
@@ -19,11 +19,11 @@ const dialogClass = ['modal-dialog', size && `modal-${size}`, 'modal-dialog-cent
 ---
 
 <!-- BEGIN MODAL -->
-<div class={modalClass} style={style} id={`modal-${modalId}`} tabindex="-1" role="dialog" aria-modal="true" aria-labelledby={titleId} aria-hidden={show ? undefined : 'true'}>
+<dialog class={modalClass} style={style} id={`modal-${modalId}`} aria-labelledby={titleId} open={show || undefined}>
   <div class={dialogClass}>
     <div class="modal-content">
       <slot />
     </div>
   </div>
-</div>
+</dialog>
 <!-- END MODAL -->

--- a/shared/ui/Datepicker.astro
+++ b/shared/ui/Datepicker.astro
@@ -71,14 +71,31 @@ const datepickerId = id ? `datepicker-${id}` : undefined;
 
 					if (!window.Litepicker) return;
 
+					const element = document.getElementById(datepickerId);
+
+					// A modal is a native <dialog> in the top layer: a calendar appended to <body>
+					// renders underneath it, so inside a modal the calendar is appended to the modal
+					// and positioned relative to it (Litepicker only knows document coordinates).
+					const modal = element.closest('.modal');
+
 					const picker = new Litepicker({
-						element: document.getElementById(datepickerId),
+						element,
 						buttonText: {
 							previousMonth: chevronLeft,
 							nextMonth: chevronRight,
 						},
 						...(inline ? { inlineMode: true } : {}),
+						...(modal && !inline ? { parentEl: modal } : {}),
 					});
+
+					if (modal && !inline) {
+						picker.on('show', () => {
+							const input = picker.triggerElement.getBoundingClientRect();
+							const parent = modal.getBoundingClientRect();
+							picker.ui.style.top = `${input.bottom - parent.top + modal.scrollTop}px`;
+							picker.ui.style.left = `${input.left - parent.left + modal.scrollLeft}px`;
+						});
+					}
 
 					// Litepicker sets buttonText as the buttons' innerHTML, and the icon SVGs are
 					// aria-hidden, so the generated month-nav buttons otherwise have no accessible

--- a/shared/ui/Select.astro
+++ b/shared/ui/Select.astro
@@ -72,10 +72,16 @@ const selectId = `select-${id}`;
 				return `<div>${escape(data.text)}</div>`;
 			};
 
+			const select = document.getElementById(selectId);
+
+			// A modal is a native <dialog> in the top layer: anything appended to <body>
+			// renders underneath it, so inside a modal the dropdown stays in its wrapper.
+			const inModal = Boolean(select.closest('.modal'));
+
 			window.TomSelect &&
-				(window.tabler_select[selectId] = new TomSelect(document.getElementById(selectId), {
+				(window.tabler_select[selectId] = new TomSelect(select, {
 					copyClassesToDropdown: false,
-					dropdownParent: 'body',
+					...(inModal ? {} : { dropdownParent: 'body' }),
 					render: {
 						item: renderOption,
 						option: renderOption,


### PR DESCRIPTION
## Summary

- `Modal` now opens with the browser's own `showModal()`/`close()` instead of a `<div>` toggled by JS. The dimmed/blurred layer is the native `::backdrop`, and focus trapping plus Escape-to-close come from the browser instead of `util/focustrap.ts` and manual key handling.
- Scroll lock moved from a JS-measured `body` padding hack to `:root.modal-open { overflow: hidden }` paired with `scrollbar-gutter: stable`, so the page no longer shifts when a modal opens.
- Every v5 class (`.modal`, `.modal-dialog`, `.modal-content`, `.modal-sm/lg/xl/fullscreen`, `.modal-dialog-centered/-scrollable`, `.modal-full-width`, `.modal-blur`, `.modal-static`), data attribute (`data-bs-toggle="modal"`, `data-bs-dismiss="modal"`, the `data-tblr-*` aliases) and JS method (`show`/`hide`/`toggle`/`dispose`/`handleUpdate`, `getInstance`/`getOrCreateInstance`) stays the same — only the root element changes from `<div class="modal">` to `<dialog class="modal">`.
- Fixed three bugs found in review after the rebuild: the browser's own `dialog:modal` style shrank every modal by ~34px in each direction because nothing reset its `max-width`/`max-height`; `opacity` on `::backdrop` also faded `backdrop-filter`, so `.modal-blur` diluted its own blur toward a flat grey; and closing the dialog by anything other than `hide()` — a `<form method="dialog">`, a direct `close()` call, or Chrome's non-cancelable Escape — left `.show`/`.modal-open` stuck, locking page scroll until the same modal was opened and closed again the normal way.
- The shared `Datepicker` component now also keeps its calendar popup inside the modal's `<dialog>` instead of on `<body>`, matching `Select`. Outside the top layer the popup still painted on top visually, but a click on a date fell through to the modal's `::backdrop` and closed the modal instead of picking a date.
- Docs examples on the Modal page (`exampleModal2/3/4`) now open from a trigger button like the first example, instead of relying on forced-visible static markup, since a closed `<dialog>` can no longer be shown that way.

## Preview

- **Demo pages:** https://tabler-git-v2-modal-dialog-tabler-io.vercel.app/all-elements.html, https://tabler-git-v2-modal-dialog-tabler-io.vercel.app/modals.html
- **Docs:** https://tabler-docs-git-v2-modal-dialog-tabler-io.vercel.app/ui/components/modal
- **How to test:** On `/modals.html`, open a few of the gallery modals and check centering, backdrop dim/blur, and scroll on the tall "New report" one. On `/all-elements.html`, open "Modals" → "Open modal" and "Modal with Select and Datepicker" (new): confirm the backdrop click and the close button both dismiss it, click the calendar to pick a date without the modal closing, and toggle light/dark theme to check the backdrop. On the docs page, use the three buttoned examples under "Prompt and alert" / "Modal with form", and check that closing one with the browser's own Escape (not the close button) also unlocks page scroll.

## Notes / rollout

- Breaking for anyone with hand-written modal markup: the root element must be a `<dialog>`, not a `<div>` — `showModal()` throws otherwise.
- `.modal-backdrop` no longer exists as a DOM element; custom CSS targeting it needs to retarget `.modal::backdrop` (custom properties renamed `--backdrop-*` → `--modal-backdrop-*`).
- `data-bs-backdrop="false"` still skips closing on an outside click, but can no longer suppress the backdrop or keep the rest of the page interactive — a `showModal()` dialog's top layer is always inert.
- `data-bs-keyboard="false"` can't be fully guaranteed in Chrome either: without a recent user activation, Chrome's close watcher makes Escape non-cancelable and closes the dialog regardless.
- `.modal-open` moved from `<body>` to `<html>`, and the `focus` JS config option was dropped (native `showModal()` always moves focus in; no usage found in this repo).
- Overlays appended to `<body>` while a modal is open (Tom Select with `dropdownParent: 'body'`, Vanilla Calendar Pro's default container, tooltips/popovers with `container: 'body'`) render underneath the top layer and are unreachable. The shared `Select` and `Datepicker` components now keep their dropdown/calendar inside the modal when rendered in one; the plugin docs say the same.
- These decisions are recorded in `BOOTSTRAP-V6-MIGRATION.md` §5, item 15.