### PR TITLE
Mix colors in oklab at runtime and remove `--tblr-*-rgb`

### DIFF
--- a/.changeset/oklab-color-mixing.md
+++ b/.changeset/oklab-color-mixing.md
@@ -1,0 +1,6 @@
+---
+"@tabler/core": minor
+"@tabler/docs": patch
+---
+
+Removed the `--tblr-*-rgb` variables and moved color mixing to `color-mix(in oklab)`; use `color-mix()` instead of `rgba(var(--tblr-*-rgb))`.

--- a/core/scss/_maps.scss
+++ b/core/scss/_maps.scss
@@ -87,15 +87,16 @@ $theme-colors-border-subtle-dark: null !default;
 // Extends the default `$theme-colors` maps to help create our utilities.
 
 // Come v6, we'll de-dupe these variables. Until then, for backward compatibility, we keep them to reassign.
+// Only the keys matter: `rgba-css-var()` builds every value from `var(--<key>)`.
 
-$utilities-colors: $theme-colors-rgb !default;
+$utilities-colors: $theme-colors !default;
 
 $utilities-text: map.merge(
   $utilities-colors,
   (
-    'black': to-rgb($black),
-    'white': to-rgb($white),
-    'body': to-rgb($body-color),
+    'black': $black,
+    'white': $white,
+    'body': $body-color,
   )
 ) !default;
 $utilities-text-colors: map-loop($utilities-text, rgba-css-var, '$key', 'text') !default;
@@ -114,9 +115,9 @@ $utilities-text-emphasis-colors: (
 $utilities-bg: map.merge(
   $utilities-colors,
   (
-    'black': to-rgb($black),
-    'white': to-rgb($white),
-    'body': to-rgb($body-bg),
+    'black': $black,
+    'white': $white,
+    'body': $body-bg,
   )
 ) !default;
 $utilities-bg-colors: map-loop($utilities-bg, rgba-css-var, '$key', 'bg') !default;
@@ -135,8 +136,8 @@ $utilities-bg-subtle: (
 $utilities-border: map.merge(
   $utilities-colors,
   (
-    'black': to-rgb($black),
-    'white': to-rgb($white),
+    'black': $black,
+    'white': $white,
   )
 ) !default;
 $utilities-border-colors: map-loop($utilities-border, rgba-css-var, '$key', 'border') !default;

--- a/core/scss/_maps.scss
+++ b/core/scss/_maps.scss
@@ -8,7 +8,6 @@
 //
 // Placed here so that others can override the default Sass maps and see automatic updates to utilities and more.
 
-$theme-colors-rgb: map-loop($theme-colors, to-rgb, '$value') !default;
 
 $theme-colors-text: (
   'primary': $primary-text-emphasis,

--- a/core/scss/_maps.scss
+++ b/core/scss/_maps.scss
@@ -8,7 +8,6 @@
 //
 // Placed here so that others can override the default Sass maps and see automatic updates to utilities and more.
 
-
 $theme-colors-text: (
   'primary': $primary-text-emphasis,
   'secondary': $secondary-text-emphasis,

--- a/core/scss/_props.scss
+++ b/core/scss/_props.scss
@@ -49,7 +49,6 @@
     --#{$name}-lt: #{theme-color-lighter($color)};
     --#{$name}-lt: color-mix(in oklab, var(--#{$name}) 10%, transparent);
     --#{$name}-200: color-mix(in oklab, var(--#{$name}) 20%, transparent);
-    --#{$name}-lt-rgb: #{to-rgb(theme-color-lighter($color))};
   }
 
   /** Gray colors */

--- a/core/scss/_props.scss
+++ b/core/scss/_props.scss
@@ -44,9 +44,7 @@
     --#{$name}: #{$color};
     --#{$name}-rgb: #{to-rgb($color)};
     --#{$name}-fg: #{if(sass(contrast-ratio($color) > $min-contrast-ratio): var(--light); else: var(--dark))};
-    --#{$name}-darken: #{theme-color-darker($color)};
     --#{$name}-darken: color-mix(in oklab, var(--#{$name}), transparent 20%);
-    --#{$name}-lt: #{theme-color-lighter($color)};
     --#{$name}-lt: color-mix(in oklab, var(--#{$name}) 10%, transparent);
     --#{$name}-200: color-mix(in oklab, var(--#{$name}) 20%, transparent);
   }

--- a/core/scss/_props.scss
+++ b/core/scss/_props.scss
@@ -42,7 +42,6 @@
   /** Theme colors */
   @each $name, $color in map.merge($theme-colors, $social-colors) {
     --#{$name}: #{$color};
-    --#{$name}-rgb: #{to-rgb($color)};
     --#{$name}-fg: #{if(sass(contrast-ratio($color) > $min-contrast-ratio): var(--light); else: var(--dark))};
     --#{$name}-darken: color-mix(in oklab, var(--#{$name}), transparent 20%);
     --#{$name}-lt: color-mix(in oklab, var(--#{$name}) 10%, transparent);

--- a/core/scss/_utilities.scss
+++ b/core/scss/_utilities.scss
@@ -97,7 +97,7 @@ $utilities: map.merge(
       css-var: true,
       css-variable-name: focus-ring-color,
       class: focus-ring,
-      values: map-loop($theme-colors-rgb, rgba-css-var, '$key', 'focus-ring'),
+      values: map-loop($theme-colors, rgba-css-var, '$key', 'focus-ring'),
     ),
     'position': (
       property: position,

--- a/core/scss/_utilities.scss
+++ b/core/scss/_utilities.scss
@@ -749,7 +749,7 @@ $utilities: map.merge(
       values: map.merge(
           $utilities-links-underline,
           (
-            null: color-mix(in srgb, var(--link-color) calc(var(--link-underline-opacity, 1) * 100%), transparent),
+            null: color-transparent(var(--link-color), calc(var(--link-underline-opacity, 1) * 100%)),
           )
         ),
     ),
@@ -776,8 +776,8 @@ $utilities: map.merge(
           $utilities-bg-colors,
           (
             'transparent': transparent,
-            'body-secondary': color-mix(in srgb, var(--secondary-bg) calc(var(--bg-opacity) * 100%), transparent),
-            'body-tertiary': color-mix(in srgb, var(--tertiary-bg) calc(var(--bg-opacity) * 100%), transparent),
+            'body-secondary': color-transparent(var(--secondary-bg), calc(var(--bg-opacity) * 100%)),
+            'body-tertiary': color-transparent(var(--tertiary-bg), calc(var(--bg-opacity) * 100%)),
           )
         ),
     ),

--- a/core/scss/_utilities.scss
+++ b/core/scss/_utilities.scss
@@ -692,9 +692,9 @@ $utilities: map.merge(
           (
             'muted': var(--secondary-color),
             // deprecated
-            'black-50': rgba($black, 0.5),
+            'black-50': color-transparent(var(--black), 0.5),
             // deprecated
-            'white-50': rgba($white, 0.5),
+            'white-50': color-transparent(var(--white), 0.5),
             // deprecated
             'body-secondary': var(--secondary-color),
             'body-tertiary': var(--tertiary-color),

--- a/core/scss/_variables-dark.scss
+++ b/core/scss/_variables-dark.scss
@@ -1,4 +1,3 @@
-@use 'sass:color';
 @use 'settings' as *;
 @use 'variables' as *;
 @use 'mixins/functions' as *;
@@ -6,12 +5,12 @@
 //
 // Dark mode
 //
-$darken-dark: color.adjust($dark, $lightness: -2%) !default;
-$lighten-dark: color.adjust($dark, $lightness: 2%) !default;
-$border-color-dark: color.adjust($dark, $lightness: 8%) !default;
+$darken-dark: adjust-lightness($dark, -2%) !default;
+$lighten-dark: adjust-lightness($dark, 2%) !default;
+$border-color-dark: adjust-lightness($dark, 8%) !default;
 $border-color-translucent-dark: rgba(128, 150, 172, 0.2) !default;
-$border-dark-color-dark: color.adjust($dark, $lightness: 4%) !default;
-$border-active-color-dark: color.adjust($dark, $lightness: 12%) !default;
+$border-dark-color-dark: adjust-lightness($dark, 4%) !default;
+$border-active-color-dark: adjust-lightness($dark, 12%) !default;
 
 //new bootsrap variables
 $body-color-dark: $gray-200 !default;

--- a/core/scss/_variables-dark.scss
+++ b/core/scss/_variables-dark.scss
@@ -5,12 +5,12 @@
 //
 // Dark mode
 //
-$darken-dark: adjust-lightness($dark, -2%) !default;
-$lighten-dark: adjust-lightness($dark, 2%) !default;
-$border-color-dark: adjust-lightness($dark, 8%) !default;
+$darken-dark: adjust-lightness-css(var(--dark), -2%) !default;
+$lighten-dark: adjust-lightness-css(var(--dark), 2%) !default;
+$border-color-dark: adjust-lightness-css(var(--dark), 8%) !default;
 $border-color-translucent-dark: rgba(128, 150, 172, 0.2) !default;
-$border-dark-color-dark: adjust-lightness($dark, 4%) !default;
-$border-active-color-dark: adjust-lightness($dark, 12%) !default;
+$border-dark-color-dark: adjust-lightness-css(var(--dark), 4%) !default;
+$border-active-color-dark: adjust-lightness-css(var(--dark), 12%) !default;
 
 //new bootsrap variables
 $body-color-dark: $gray-200 !default;

--- a/core/scss/_variables-dark.scss
+++ b/core/scss/_variables-dark.scss
@@ -50,9 +50,9 @@ $dark-border-subtle-dark: $gray-800 !default;
 
 // Body dark
 $body-bg-dark: $gray-900 !default;
-$body-secondary-color-dark: rgba($body-color-dark, 0.75) !default;
+$body-secondary-color-dark: color-transparent(var(--body-color), 0.75) !default;
 $body-secondary-bg-dark: $gray-800 !default;
-$body-tertiary-color-dark: rgba($body-color-dark, 0.5) !default;
+$body-tertiary-color-dark: color-transparent(var(--body-color), 0.5) !default;
 $body-tertiary-bg-dark: mix-color($gray-800, $gray-900, 50%) !default;
 
 // Headings dark

--- a/core/scss/_variables-dark.scss
+++ b/core/scss/_variables-dark.scss
@@ -20,32 +20,32 @@ $body-emphasis-color-dark: $white !default;
 $text-secondary-dark: rgba(153, 159, 164, 1) !default;
 
 // Theme text emphasis dark
-$primary-text-emphasis-dark: tint-color($primary, 40%) !default;
-$secondary-text-emphasis-dark: tint-color($secondary, 40%) !default;
-$success-text-emphasis-dark: tint-color($success, 40%) !default;
-$info-text-emphasis-dark: tint-color($info, 40%) !default;
-$warning-text-emphasis-dark: tint-color($warning, 40%) !default;
-$danger-text-emphasis-dark: tint-color($danger, 40%) !default;
+$primary-text-emphasis-dark: mix-color-css(var(--white), var(--primary), 40%) !default;
+$secondary-text-emphasis-dark: mix-color-css(var(--white), var(--secondary), 40%) !default;
+$success-text-emphasis-dark: mix-color-css(var(--white), var(--success), 40%) !default;
+$info-text-emphasis-dark: mix-color-css(var(--white), var(--info), 40%) !default;
+$warning-text-emphasis-dark: mix-color-css(var(--white), var(--warning), 40%) !default;
+$danger-text-emphasis-dark: mix-color-css(var(--white), var(--danger), 40%) !default;
 $light-text-emphasis-dark: $gray-100 !default;
 $dark-text-emphasis-dark: $gray-300 !default;
 
 // Theme bg subtle dark
-$primary-bg-subtle-dark: shade-color($primary, 80%) !default;
-$secondary-bg-subtle-dark: shade-color($secondary, 80%) !default;
-$success-bg-subtle-dark: shade-color($success, 80%) !default;
-$info-bg-subtle-dark: shade-color($info, 80%) !default;
-$warning-bg-subtle-dark: shade-color($warning, 80%) !default;
-$danger-bg-subtle-dark: shade-color($danger, 80%) !default;
+$primary-bg-subtle-dark: mix-color-css(var(--black), var(--primary), 80%) !default;
+$secondary-bg-subtle-dark: mix-color-css(var(--black), var(--secondary), 80%) !default;
+$success-bg-subtle-dark: mix-color-css(var(--black), var(--success), 80%) !default;
+$info-bg-subtle-dark: mix-color-css(var(--black), var(--info), 80%) !default;
+$warning-bg-subtle-dark: mix-color-css(var(--black), var(--warning), 80%) !default;
+$danger-bg-subtle-dark: mix-color-css(var(--black), var(--danger), 80%) !default;
 $light-bg-subtle-dark: $gray-800 !default;
-$dark-bg-subtle-dark: color.mix($gray-800, $black) !default;
+$dark-bg-subtle-dark: mix-color-css(var(--gray-800), var(--black)) !default;
 
 // Theme border subtle dark
-$primary-border-subtle-dark: shade-color($primary, 40%) !default;
-$secondary-border-subtle-dark: shade-color($secondary, 40%) !default;
-$success-border-subtle-dark: shade-color($success, 40%) !default;
-$info-border-subtle-dark: shade-color($info, 40%) !default;
-$warning-border-subtle-dark: shade-color($warning, 40%) !default;
-$danger-border-subtle-dark: shade-color($danger, 40%) !default;
+$primary-border-subtle-dark: mix-color-css(var(--black), var(--primary), 40%) !default;
+$secondary-border-subtle-dark: mix-color-css(var(--black), var(--secondary), 40%) !default;
+$success-border-subtle-dark: mix-color-css(var(--black), var(--success), 40%) !default;
+$info-border-subtle-dark: mix-color-css(var(--black), var(--info), 40%) !default;
+$warning-border-subtle-dark: mix-color-css(var(--black), var(--warning), 40%) !default;
+$danger-border-subtle-dark: mix-color-css(var(--black), var(--danger), 40%) !default;
 $light-border-subtle-dark: $gray-700 !default;
 $dark-border-subtle-dark: $gray-800 !default;
 
@@ -54,7 +54,7 @@ $body-bg-dark: $gray-900 !default;
 $body-secondary-color-dark: rgba($body-color-dark, 0.75) !default;
 $body-secondary-bg-dark: $gray-800 !default;
 $body-tertiary-color-dark: rgba($body-color-dark, 0.5) !default;
-$body-tertiary-bg-dark: color.mix($gray-800, $gray-900, 50%) !default;
+$body-tertiary-bg-dark: mix-color($gray-800, $gray-900, 50%) !default;
 
 // Headings dark
 $headings-color-dark: inherit !default;
@@ -65,7 +65,7 @@ $link-hover-color-dark: shift-color($link-color-dark, -$link-shade-percentage) !
 
 // Mark dark
 $mark-color-dark: $body-color-dark !default;
-$mark-bg-dark: shade-color($yellow, 60%) !default;
+$mark-bg-dark: mix-color-css(var(--black), var(--yellow), 60%) !default;
 
 //
 // Forms dark
@@ -78,10 +78,10 @@ $form-switch-color-dark: rgba($white, 0.25) !default;
 $form-switch-bg-image-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color-dark}'/></svg>") !default;
 
 // Form validation colors dark
-$form-valid-color-dark: tint-color($green, 40%) !default;
-$form-valid-border-color-dark: tint-color($green, 40%) !default;
-$form-invalid-color-dark: tint-color($red, 40%) !default;
-$form-invalid-border-color-dark: tint-color($red, 40%) !default;
+$form-valid-color-dark: mix-color-css(var(--white), var(--green), 40%) !default;
+$form-valid-border-color-dark: mix-color-css(var(--white), var(--green), 40%) !default;
+$form-invalid-color-dark: mix-color-css(var(--white), var(--red), 40%) !default;
+$form-invalid-border-color-dark: mix-color-css(var(--white), var(--red), 40%) !default;
 
 //
 // Accordion dark

--- a/core/scss/_variables-dark.scss
+++ b/core/scss/_variables-dark.scss
@@ -73,6 +73,7 @@ $mark-bg-dark: mix-color-css(var(--black), var(--yellow), 60%) !default;
 $form-select-indicator-color-dark: $body-color-dark !default;
 $form-select-indicator-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-select-indicator-color-dark}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>") !default;
 
+// Compile-time `rgba()` on purpose: url-encoded into the svg below, where `var()` cannot resolve.
 $form-switch-color-dark: rgba($white, 0.25) !default;
 $form-switch-bg-image-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color-dark}'/></svg>") !default;
 

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -558,19 +558,19 @@ $text-secondary-dark: $gray-600 !default;
 
 $border-light-color: var(--gray-200) !default;
 $border-light-opacity: 4.7% !default;
-$border-light-color-translucent: color-mix(in srgb, var(--gray-800) #{$border-light-opacity}, transparent) !default;
+$border-light-color-translucent: color-transparent(var(--gray-800), $border-light-opacity) !default;
 
 $border-color: var(--gray-200) !default;
 $border-opacity: 11.9% !default;
-$border-color-translucent: color-mix(in srgb, var(--gray-800) #{$border-opacity}, transparent) !default;
+$border-color-translucent: color-transparent(var(--gray-800), $border-opacity) !default;
 
 $border-dark-color: var(--gray-300) !default;
 $border-dark-opacity: 20.7% !default;
-$border-dark-color-translucent: color-mix(in srgb, var(--gray-800) #{$border-dark-opacity}, transparent) !default;
+$border-dark-color-translucent: color-transparent(var(--gray-800), $border-dark-opacity) !default;
 
 $border-active-color: var(--gray-400) !default;
 $border-active-opacity: 44.8% !default;
-$border-active-color-translucent: color-mix(in srgb, var(--gray-800) #{$border-active-opacity}, transparent) !default;
+$border-active-color-translucent: color-transparent(var(--gray-800), $border-active-opacity) !default;
 
 $active-bg: color-transparent(var(--primary), 0.04) !default;
 $active-color: var(--primary) !default;
@@ -728,8 +728,8 @@ $backdrop-opacity: 0.32 !default;
 $backdrop-blur: 4px !default;
 $backdrop-bg: light-dark(var(--gray-800), var(--black)) !default;
 $backdrops: (
-  dark: color-mix(in sRGB, var(--dark), transparent var(--backdrop-opacity)),
-  light: color-mix(in sRGB, var(--light), transparent var(--backdrop-opacity)),
+  dark: color-transparent(var(--dark), calc(var(--backdrop-opacity) * 100%)),
+  light: color-transparent(var(--light), calc(var(--backdrop-opacity) * 100%)),
 ) !default;
 
 // Gradient
@@ -1020,7 +1020,7 @@ $component-active-bg: $primary !default;
 // Focus (WCAG 2.2 SC 1.4.11)
 $focus-ring-width: 0.25rem !default;
 $focus-ring-opacity: 0.25 !default;
-$focus-ring-color: color-mix(in srgb, var(--primary) #{math.percentage($focus-ring-opacity)}, transparent) !default;
+$focus-ring-color: color-transparent(var(--primary), $focus-ring-opacity) !default;
 $focus-ring-blur: 0 !default;
 // Inner 2px solid ring keeps the indicator above the 3:1 non-text contrast minimum;
 // the translucent halo preserves the soft look
@@ -1808,7 +1808,7 @@ $table-active-bg: var(--active-bg) !default;
 
 $table-hover-color: $table-color !default;
 $table-hover-bg-factor: 0.075 !default;
-$table-hover-bg: color-mix(in srgb, var(--emphasis-color) #{math.percentage($table-hover-bg-factor)}, transparent) !default;
+$table-hover-bg: color-transparent(var(--emphasis-color), $table-hover-bg-factor) !default;
 
 $table-caption-color: var(--secondary-color) !default;
 
@@ -2091,7 +2091,7 @@ $form-validation-states: (
     'icon': $form-feedback-icon-valid,
     'tooltip-color': #fff,
     'tooltip-bg-color': var(--success),
-    'focus-box-shadow': 0 0 $input-btn-focus-blur $input-focus-width color-mix(in srgb, var(--success) #{math.percentage($input-btn-focus-color-opacity)}, transparent),
+    'focus-box-shadow': 0 0 $input-btn-focus-blur $input-focus-width color-transparent(var(--success), $input-btn-focus-color-opacity),
     'border-color': var(--form-valid-border-color),
   ),
   'invalid': (
@@ -2099,7 +2099,7 @@ $form-validation-states: (
     'icon': $form-feedback-icon-invalid,
     'tooltip-color': #fff,
     'tooltip-bg-color': var(--danger),
-    'focus-box-shadow': 0 0 $input-btn-focus-blur $input-focus-width color-mix(in srgb, var(--danger) #{math.percentage($input-btn-focus-color-opacity)}, transparent),
+    'focus-box-shadow': 0 0 $input-btn-focus-blur $input-focus-width color-transparent(var(--danger), $input-btn-focus-color-opacity),
     'border-color': var(--form-invalid-border-color),
   ),
 ) !default;

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -1,7 +1,6 @@
 @use 'sass:string';
 @use 'sass:math';
 @use 'sass:map';
-@use 'sass:color';
 @use 'settings' as *;
 @use 'mixins/functions' as *;
 
@@ -694,32 +693,32 @@ $colors: (
 ) !default;
 
 // Theme color emphasis
-$primary-text-emphasis: shade-color($primary, 60%) !default;
-$secondary-text-emphasis: shade-color($secondary, 60%) !default;
-$success-text-emphasis: shade-color($success, 60%) !default;
-$info-text-emphasis: shade-color($info, 60%) !default;
-$warning-text-emphasis: shade-color($warning, 60%) !default;
-$danger-text-emphasis: shade-color($danger, 60%) !default;
+$primary-text-emphasis: mix-color-css(var(--black), var(--primary), 60%) !default;
+$secondary-text-emphasis: mix-color-css(var(--black), var(--secondary), 60%) !default;
+$success-text-emphasis: mix-color-css(var(--black), var(--success), 60%) !default;
+$info-text-emphasis: mix-color-css(var(--black), var(--info), 60%) !default;
+$warning-text-emphasis: mix-color-css(var(--black), var(--warning), 60%) !default;
+$danger-text-emphasis: mix-color-css(var(--black), var(--danger), 60%) !default;
 $light-text-emphasis: $gray-700 !default;
 $dark-text-emphasis: $gray-700 !default;
 
 // Theme bg subtle
-$primary-bg-subtle: tint-color($primary, 80%) !default;
-$secondary-bg-subtle: tint-color($secondary, 80%) !default;
-$success-bg-subtle: tint-color($success, 80%) !default;
-$info-bg-subtle: tint-color($info, 80%) !default;
-$warning-bg-subtle: tint-color($warning, 80%) !default;
-$danger-bg-subtle: tint-color($danger, 80%) !default;
-$light-bg-subtle: color.mix($gray-100, $white) !default;
+$primary-bg-subtle: mix-color-css(var(--white), var(--primary), 80%) !default;
+$secondary-bg-subtle: mix-color-css(var(--white), var(--secondary), 80%) !default;
+$success-bg-subtle: mix-color-css(var(--white), var(--success), 80%) !default;
+$info-bg-subtle: mix-color-css(var(--white), var(--info), 80%) !default;
+$warning-bg-subtle: mix-color-css(var(--white), var(--warning), 80%) !default;
+$danger-bg-subtle: mix-color-css(var(--white), var(--danger), 80%) !default;
+$light-bg-subtle: mix-color-css(var(--gray-100), var(--white)) !default;
 $dark-bg-subtle: $gray-400 !default;
 
 // Theme border subtle
-$primary-border-subtle: tint-color($primary, 60%) !default;
-$secondary-border-subtle: tint-color($secondary, 60%) !default;
-$success-border-subtle: tint-color($success, 60%) !default;
-$info-border-subtle: tint-color($info, 60%) !default;
-$warning-border-subtle: tint-color($warning, 60%) !default;
-$danger-border-subtle: tint-color($danger, 60%) !default;
+$primary-border-subtle: mix-color-css(var(--white), var(--primary), 60%) !default;
+$secondary-border-subtle: mix-color-css(var(--white), var(--secondary), 60%) !default;
+$success-border-subtle: mix-color-css(var(--white), var(--success), 60%) !default;
+$info-border-subtle: mix-color-css(var(--white), var(--info), 60%) !default;
+$warning-border-subtle: mix-color-css(var(--white), var(--warning), 60%) !default;
+$danger-border-subtle: mix-color-css(var(--white), var(--danger), 60%) !default;
 $light-border-subtle: $gray-200 !default;
 $dark-border-subtle: $gray-500 !default;
 

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -1202,7 +1202,7 @@ $input-box-shadow: var(--shadow-input) !default;
 $input-plaintext-color: var(--body-color) !default;
 
 $input-focus-bg: $input-bg !default;
-$input-focus-border-color: tint-color($component-active-bg, 50%) !default;
+$input-focus-border-color: mix-color-css(var(--white), var(--primary), 50%) !default;
 $input-focus-color: var(--body-color) !default;
 $input-focus-width: $input-btn-focus-width !default;
 $input-focus-box-shadow: $input-btn-focus-box-shadow !default;
@@ -2005,7 +2005,8 @@ $form-switch-padding-start: $form-switch-width + 0.5rem !default;
 $form-switch-bg-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color}'/></svg>") !default;
 $form-switch-border-radius: $form-switch-width !default;
 $form-switch-transition: background-position 0.15s ease-in-out !default;
-$form-switch-focus-color: $input-focus-border-color !default;
+// Compile-time tint on purpose: url-encoded into the svg below, where `var()` cannot resolve.
+$form-switch-focus-color: tint-color($component-active-bg, 50%) !default;
 $form-switch-focus-bg-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-focus-color}'/></svg>") !default;
 $form-switch-checked-color: $white !default;
 $form-switch-checked-bg-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-checked-color}'/></svg>") !default;
@@ -2029,7 +2030,7 @@ $form-range-thumb-focus-box-shadow:
   0 0 0 1px $body-bg,
   $input-focus-box-shadow !default;
 $form-range-thumb-focus-box-shadow-width: 0.125rem !default;
-$form-range-thumb-active-bg: tint-color($component-active-bg, 70%) !default;
+$form-range-thumb-active-bg: mix-color-css(var(--white), var(--primary), 70%) !default;
 $form-range-thumb-disabled-bg: var(--secondary-color) !default;
 $form-range-thumb-transition:
   background-color 0.15s ease-in-out,

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -369,10 +369,10 @@ $body-text-align: start !default;
 $body-color: $gray-500 !default;
 $body-bg: $white !default;
 
-$body-secondary-color: rgba($body-color, 0.75) !default;
+$body-secondary-color: color-transparent(var(--body-color), 0.75) !default;
 $body-secondary-bg: $gray-200 !default;
 
-$body-tertiary-color: rgba($body-color, 0.5) !default;
+$body-tertiary-color: color-transparent(var(--body-color), 0.5) !default;
 $body-tertiary-bg: $gray-100 !default;
 
 // Typography
@@ -662,7 +662,6 @@ $gray-colors: (
 
 $theme-colors: map.merge($theme-colors, map.merge($extra-colors, ()));
 
-$theme-colors-rgb: map-loop($theme-colors, to-rgb, '$value') !default;
 $grays: (
   '100': $gray-100,
   '200': $gray-200,

--- a/core/scss/_variables.scss
+++ b/core/scss/_variables.scss
@@ -732,7 +732,7 @@ $backdrops: (
 ) !default;
 
 // Gradient
-$gradient: linear-gradient(180deg, rgba($white, 0.15), rgba($white, 0)) !default;
+$gradient: linear-gradient(180deg, color-transparent(var(--white), 0.15), color-transparent(var(--white), 0)) !default;
 
 // Borders
 $border-width: 1px !default;
@@ -1045,7 +1045,7 @@ $alert-margin-bottom: 1rem !default;
 $alert-link-font-weight: var(--font-weight-semibold) !default;
 $alert-border-width: var(--border-width) !default;
 $alert-border-color: var(--border-color-translucent) !default;
-$alert-shadow: rgba($dark, 0.04) 0 2px 4px 0 !default;
+$alert-shadow: color-transparent(var(--dark), 0.04) 0 2px 4px 0 !default;
 $alert-heading-margin-bottom: 0.25rem !default;
 $alert-icon-size: 1.25rem !default;
 $alert-padding-inline-end: 3rem !default;
@@ -1133,7 +1133,7 @@ $btn-font-weight: var(--font-weight-medium) !default;
 $btn-box-shadow: var(--shadow-input) !default;
 $btn-focus-box-shadow: $focus-ring-box-shadow !default;
 $btn-disabled-opacity: 0.4 !default;
-$btn-active-box-shadow: inset 0 3px 5px rgba($black, 0.125) !default;
+$btn-active-box-shadow: inset 0 3px 5px color-transparent(var(--black), 0.125) !default;
 
 $btn-link-color: var(--link-color) !default;
 $btn-link-hover-color: var(--link-hover-color) !default;
@@ -1449,7 +1449,7 @@ $dropdown-dark-divider-bg: $dropdown-divider-bg !default;
 $dropdown-dark-box-shadow: null !default;
 $dropdown-dark-link-color: $dropdown-dark-color !default;
 $dropdown-dark-link-hover-color: $white !default;
-$dropdown-dark-link-hover-bg: rgba($white, 0.15) !default;
+$dropdown-dark-link-hover-bg: color-transparent(var(--white), 0.15) !default;
 $dropdown-dark-link-active-color: $dropdown-link-active-color !default;
 $dropdown-dark-link-active-bg: $dropdown-link-active-bg !default;
 $dropdown-dark-link-disabled-color: $gray-500 !default;
@@ -1594,23 +1594,24 @@ $navbar-light-active-color: var(--body-color) !default;
 $navbar-light-hover-color: var(--body-color) !default;
 $navbar-light-disabled-color: var(--disabled-color) !default;
 $navbar-light-active-bg: color-transparent(var(--primary), 0.08) !default;
-// Spelled with the literal prefix: this value is url-encoded into the svg data
-// uri below, so the build-time prefixing in .build/build-css.ts never sees a
-// `var()` here to rewrite (it arrives as `var%28--body-color%29`).
-$navbar-light-icon-color: color-transparent(var(--tblr-body-color), 0.75) !default;
+// Compile-time `rgba()` on purpose: this value is url-encoded into the svg data
+// uri below, and an svg image cannot resolve `var()` or `color-mix()` with
+// `var()` — the stroke would be dropped and the icon would disappear.
+$navbar-light-icon-color: rgba($body-color, 0.75) !default;
 $navbar-light-toggler-icon-bg: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='#{$navbar-light-icon-color}' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>") !default;
 $navbar-light-toggler-border-color: color-transparent(var(--emphasis-color), 0.15) !default;
 $navbar-light-brand-hover-color: $navbar-light-active-color !default;
 
-$navbar-dark-color: rgba($white, $text-secondary-opacity) !default;
-$navbar-dark-hover-color: rgba($white, 0.75) !default;
-$navbar-dark-active-bg: rgba($white, 0.06) !default;
+$navbar-dark-color: color-transparent(var(--white), $text-secondary-opacity) !default;
+$navbar-dark-hover-color: color-transparent(var(--white), 0.75) !default;
+$navbar-dark-active-bg: color-transparent(var(--white), 0.06) !default;
 $navbar-dark-brand-color: $white !default;
 $navbar-dark-active-color: $white !default;
 $navbar-dark-disabled-color: var(--disabled-color) !default;
-$navbar-dark-icon-color: $navbar-dark-color !default;
+// Compile-time `rgba()` on purpose, see `$navbar-light-icon-color`.
+$navbar-dark-icon-color: rgba($white, $text-secondary-opacity) !default;
 $navbar-dark-toggler-icon-bg: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='#{$navbar-dark-icon-color}' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>") !default;
-$navbar-dark-toggler-border-color: rgba($white, 0.1) !default;
+$navbar-dark-toggler-border-color: color-transparent(var(--white), 0.1) !default;
 $navbar-dark-brand-hover-color: $navbar-dark-active-color !default;
 
 $navbar-brand-font-size: $h2-font-size !default;
@@ -2023,7 +2024,7 @@ $form-range-thumb-height: 1rem !default;
 $form-range-thumb-bg: var(--primary) !default;
 $form-range-thumb-border: 2px var(--border-style) $white !default;
 $form-range-thumb-border-radius: 1rem !default;
-$form-range-thumb-box-shadow: 0 0.1rem 0.25rem rgba($black, 0.1) !default;
+$form-range-thumb-box-shadow: 0 0.1rem 0.25rem color-transparent(var(--black), 0.1) !default;
 $form-range-thumb-focus-box-shadow:
   0 0 0 1px $body-bg,
   $input-focus-box-shadow !default;

--- a/core/scss/bootstrap/_carousel.scss
+++ b/core/scss/bootstrap/_carousel.scss
@@ -117,11 +117,11 @@
 }
 .carousel-control-prev {
   inset-inline-start: 0;
-  background-image: if(sass($enable-gradients): linear-gradient(90deg, rgba($black, 0.25), rgba($black, 0.001)); else: null);
+  background-image: if(sass($enable-gradients): linear-gradient(90deg, color-transparent(var(--black), 0.25), color-transparent(var(--black), 0.001)); else: null);
 }
 .carousel-control-next {
   inset-inline-end: 0;
-  background-image: if(sass($enable-gradients): linear-gradient(270deg, rgba($black, 0.25), rgba($black, 0.001)); else: null);
+  background-image: if(sass($enable-gradients): linear-gradient(270deg, color-transparent(var(--black), 0.25), color-transparent(var(--black), 0.001)); else: null);
 }
 
 // Icons for within

--- a/core/scss/bootstrap/_reboot.scss
+++ b/core/scss/bootstrap/_reboot.scss
@@ -232,11 +232,11 @@ sup {
 // Links
 
 a {
-  color: rgba(var(--link-color-rgb), var(--link-opacity, 1));
+  color: color-transparent(var(--link-color), calc(var(--link-opacity, 1) * 100%));
   text-decoration: $link-decoration;
 
   &:hover {
-    --link-color-rgb: var(--link-hover-color-rgb);
+    --link-color: var(--link-hover-color);
     text-decoration: $link-hover-decoration;
   }
 }

--- a/core/scss/bootstrap/_root.scss
+++ b/core/scss/bootstrap/_root.scss
@@ -51,7 +51,6 @@
     }
   }
 
-
   // Fonts
 
   // Note: Use `inspect` for lists so that quoted items keep the quotes.

--- a/core/scss/bootstrap/_root.scss
+++ b/core/scss/bootstrap/_root.scss
@@ -24,10 +24,6 @@
     --#{$color}: #{$value};
   }
 
-  @each $color, $value in $theme-colors-rgb {
-    --#{$color}-rgb: #{$value};
-  }
-
   // $theme-colors-*-dark maps are only populated when $enable-dark-mode is true (see _maps.scss)
   @if $enable-dark-mode {
     @each $color, $value in $theme-colors-text {
@@ -55,8 +51,6 @@
     }
   }
 
-  --white-rgb: #{to-rgb($white)};
-  --black-rgb: #{to-rgb($black)};
 
   // Fonts
 
@@ -78,22 +72,15 @@
   --body-text-align: #{$body-text-align};
 
   --body-color: light-dark(#{$body-color}, #{$body-color-dark});
-  --body-color-rgb: #{to-rgb($body-color)};
   --body-bg: light-dark(#{$body-bg}, #{$body-bg-dark});
-  --body-bg-rgb: #{to-rgb($body-bg)};
 
   --emphasis-color: light-dark(#{$body-emphasis-color}, #{$body-emphasis-color-dark});
-  --emphasis-color-rgb: #{to-rgb($body-emphasis-color)};
 
   --secondary-color: light-dark(#{$body-secondary-color}, #{$body-secondary-color-dark});
-  --secondary-color-rgb: #{to-rgb($body-secondary-color)};
   --secondary-bg: light-dark(#{$body-secondary-bg}, #{$body-secondary-bg-dark});
-  --secondary-bg-rgb: #{to-rgb($body-secondary-bg)};
 
   --tertiary-color: light-dark(#{$body-tertiary-color}, #{$body-tertiary-color-dark});
-  --tertiary-color-rgb: #{to-rgb($body-tertiary-color)};
   --tertiary-bg: light-dark(#{$body-tertiary-bg}, #{$body-tertiary-bg-dark});
-  --tertiary-bg-rgb: #{to-rgb($body-tertiary-bg)};
   // scss-docs-end root-body-variables
 
   // $headings-color is itself light-dark(gray-900, white); the dark-mode block below
@@ -101,11 +88,9 @@
   --heading-color: #{$headings-color};
 
   --link-color: light-dark(#{$link-color}, #{$link-color-dark});
-  --link-color-rgb: #{to-rgb($link-color)};
   --link-decoration: #{$link-decoration};
 
   --link-hover-color: light-dark(#{$link-hover-color}, #{$link-hover-color-dark});
-  --link-hover-color-rgb: #{to-rgb($link-hover-color)};
 
   @if $link-hover-decoration != null {
     --link-hover-decoration: #{$link-hover-decoration};
@@ -155,19 +140,10 @@
 @if $enable-dark-mode {
   @include color-mode(dark, true) {
     // scss-docs-start root-dark-mode-vars
-    // -rgb triplets and non-color overrides can't be expressed inside light-dark(), so they stay here.
-    --body-color-rgb: #{to-rgb($body-color-dark)};
-    --body-bg-rgb: #{to-rgb($body-bg-dark)};
-    --emphasis-color-rgb: #{to-rgb($body-emphasis-color-dark)};
-    --secondary-color-rgb: #{to-rgb($body-secondary-color-dark)};
-    --secondary-bg-rgb: #{to-rgb($body-secondary-bg-dark)};
-    --tertiary-color-rgb: #{to-rgb($body-tertiary-color-dark)};
-    --tertiary-bg-rgb: #{to-rgb($body-tertiary-bg-dark)};
+    // Non-color overrides can't be expressed inside light-dark(), so they stay here.
 
     --heading-color: #{$headings-color-dark};
 
-    --link-color-rgb: #{to-rgb($link-color-dark)};
-    --link-hover-color-rgb: #{to-rgb($link-hover-color-dark)};
     // scss-docs-end root-dark-mode-vars
   }
 }

--- a/core/scss/bootstrap/forms/_floating-labels.scss
+++ b/core/scss/bootstrap/forms/_floating-labels.scss
@@ -20,7 +20,7 @@
     height: 100%; // allow textareas
     padding: $form-floating-padding-y $form-floating-padding-x;
     overflow: hidden;
-    color: rgba(var(--body-color-rgb), #{$form-floating-label-opacity});
+    color: color-transparent(var(--body-color), $form-floating-label-opacity);
     text-align: start;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/core/scss/layout/_root.scss
+++ b/core/scss/layout/_root.scss
@@ -29,8 +29,8 @@
 
   // Dark mode tints the primary towards white, so links keep a 4.5:1 contrast
   // on the dark surfaces. Hover shades the link in light mode and tints it in dark.
-  --link-color: light-dark(var(--primary), color-mix(in srgb, var(--primary), #fff 40%));
-  --link-hover-color: light-dark(color-mix(in srgb, var(--link-color), #000 20%), color-mix(in srgb, var(--link-color), #fff 20%));
+  --link-color: light-dark(var(--primary), #{mix-color-css(var(--white), var(--primary), 40%)});
+  --link-hover-color: light-dark(#{mix-color-css(var(--black), var(--link-color), 20%)}, #{mix-color-css(var(--white), var(--link-color), 20%)});
 
   --secondary: light-dark(var(--gray-500), var(--gray-400));
   --tertiary: var(--gray-400);

--- a/core/scss/mixins/_functions.scss
+++ b/core/scss/mixins/_functions.scss
@@ -27,6 +27,14 @@
   @return color.to-gamut(color.adjust($color, $lightness: $amount, $space: oklch), $space: rgb, $method: clip);
 }
 
+// Runtime counterpart of `adjust-lightness()`: relative color syntax, so the
+// token follows `--tblr-*` overrides in the browser. Emit-only, like `mix-color-css()`.
+@function adjust-lightness-css($color, $amount) {
+  $delta: math.div($amount, 100%);
+  $sign: if(sass($delta < 0): '-'; else: '+');
+  @return oklch(from #{$color} calc(l #{$sign} #{math.abs($delta)}) c h);
+}
+
 @function theme-color-lighter($color, $background: #fff) {
   @return mix-color($color, $background, 10%);
 }

--- a/core/scss/mixins/_functions.scss
+++ b/core/scss/mixins/_functions.scss
@@ -54,7 +54,10 @@
  * @return {String} - The percentage representation of the value.
  */
 @function to-percentage($value) {
-  @return if(sass(math.is-unitless($value)): math.percentage($value); else: $value);
+  @if meta.type-of($value) == number and math.is-unitless($value) {
+    @return math.percentage($value);
+  }
+  @return $value;
 }
 
 /**
@@ -65,11 +68,10 @@
  * @return {Color} - The resulting color with the specified transparency.
  */
 @function color-transparent($color, $alpha: 1, $background: transparent) {
-  @if $alpha == 1 {
+  @if $alpha == 1 or $alpha == 100% {
     @return $color;
-  } @else {
-    @return color-mix(in srgb, #{$color} #{to-percentage($alpha)}, $background);
   }
+  @return color-mix(in srgb, #{$color} #{to-percentage($alpha)}, $background);
 }
 
 @function url-svg($svg) {
@@ -121,13 +123,12 @@
 // stylelint-disable scss/dollar-variable-pattern
 @function rgba-css-var($identifier, $target) {
   @if $identifier == 'body' and $target == 'bg' {
-    @return color-mix(in srgb, var(--#{$identifier}-bg) calc(var(--#{$target}-opacity) * 100%), transparent);
+    @return color-transparent(var(--#{$identifier}-bg), calc(var(--#{$target}-opacity) * 100%));
   }
   @if $identifier == 'body' and $target == 'text' {
-    @return color-mix(in srgb, var(--#{$identifier}-color) calc(var(--#{$target}-opacity) * 100%), transparent);
-  } @else {
-    @return color-mix(in srgb, var(--#{$identifier}) calc(var(--#{$target}-opacity) * 100%), transparent);
+    @return color-transparent(var(--#{$identifier}-color), calc(var(--#{$target}-opacity) * 100%));
   }
+  @return color-transparent(var(--#{$identifier}), calc(var(--#{$target}-opacity) * 100%));
 }
 
 @function map-loop($map, $func, $args...) {

--- a/core/scss/mixins/_functions.scss
+++ b/core/scss/mixins/_functions.scss
@@ -21,6 +21,12 @@
   @return color-mix(in oklab, #{$color1} #{to-percentage($weight)}, #{$color2});
 }
 
+// Shifts lightness in `oklch` (perceptual, keeps hue and chroma) and clips the
+// result to sRGB. `$amount` is a percentage added to the oklch L channel.
+@function adjust-lightness($color, $amount) {
+  @return color.to-gamut(color.adjust($color, $lightness: $amount, $space: oklch), $space: rgb, $method: clip);
+}
+
 @function theme-color-lighter($color, $background: #fff) {
   @return mix-color($color, $background, 10%);
 }

--- a/core/scss/mixins/_functions.scss
+++ b/core/scss/mixins/_functions.scss
@@ -66,12 +66,16 @@
  * @param {Color} $color - The base color to be made transparent.
  * @param {Number} $alpha - The level of transparency, ranging from 0 (fully transparent) to 1 (fully opaque). Default is 1.
  * @return {Color} - The resulting color with the specified transparency.
+ *
+ * Mixes in `oklab` so tints against an opaque background (e.g. alert backgrounds
+ * over `--bg-surface`) stay perceptually even; mixing with `transparent` gives
+ * the same result in every color space.
  */
 @function color-transparent($color, $alpha: 1, $background: transparent) {
   @if $alpha == 1 or $alpha == 100% {
     @return $color;
   }
-  @return color-mix(in srgb, #{$color} #{to-percentage($alpha)}, $background);
+  @return color-mix(in oklab, #{$color} #{to-percentage($alpha)}, $background);
 }
 
 @function url-svg($svg) {

--- a/core/scss/mixins/_functions.scss
+++ b/core/scss/mixins/_functions.scss
@@ -7,8 +7,22 @@
 @use '../settings' as *;
 @use 'bootstrap/breakpoints' as *;
 
+// Mixes two colours in `oklab` so tints and shades stay perceptually even, then
+// clips the result to the sRGB gamut so every consumer (`luminance()`,
+// `to-rgb()`, the emitted `rgb()` values) keeps working on legacy channels.
+@function mix-color($color1, $color2, $weight: 50%) {
+  @return color.to-gamut(color.mix($color1, $color2, $weight, $method: oklab), $space: rgb, $method: clip);
+}
+
+// Runtime counterpart of `mix-color()`: returns a CSS `color-mix()` so the token
+// follows `--tblr-*` overrides in the browser. Use it only where the result is
+// emitted as-is; it cannot feed `color-contrast()`, `to-rgb()` or `luminance()`.
+@function mix-color-css($color1, $color2, $weight: 50%) {
+  @return color-mix(in oklab, #{$color1} #{to-percentage($weight)}, #{$color2});
+}
+
 @function theme-color-lighter($color, $background: #fff) {
-  @return color.mix($color, $background, 10%);
+  @return mix-color($color, $background, 10%);
 }
 
 @function theme-color-darker($color) {
@@ -308,14 +322,14 @@ $_luminance-list: 0.0008 0.001 0.0011 0.0013 0.0015 0.0017 0.002 0.0022 0.0025 0
   @return color.mix(rgba($foreground, 1), $background, color.opacity($foreground) * 100%);
 }
 
-// Tint a color: mix a color with white
+// Tint a color: mix a color with white (in oklab, see `mix-color()`)
 @function tint-color($color, $weight) {
-  @return color.mix(white, $color, $weight);
+  @return mix-color(white, $color, $weight);
 }
 
-// Shade a color: mix a color with black
+// Shade a color: mix a color with black (in oklab, see `mix-color()`)
 @function shade-color($color, $weight) {
-  @return color.mix(black, $color, $weight);
+  @return mix-color(black, $color, $weight);
 }
 
 // Shade the color if the weight is positive, else tint it

--- a/core/scss/mixins/_functions.scss
+++ b/core/scss/mixins/_functions.scss
@@ -35,14 +35,6 @@
   @return oklch(from #{$color} calc(l #{$sign} #{math.abs($delta)}) c h);
 }
 
-@function theme-color-lighter($color, $background: #fff) {
-  @return mix-color($color, $background, 10%);
-}
-
-@function theme-color-darker($color) {
-  @return shade-color($color, 10%);
-}
-
 // str-replace was defined here twice — the canonical copy lives in the
 // "Bootstrap functions" section below.
 

--- a/core/scss/mixins/bootstrap/_forms.scss
+++ b/core/scss/mixins/bootstrap/_forms.scss
@@ -21,7 +21,7 @@
   }
 }
 
-@mixin form-validation-state($state, $color, $icon, $tooltip-color: color-contrast($color), $tooltip-bg-color: rgba($color, $form-feedback-tooltip-opacity), $focus-box-shadow: 0 0 $input-btn-focus-blur $input-focus-width rgba($color, $input-btn-focus-color-opacity), $border-color: $color) {
+@mixin form-validation-state($state, $color, $icon, $tooltip-color: color-contrast($color), $tooltip-bg-color: color-transparent($color, $form-feedback-tooltip-opacity), $focus-box-shadow: 0 0 $input-btn-focus-blur $input-focus-width color-transparent($color, $input-btn-focus-color-opacity), $border-color: $color) {
   .#{$state}-feedback {
     display: none;
     width: 100%;

--- a/core/scss/mixins/bootstrap/_gradients.scss
+++ b/core/scss/mixins/bootstrap/_gradients.scss
@@ -38,6 +38,6 @@
   background-image: radial-gradient(circle, $inner-color, $outer-color);
 }
 
-@mixin gradient-striped($color: rgba($white, 0.15), $angle: 45deg) {
+@mixin gradient-striped($color: color-transparent(var(--white), 0.15), $angle: 45deg) {
   background-image: linear-gradient($angle, $color 25%, transparent 25%, transparent 50%, $color 50%, $color 75%, transparent 75%, transparent);
 }

--- a/core/scss/mixins/bootstrap/_table-variants.scss
+++ b/core/scss/mixins/bootstrap/_table-variants.scss
@@ -2,16 +2,15 @@
 @use '../../variables' as *;
 @use '../functions' as *;
 @use 'breakpoints' as *;
-@use 'sass:color';
 @use 'sass:math';
 
 @mixin table-variant($state, $background) {
   .table-#{$state} {
     $color: color-contrast(opaque($body-bg, $background));
-    $hover-bg: color.mix($color, $background, math.percentage($table-hover-bg-factor));
-    $striped-bg: color.mix($color, $background, math.percentage($table-striped-bg-factor));
-    $active-bg: color.mix($color, $background, math.percentage($table-active-bg-factor));
-    $table-border-color: color.mix($color, $background, math.percentage($table-border-factor));
+    $hover-bg: mix-color($color, $background, math.percentage($table-hover-bg-factor));
+    $striped-bg: mix-color($color, $background, math.percentage($table-striped-bg-factor));
+    $active-bg: mix-color($color, $background, math.percentage($table-active-bg-factor));
+    $table-border-color: mix-color($color, $background, math.percentage($table-border-factor));
 
     --table-color: #{$color};
     --table-bg: #{$background};

--- a/core/scss/tabler-themes.scss
+++ b/core/scss/tabler-themes.scss
@@ -95,7 +95,6 @@
   [data-bs-theme-primary='#{$name}'],
   [data-theme-primary='#{$name}'] {
     --primary: #{$value};
-    --primary-rgb: #{to-rgb($value)};
   }
 }
 
@@ -110,7 +109,6 @@
 [data-theme-primary='inverted'] {
   --primary: var(--gray-800);
   --primary-fg: var(--light);
-  --primary-rgb: #{to-rgb($dark)};
 
   &[data-bs-theme='dark'],
   [data-bs-theme='dark'],
@@ -118,7 +116,6 @@
   [data-theme='dark'] {
     --primary: #{$light};
     --primary-fg: var(--dark);
-    --primary-rgb: #{to-rgb($light)};
   }
 }
 

--- a/core/scss/tests/__snapshots__/css-var-prefix.test.mjs.snap
+++ b/core/scss/tests/__snapshots__/css-var-prefix.test.mjs.snap
@@ -42,6 +42,7 @@ exports[`css custom-property prefixing > leaves vendor-owned names alone and pre
   "--tblr-bg-surface",
   "--tblr-bg-surface-inverted",
   "--tblr-bg-surface-secondary",
+  "--tblr-black",
   "--tblr-body-bg",
   "--tblr-body-color",
   "--tblr-border-color",

--- a/core/scss/tests/_cards.test.scss
+++ b/core/scss/tests/_cards.test.scss
@@ -1,6 +1,6 @@
 // Regression coverage for the multi-layer .card-gradient background: every
 // zero-value gradient stop must keep its `%` unit. Unlike <length>,
-// <percentage> has no unitless-zero exception, so `color-mix(in srgb, x 0,
+// <percentage> has no unitless-zero exception, so `color-mix(in oklab, x 0,
 // y)` (missing the %) is invalid CSS and the whole color-mix() — and the
 // gradient layer using it — silently drops in the browser.
 //
@@ -21,8 +21,8 @@
       @include expect() {
         .t {
           background:
-            radial-gradient(ellipse at center, var(--card-bg) 0%, color-mix(in srgb, var(--card-bg) 0%, transparent) 80%) border-box,
-            linear-gradient(var(--card-gradient-direction), color-mix(in srgb, var(--card-bg) var(--card-gradient-opacity), transparent) 0%, var(--card-bg) 40%) border-box,
+            radial-gradient(ellipse at center, var(--card-bg) 0%, color-mix(in oklab, var(--card-bg) 0%, transparent) 80%) border-box,
+            linear-gradient(var(--card-gradient-direction), color-mix(in oklab, var(--card-bg) var(--card-gradient-opacity), transparent) 0%, var(--card-bg) 40%) border-box,
             linear-gradient(calc(270deg + var(--card-gradient-direction)), var(--card-gradient)) border-box;
         }
       }

--- a/core/scss/tests/_cards.test.scss
+++ b/core/scss/tests/_cards.test.scss
@@ -1,6 +1,6 @@
 // Regression coverage for the multi-layer .card-gradient background: every
 // zero-value gradient stop must keep its `%` unit. Unlike <length>,
-// <percentage> has no unitless-zero exception, so `color-mix(in sRGB, x 0,
+// <percentage> has no unitless-zero exception, so `color-mix(in srgb, x 0,
 // y)` (missing the %) is invalid CSS and the whole color-mix() — and the
 // gradient layer using it — silently drops in the browser.
 //
@@ -21,8 +21,8 @@
       @include expect() {
         .t {
           background:
-            radial-gradient(ellipse at center, var(--card-bg) 0%, color-mix(in sRGB, var(--card-bg) 0%, transparent) 80%) border-box,
-            linear-gradient(var(--card-gradient-direction), color-mix(in sRGB, var(--card-bg) var(--card-gradient-opacity), transparent) 0%, var(--card-bg) 40%) border-box,
+            radial-gradient(ellipse at center, var(--card-bg) 0%, color-mix(in srgb, var(--card-bg) 0%, transparent) 80%) border-box,
+            linear-gradient(var(--card-gradient-direction), color-mix(in srgb, var(--card-bg) var(--card-gradient-opacity), transparent) 0%, var(--card-bg) 40%) border-box,
             linear-gradient(calc(270deg + var(--card-gradient-direction)), var(--card-gradient)) border-box;
         }
       }

--- a/core/scss/tests/_color.test.scss
+++ b/core/scss/tests/_color.test.scss
@@ -6,6 +6,7 @@
 
 @use 'sass:color';
 @use 'sass:math';
+@use 'sass:meta';
 @use '../mixins/functions' as *;
 
 @include describe('luminance') {
@@ -50,6 +51,16 @@
   @include it('keeps the hue and returns a legacy rgb colour') {
     @include assert-equal(math.round(color.channel(adjust-lightness(#066fd1, 5%), 'hue', $space: oklch)), math.round(color.channel(#066fd1, 'hue', $space: oklch)));
     @include assert-true(color.is-legacy(adjust-lightness(#066fd1, 5%)));
+  }
+}
+
+@include describe('adjust-lightness-css') {
+  @include it('builds a relative oklch colour that adds to the lightness channel') {
+    @include assert-equal(meta.inspect(adjust-lightness-css(var(--dark), 8%)), 'oklch(from var(--dark) calc(l + 0.08) c h)');
+  }
+
+  @include it('subtracts when the amount is negative') {
+    @include assert-equal(meta.inspect(adjust-lightness-css(var(--dark), -2%)), 'oklch(from var(--dark) calc(l - 0.02) c h)');
   }
 }
 

--- a/core/scss/tests/_color.test.scss
+++ b/core/scss/tests/_color.test.scss
@@ -4,6 +4,8 @@
 // isolation. A regression here silently degrades accessibility, which is why
 // they rank high.
 
+@use 'sass:color';
+@use 'sass:math';
 @use '../mixins/functions' as *;
 
 @include describe('luminance') {
@@ -24,12 +26,19 @@
 }
 
 @include describe('shade-color / tint-color') {
-  @include it('shade mixes the colour toward black') {
-    @include assert-equal(shade-color(#ffffff, 10%), rgb(229.5, 229.5, 229.5));
+  @include it('shade mixes the colour toward black in oklab') {
+    @include assert-equal(shade-color(#ffffff, 10%), color.mix(black, #ffffff, 10%, $method: oklab));
+    @include assert-equal(math.round(color.channel(shade-color(#ffffff, 10%), 'red')), 222);
   }
 
-  @include it('tint mixes the colour toward white') {
-    @include assert-equal(tint-color(#000000, 10%), rgb(25.5, 25.5, 25.5));
+  @include it('tint mixes the colour toward white in oklab') {
+    @include assert-equal(tint-color(#000000, 10%), color.mix(white, #000000, 10%, $method: oklab));
+    @include assert-equal(math.round(color.channel(tint-color(#000000, 10%), 'red')), 3);
+  }
+
+  @include it('returns a legacy rgb colour inside the sRGB gamut') {
+    @include assert-true(color.is-legacy(tint-color(#f59f00, 40%)));
+    @include assert-true(color.is-in-gamut(shade-color(#f59f00, 20%), $space: rgb));
   }
 }
 

--- a/core/scss/tests/_color.test.scss
+++ b/core/scss/tests/_color.test.scss
@@ -42,6 +42,17 @@
   }
 }
 
+@include describe('adjust-lightness') {
+  @include it('shifts the oklch lightness channel by the given amount') {
+    @include assert-equal(math.round(color.channel(adjust-lightness(#1f2937, 8%), 'lightness', $space: oklch)), math.round(color.channel(#1f2937, 'lightness', $space: oklch)) + 8);
+  }
+
+  @include it('keeps the hue and returns a legacy rgb colour') {
+    @include assert-equal(math.round(color.channel(adjust-lightness(#066fd1, 5%), 'hue', $space: oklch)), math.round(color.channel(#066fd1, 'hue', $space: oklch)));
+    @include assert-true(color.is-legacy(adjust-lightness(#066fd1, 5%)));
+  }
+}
+
 @include describe('shift-color') {
   @include it('shades when the weight is positive') {
     @include assert-equal(shift-color(#808080, 20%), shade-color(#808080, 20%));

--- a/core/scss/tests/_colors-misc.test.scss
+++ b/core/scss/tests/_colors-misc.test.scss
@@ -51,19 +51,19 @@
   }
 
   @include it('builds a color-mix() with the alpha as a percentage otherwise') {
-    @include assert-equal(meta.inspect(color-transparent(#f00, 0.5)), 'color-mix(in srgb, #f00 50%, transparent)');
+    @include assert-equal(meta.inspect(color-transparent(#f00, 0.5)), 'color-mix(in oklab, #f00 50%, transparent)');
   }
 
   @include it('accepts a percentage alpha and a custom property colour') {
-    @include assert-equal(meta.inspect(color-transparent(var(--primary), 40%)), 'color-mix(in srgb, var(--primary) 40%, transparent)');
+    @include assert-equal(meta.inspect(color-transparent(var(--primary), 40%)), 'color-mix(in oklab, var(--primary) 40%, transparent)');
   }
 
   @include it('passes a calc() alpha through so opacity can come from a custom property') {
-    @include assert-equal(meta.inspect(color-transparent(var(--primary), calc(var(--bg-opacity) * 100%))), 'color-mix(in srgb, var(--primary) calc(var(--bg-opacity) * 100%), transparent)');
+    @include assert-equal(meta.inspect(color-transparent(var(--primary), calc(var(--bg-opacity) * 100%))), 'color-mix(in oklab, var(--primary) calc(var(--bg-opacity) * 100%), transparent)');
   }
 
   @include it('mixes against a custom background instead of transparent') {
-    @include assert-equal(meta.inspect(color-transparent(var(--primary), 0.16, var(--bg-surface))), 'color-mix(in srgb, var(--primary) 16%, var(--bg-surface))');
+    @include assert-equal(meta.inspect(color-transparent(var(--primary), 0.16, var(--bg-surface))), 'color-mix(in oklab, var(--primary) 16%, var(--bg-surface))');
   }
 }
 

--- a/core/scss/tests/_colors-misc.test.scss
+++ b/core/scss/tests/_colors-misc.test.scss
@@ -35,6 +35,10 @@
   @include it('passes a value that already has a unit straight through') {
     @include assert-equal(to-percentage(10px), 10px);
   }
+
+  @include it('passes a calc() expression straight through') {
+    @include assert-equal(meta.inspect(to-percentage(calc(var(--x) * 100%))), 'calc(var(--x) * 100%)');
+  }
 }
 
 @include describe('color-transparent') {
@@ -42,8 +46,24 @@
     @include assert-equal(color-transparent(#f00, 1), #f00);
   }
 
+  @include it('returns the colour untouched when alpha is 100%') {
+    @include assert-equal(color-transparent(#f00, 100%), #f00);
+  }
+
   @include it('builds a color-mix() with the alpha as a percentage otherwise') {
     @include assert-equal(meta.inspect(color-transparent(#f00, 0.5)), 'color-mix(in srgb, #f00 50%, transparent)');
+  }
+
+  @include it('accepts a percentage alpha and a custom property colour') {
+    @include assert-equal(meta.inspect(color-transparent(var(--primary), 40%)), 'color-mix(in srgb, var(--primary) 40%, transparent)');
+  }
+
+  @include it('passes a calc() alpha through so opacity can come from a custom property') {
+    @include assert-equal(meta.inspect(color-transparent(var(--primary), calc(var(--bg-opacity) * 100%))), 'color-mix(in srgb, var(--primary) calc(var(--bg-opacity) * 100%), transparent)');
+  }
+
+  @include it('mixes against a custom background instead of transparent') {
+    @include assert-equal(meta.inspect(color-transparent(var(--primary), 0.16, var(--bg-surface))), 'color-mix(in srgb, var(--primary) 16%, var(--bg-surface))');
   }
 }
 

--- a/core/scss/tests/_css-var.test.scss
+++ b/core/scss/tests/_css-var.test.scss
@@ -28,10 +28,10 @@
 
 @include describe('rgba-css-var') {
   @include it('builds a color-mix() from the identifier and target opacity') {
-    @include assert-equal(meta.inspect(rgba-css-var('primary', 'bg')), 'color-mix(in srgb, var(--primary) calc(var(--bg-opacity) * 100%), transparent)');
+    @include assert-equal(meta.inspect(rgba-css-var('primary', 'bg')), 'color-mix(in oklab, var(--primary) calc(var(--bg-opacity) * 100%), transparent)');
   }
 
   @include it('special-cases the body background') {
-    @include assert-equal(meta.inspect(rgba-css-var('body', 'bg')), 'color-mix(in srgb, var(--body-bg) calc(var(--bg-opacity) * 100%), transparent)');
+    @include assert-equal(meta.inspect(rgba-css-var('body', 'bg')), 'color-mix(in oklab, var(--body-bg) calc(var(--bg-opacity) * 100%), transparent)');
   }
 }

--- a/core/scss/tests/_mixins.test.scss
+++ b/core/scss/tests/_mixins.test.scss
@@ -116,7 +116,7 @@
           outline: 0;
           box-shadow:
             0 0 0 2px var(--primary),
-            0 0 0 0.25rem color-mix(in srgb, var(--primary) 25%, transparent);
+            0 0 0 0.25rem color-mix(in oklab, var(--primary) 25%, transparent);
         }
       }
     }
@@ -134,8 +134,8 @@
           outline: 0;
           box-shadow:
             0 0 0 2px var(--primary),
-            0 0 0 0.25rem color-mix(in srgb, var(--primary) 25%, transparent);
-          border-color: color-mix(in srgb, var(--primary) 25%, transparent);
+            0 0 0 0.25rem color-mix(in oklab, var(--primary) 25%, transparent);
+          border-color: color-mix(in oklab, var(--primary) 25%, transparent);
         }
       }
     }
@@ -176,7 +176,7 @@
       }
       @include expect() {
         .scroll {
-          scrollbar-color: color-mix(in srgb, var(--scrollbar-color, var(--body-color)) 20%, transparent) transparent;
+          scrollbar-color: color-mix(in oklab, var(--scrollbar-color, var(--body-color)) 20%, transparent) transparent;
         }
         .scroll::-webkit-scrollbar {
           width: 1rem;
@@ -191,13 +191,13 @@
         .scroll::-webkit-scrollbar-thumb {
           border-radius: 1rem;
           border: 5px solid transparent;
-          box-shadow: inset 0 0 0 1rem color-mix(in srgb, var(--scrollbar-color, var(--body-color)) 20%, transparent);
+          box-shadow: inset 0 0 0 1rem color-mix(in oklab, var(--scrollbar-color, var(--body-color)) 20%, transparent);
         }
         .scroll::-webkit-scrollbar-track {
           background: transparent;
         }
         .scroll:hover::-webkit-scrollbar-thumb {
-          box-shadow: inset 0 0 0 1rem color-mix(in srgb, var(--scrollbar-color, var(--body-color)) 40%, transparent);
+          box-shadow: inset 0 0 0 1rem color-mix(in oklab, var(--scrollbar-color, var(--body-color)) 40%, transparent);
         }
         .scroll::-webkit-scrollbar-corner {
           background: transparent;

--- a/core/scss/ui/_alerts.scss
+++ b/core/scss/ui/_alerts.scss
@@ -24,7 +24,7 @@
   padding: var(--alert-padding-y) var(--alert-padding-x);
   margin-bottom: var(--alert-margin-bottom);
   color: var(--alert-color);
-  background-color: color-mix(in srgb, var(--alert-bg), var(--bg-surface));
+  background-color: color-mix(in oklab, var(--alert-bg), var(--bg-surface));
   border: var(--border-width) var(--border-style) var(--alert-border-color);
   @include border-radius(var(--alert-border-radius));
 }

--- a/core/scss/ui/_alerts.scss
+++ b/core/scss/ui/_alerts.scss
@@ -24,7 +24,7 @@
   padding: var(--alert-padding-y) var(--alert-padding-x);
   margin-bottom: var(--alert-margin-bottom);
   color: var(--alert-color);
-  background-color: color-mix(in sRGB, var(--alert-bg), var(--bg-surface));
+  background-color: color-mix(in srgb, var(--alert-bg), var(--bg-surface));
   border: var(--border-width) var(--border-style) var(--alert-border-color);
   @include border-radius(var(--alert-border-radius));
 }

--- a/core/scss/ui/_buttons.scss
+++ b/core/scss/ui/_buttons.scss
@@ -1,4 +1,3 @@
-@use 'sass:color';
 @use 'sass:map';
 
 //
@@ -67,7 +66,7 @@
   // here would leave a disabled link button with the default surface and border.
   --btn-bg: transparent;
   --btn-border-color: transparent;
-  color: #{color.adjust($primary, $lightness: 5%)};
+  color: #{adjust-lightness($primary, 5%)};
   background-color: transparent;
   border-color: transparent;
   box-shadow: none;

--- a/core/scss/ui/_buttons.scss
+++ b/core/scss/ui/_buttons.scss
@@ -66,7 +66,7 @@
   // here would leave a disabled link button with the default surface and border.
   --btn-bg: transparent;
   --btn-border-color: transparent;
-  color: #{adjust-lightness($primary, 5%)};
+  color: #{adjust-lightness-css(var(--primary), 5%)};
   background-color: transparent;
   border-color: transparent;
   box-shadow: none;

--- a/core/scss/ui/_cards.scss
+++ b/core/scss/ui/_cards.scss
@@ -710,8 +710,8 @@ Card gradient
 // referenced in isolation by sass-true.
 @mixin card-gradient-background {
   background:
-    radial-gradient(ellipse at center, var(--card-bg) 0%, color-mix(in sRGB, var(--card-bg) 0%, transparent) 80%) border-box,
-    linear-gradient(var(--card-gradient-direction), color-mix(in sRGB, var(--card-bg) var(--card-gradient-opacity), transparent) 0%, var(--card-bg) 40%) border-box,
+    radial-gradient(ellipse at center, var(--card-bg) 0%, color-transparent(var(--card-bg), 0) 80%) border-box,
+    linear-gradient(var(--card-gradient-direction), color-transparent(var(--card-bg), var(--card-gradient-opacity)) 0%, var(--card-bg) 40%) border-box,
     linear-gradient(calc(270deg + var(--card-gradient-direction)), var(--card-gradient)) border-box;
 }
 

--- a/core/scss/ui/_cards.scss
+++ b/core/scss/ui/_cards.scss
@@ -192,7 +192,7 @@ Stacked card
     top: 0;
     bottom: 0;
     content: '';
-    background: rgba($dark, 0.48);
+    background: color-transparent(var(--dark), 0.48);
   }
 
   &:first-child,

--- a/core/scss/ui/_carousel.scss
+++ b/core/scss/ui/_carousel.scss
@@ -69,5 +69,5 @@
   bottom: 0;
   height: 90%;
   background: $dark;
-  background: linear-gradient(0deg, rgba($dark, 0.9), rgba($dark, 0));
+  background: linear-gradient(0deg, color-transparent(var(--dark), 0.9), color-transparent(var(--dark), 0));
 }

--- a/core/scss/ui/_forms.scss
+++ b/core/scss/ui/_forms.scss
@@ -99,17 +99,17 @@ Form control
 
 .form-control-dark {
   color: $white;
-  background-color: rgba($black, 0.1);
+  background-color: color-transparent(var(--black), 0.1);
   border-color: transparent;
 
   &:focus {
-    background-color: rgba($black, 0.1);
-    border-color: rgba($white, 0.24);
+    background-color: color-transparent(var(--black), 0.1);
+    border-color: color-transparent(var(--white), 0.24);
     box-shadow: none;
   }
 
   &::placeholder {
-    color: rgba($white, 0.6);
+    color: color-transparent(var(--white), 0.6);
   }
 }
 

--- a/core/scss/ui/_modals.scss
+++ b/core/scss/ui/_modals.scss
@@ -91,7 +91,7 @@
 // The alpha is part of the color instead of `opacity`, so that `backdrop-filter`
 // blurs the page instead of blending a blurred copy over the sharp one.
 dialog::backdrop {
-  background: color-mix(in sRGB, var(--backdrop-bg) calc(var(--backdrop-opacity) * 100%), transparent);
+  background: color-transparent(var(--backdrop-bg), calc(var(--backdrop-opacity) * 100%));
 }
 
 dialog.modal-blur::backdrop {

--- a/core/scss/ui/_patterns.scss
+++ b/core/scss/ui/_patterns.scss
@@ -4,7 +4,7 @@
   --pattern-color: var(--body-color);
   --pattern-size: #{$pattern-size};
   --pattern-opacity: calc(var(--pattern-opacity-factor, #{$pattern-opacity-factor}) * #{$opacity});
-  --pattern-fill: color-mix(in oklch, var(--pattern-color) var(--pattern-opacity), transparent);
+  --pattern-fill: #{color-transparent(var(--pattern-color), var(--pattern-opacity))};
   background-clip: padding-box;
 }
 

--- a/core/scss/ui/_status.scss
+++ b/core/scss/ui/_status.scss
@@ -46,7 +46,6 @@
 .status {
   --status-height: #{$status-height};
   --status-color: #{$text-secondary};
-  --status-color-rgb: #{to-rgb($text-secondary)};
   --status-padding-y: #{$status-padding-y};
   --status-padding-x: #{$status-padding-x};
   --status-gap: #{$status-gap};
@@ -84,7 +83,6 @@
 @each $name, $color in map.merge($theme-colors, $social-colors) {
   .status-#{$name} {
     --status-color: var(--#{$name});
-    --status-color-rgb: var(--#{$name}-rgb);
   }
 }
 

--- a/core/scss/ui/_type.scss
+++ b/core/scss/ui/_type.scss
@@ -9,10 +9,10 @@
 
 a {
   text-decoration-skip-ink: auto;
-  color: color-mix(in sRGB, transparent, var(--link-color) calc(var(--link-opacity, 1) * 100%));
+  color: color-transparent(var(--link-color), calc(var(--link-opacity, 1) * 100%));
 
   &:hover {
-    color: color-mix(in sRGB, transparent, var(--link-hover-color) calc(var(--link-opacity, 1) * 100%));
+    color: color-transparent(var(--link-hover-color), calc(var(--link-opacity, 1) * 100%));
   }
 }
 

--- a/core/scss/utils/_background.scss
+++ b/core/scss/utils/_background.scss
@@ -2,12 +2,12 @@
 
 .bg-white-overlay {
   color: $white;
-  background-color: rgba($light, 0.24);
+  background-color: color-transparent(var(--light), 0.24);
 }
 
 .bg-dark-overlay {
   color: $white;
-  background-color: rgba($dark, 0.24);
+  background-color: color-transparent(var(--dark), 0.24);
 }
 
 .bg-cover {

--- a/core/scss/utils/_colors.scss
+++ b/core/scss/utils/_colors.scss
@@ -13,16 +13,16 @@
     )
 {
   .bg-#{'' + $color} {
-    background-color: color-mix(in srgb, var(--#{$color}) calc(var(--bg-opacity, 1) * 100%), transparent) !important;
+    background-color: color-transparent(var(--#{$color}), calc(var(--bg-opacity, 1) * 100%)) !important;
   }
 
   .bg-#{'' + $color}-lt {
-    color: color-mix(in srgb, var(--#{$color}) calc(var(--text-opacity, 1) * 100%), transparent) !important;
-    background-color: color-mix(in srgb, var(--#{$color}-lt) calc(var(--bg-opacity, 1) * 100%), transparent) !important;
+    color: color-transparent(var(--#{$color}), calc(var(--text-opacity, 1) * 100%)) !important;
+    background-color: color-transparent(var(--#{$color}-lt), calc(var(--bg-opacity, 1) * 100%)) !important;
   }
 
   .border-#{'' + $color} {
-    border-color: color-mix(in srgb, var(--#{$color}) calc(var(--border-opacity, 1) * 100%), transparent) !important;
+    border-color: color-transparent(var(--#{$color}), calc(var(--border-opacity, 1) * 100%)) !important;
   }
 
   .bg-gradient-from-#{'' + $color} {
@@ -44,8 +44,8 @@
   }
 
   .link-#{'' + $color} {
-    color: color-mix(in srgb, var(--#{$color}) calc(var(--link-opacity, 1) * 100%), transparent) !important;
-    text-decoration-color: color-mix(in srgb, var(--#{$color}) calc(var(--link-underline-opacity, 1) * 100%), transparent) !important;
+    color: color-transparent(var(--#{$color}), calc(var(--link-opacity, 1) * 100%)) !important;
+    text-decoration-color: color-transparent(var(--#{$color}), calc(var(--link-underline-opacity, 1) * 100%)) !important;
 
     @if $link-shade-percentage != 0 {
       &:hover,
@@ -61,7 +61,7 @@
 @each $color, $value in $theme-colors {
   .text-#{'' + $color} {
     --text-opacity: 1;
-    color: color-mix(in srgb, var(--#{$color}) calc(var(--text-opacity) * 100%), transparent) !important;
+    color: color-transparent(var(--#{$color}), calc(var(--text-opacity) * 100%)) !important;
   }
 
   .text-#{'' + $color}-fg {
@@ -72,7 +72,7 @@
 @each $color, $value in $gray-colors {
   .bg-#{'' + $color} {
     --bg-opacity: 1;
-    background-color: color-mix(in srgb, var(--#{$color}) calc(var(--bg-opacity) * 100%), transparent) !important;
+    background-color: color-transparent(var(--#{$color}), calc(var(--bg-opacity) * 100%)) !important;
   }
 
   .text-#{'' + $color}-fg {
@@ -87,7 +87,7 @@
 @each $color, $value in $social-colors {
   .bg-#{'' + $color} {
     --bg-opacity: 1;
-    background-color: color-mix(in srgb, var(--#{$color}) calc(var(--bg-opacity) * 100%), transparent) !important;
+    background-color: color-transparent(var(--#{$color}), calc(var(--bg-opacity) * 100%)) !important;
   }
 
   .text-#{'' + $color}-fg {
@@ -97,7 +97,7 @@
 
 .bg-inverted {
   --bg-opacity: 1;
-  background-color: color-mix(in sRGB, var(--bg-surface-inverted) calc(var(--bg-opacity) * 100%), transparent) !important;
+  background-color: color-transparent(var(--bg-surface-inverted), calc(var(--bg-opacity) * 100%)) !important;
 }
 .bg-surface {
   background-color: var(--bg-surface) !important;

--- a/core/scss/utils/_colors.scss
+++ b/core/scss/utils/_colors.scss
@@ -50,9 +50,12 @@
     @if $link-shade-percentage != 0 {
       &:hover,
       &:focus {
-        $hover-color: if(sass(color-contrast($value) == $color-contrast-light): shade-color($value, $link-shade-percentage); else: tint-color($value, $link-shade-percentage));
-        color: RGBA(#{to-rgb($hover-color)}, var(--link-opacity, 1)) if(sass($enable-important-utilities): !important; else: null);
-        text-decoration-color: rgba(to-rgb($hover-color), var(--link-underline-opacity, 1)) if(sass($enable-important-utilities): !important; else: null);
+        // Shade light-on-dark colours, tint the rest: decided at compile time from
+        // the palette, mixed at runtime so the hover follows a `--tblr-*` override.
+        $hover-mix: if(sass(color-contrast($value) == $color-contrast-light): var(--black); else: var(--white));
+        $hover-color: mix-color-css($hover-mix, var(--#{$color}), $link-shade-percentage);
+        color: color-transparent($hover-color, calc(var(--link-opacity, 1) * 100%)) if(sass($enable-important-utilities): !important; else: null);
+        text-decoration-color: color-transparent($hover-color, calc(var(--link-underline-opacity, 1) * 100%)) if(sass($enable-important-utilities): !important; else: null);
       }
     }
   }

--- a/core/scss/utils/_colors.scss
+++ b/core/scss/utils/_colors.scss
@@ -40,7 +40,7 @@
 
   .text-bg-#{'' + $color} {
     color: color-contrast($value) if(sass($enable-important-utilities): !important; else: null);
-    background-color: RGBA(var(--#{$color}-rgb), var(--bg-opacity, 1)) if(sass($enable-important-utilities): !important; else: null);
+    background-color: color-transparent(var(--#{$color}), calc(var(--bg-opacity, 1) * 100%)) if(sass($enable-important-utilities): !important; else: null);
   }
 
   .link-#{'' + $color} {

--- a/docs/content/ui/getting-started/customize.mdx
+++ b/docs/content/ui/getting-started/customize.mdx
@@ -88,7 +88,7 @@ If you need a transparent version of a Tabler color in your own CSS, use `color-
 }
 ```
 
-The `--tblr-*-rgb` variables (for example `--tblr-primary-rgb: 6, 111, 209`) are still emitted for backward compatibility, but Tabler no longer reads them and they are deprecated. They will be removed in Tabler 2.0.
+The `--tblr-*-rgb` variables (for example `--tblr-primary-rgb: 6, 111, 209`) are no longer emitted. Replace any `rgba(var(--tblr-primary-rgb), 0.5)` in your own CSS with `color-mix(in oklab, var(--tblr-primary) 50%, transparent)`.
 
 ## Other system colors
 

--- a/docs/content/ui/getting-started/customize.mdx
+++ b/docs/content/ui/getting-started/customize.mdx
@@ -69,17 +69,26 @@ To change the primary color of Tabler you need to set the `--tblr-primary` varia
 </style>
 ```
 
-If you use `--tblr-primary` in `rgba()` contexts (or see inconsistent colors), also override `--tblr-primary-rgb` (as comma-separated RGB values) and optionally `--tblr-primary-fg` (text/icon color used on primary backgrounds):
+Every tint, shade and transparent variant of the primary color is derived from `--tblr-primary` at runtime with `color-mix()`, so this one variable is enough. Optionally override `--tblr-primary-fg` (text/icon color used on primary backgrounds):
 
 ```html
 <style>
   :root {
     --tblr-primary: #f11d46;
-    --tblr-primary-rgb: 241, 29, 70;
     --tblr-primary-fg: #fff;
   }
 </style>
 ```
+
+If you need a transparent version of a Tabler color in your own CSS, use `color-mix()` instead of `rgba(var(--tblr-primary-rgb), …)`:
+
+```css
+.my-highlight {
+  background-color: color-mix(in oklab, var(--tblr-primary) 20%, transparent);
+}
+```
+
+The `--tblr-*-rgb` variables (for example `--tblr-primary-rgb: 6, 111, 209`) are still emitted for backward compatibility, but Tabler no longer reads them and they are deprecated. They will be removed in Tabler 2.0.
 
 ## Other system colors
 


### PR DESCRIPTION
## Summary

- Color mixing moves from sRGB to `oklab`. Every `color-mix(in srgb, …)` in `core/scss` now goes through four helpers in `mixins/_functions.scss`: `color-transparent()` (alpha), `mix-color()` and `mix-color-css()` (tints and shades, compile-time and runtime), `adjust-lightness()` and `adjust-lightness-css()` (lightness in `oklch`, the runtime one uses relative color syntax).
- Derived colors are computed in the browser instead of being baked in by Sass: `*-bg-subtle`, `*-text-emphasis`, `*-border-subtle`, `.link-*` hover, `.table-*` variants, dark-mode borders, focus ring, range thumb, shadows, gradients and the alert background all follow a `--tblr-primary` / `--tblr-dark` override on `:root`.
- **Breaking:** the `--tblr-*-rgb` custom properties and `$theme-colors-rgb` are removed. Nothing in Tabler read them any more; `rgba(var(--tblr-primary-rgb), .5)` in your own CSS becomes `color-mix(in oklab, var(--tblr-primary) 50%, transparent)`. The customize docs show the replacement.
- Fixed along the way: `--tblr-backdrop-bg-dark` / `-light` had a unitless opacity and were invalid, and the light `.navbar-toggler-icon` was invisible because its SVG data URI referenced a `var()` that an image cannot resolve. Colors that end up inside SVG data URIs stay compile-time `rgba()` with a comment.
- Sass palette stays in hex. This PR is the runtime half of the color work; the `oklch()` source palette is scheduled for 2.0.

Visual impact: mixes with `transparent` are identical in every color space, so most of the CSS renders the same. Alerts, `.table-*` variants, subtle/emphasis tokens and link hover colors shift slightly because they now mix in `oklab`. `tabler.css` is 82.45 KB gzip, under the 84 KB bundlewatch limit.

## Preview

- **URL:** [preview link](https://tabler-git-refactor-color-transparent-helper-tabler-io.vercel.app/colors.html), [docs](https://tabler-docs-git-refactor-color-transparent-helper-tabler-io.vercel.app/ui/getting-started/customize)
- **How to test:** open `/colors.html`, `/alerts.html`, `/tables.html`, `/modals.html` and `/patterns.html` in light and dark mode. Everything should look as before, with slightly smoother tints on alerts, table variants and `.bg-*-subtle`. In DevTools set `--tblr-primary: #8b5cf6` on `:root`: `.bg-primary-subtle`, `.text-primary-emphasis`, `.link-primary:hover` and the focus ring recolor with it. `getComputedStyle(document.documentElement).getPropertyValue('--tblr-primary-rgb')` is empty.

## Notes / rollout

- Breaking change for projects that use `--tblr-*-rgb` in their own CSS; needs a changeset with that note before release.
- Relative color syntax (`oklch(from …)`) needs Chrome 119, Safari 16.4 and Firefox 128, all inside the current `.browserslistrc` floor.
